### PR TITLE
(chore) update maintainer list

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -4,9 +4,9 @@ This file is the official list of maintainers for the Concerto project.
 Changes to this list should be submitted by submitting a pull request that changes this file, and requesting reviews on that pull request from all of the current maintainers.
 The maintainers are listed in alphabetical order.
 
-- Caroline Church ([caroline-church](https://github.com/caroline-church))
+- Matt Roberts ([dselman](https://github.com/mttrbrts))
 - Daniel Selman ([dselman](https://github.com/dselman))
-- Simon Stone ([sstone1](https://github.com/sstone1))
+- Jerome Simeon ([dselman](https://github.com/jeromesimeon))
 
 ## License <a name="license"></a>
-Hyperledger Project source code files are made available under the Apache License, Version 2.0 (Apache-2.0), located in the LICENSE file. Hyperledger Project documentation files are made available under the Creative Commons Attribution 4.0 International License (CC-BY-4.0), available at http://creativecommons.org/licenses/by/4.0/.
+Accord Project Project source code files are made available under the Apache License, Version 2.0 (Apache-2.0), located in the LICENSE file. Hyperledger Project documentation files are made available under the Creative Commons Attribution 4.0 International License (CC-BY-4.0), available at http://creativecommons.org/licenses/by/4.0/.


### PR DESCRIPTION
Remove Caroline Church and Simon Stone from the maintainers list.