### PR TITLE
fix(cli): CLI now functional

### DIFF
--- a/packages/concerto-cli/index.js
+++ b/packages/concerto-cli/index.js
@@ -18,8 +18,6 @@
 
 const Commands = require('./lib/commands');
 
-console.log('yargs');
-
 require('yargs')
     .scriptName('cli')
     .usage('$0 <cmd> [args]')
@@ -71,7 +69,7 @@ require('yargs')
             console.log(`Saving external models into directory: ${argv.outputDirectory}`);
         }
 
-        return Commands.getExternalModels(argv.ctoFiles, argv.outputDirectory)
+        return Commands.getExternalModels(argv.ctoFiles, argv.out)
             .catch((err) => {
                 console.log(err.message + ' ' + err);
             });

--- a/packages/concerto-cli/package.json
+++ b/packages/concerto-cli/package.json
@@ -19,7 +19,6 @@
     "url": "https://github.com/accordproject/concerto/issues"
   },
   "devDependencies": {
-    "@accordproject/concerto-tools": "0.80.3",
     "ajv": "6.5.4",
     "babel-preset-latest": "6.24.1",
     "chai": "4.2.0",
@@ -42,6 +41,7 @@
   },
   "dependencies": {
     "@accordproject/concerto": "0.80.3",
+    "@accordproject/concerto-tools": "0.80.3",
     "debug": "4.1.0",
     "mkdirp": "0.5.1",
     "yargs": "13.2.2"

--- a/packages/concerto-core/lib/modelmanager.js
+++ b/packages/concerto-core/lib/modelmanager.js
@@ -395,7 +395,7 @@ class ModelManager {
                 return;
             }
             const filename = file.fileName.split(fsPath.sep).pop();
-            fs.writeFileSync(path + fsPath.sep + filename, file.content);
+            fs.writeFileSync(path + fsPath.sep + filename, file.definitions);
         });
     }
 


### PR DESCRIPTION
# Issue #67 
Basic functionality in Concerto CLI.

Usage:
```
concerto get --ctoFiles model.cto [--out ./models]
```

### Changes
- Fixes CLI dependencies, and bug in `modelManager.writeModelsToFileSystem`