### PR TITLE
fix(CLI) use concerto name

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
       "LICENSE",
       "HEADER",
       "docs/",
+      "umd/",
       "coverage",
       ".DS_Store",
       "packages/concerto-core/api.txt",

--- a/packages/concerto-cli/index.js
+++ b/packages/concerto-cli/index.js
@@ -19,7 +19,7 @@
 const Commands = require('./lib/commands');
 
 require('yargs')
-    .scriptName('cli')
+    .scriptName('concerto')
     .usage('$0 <cmd> [args]')
     .command('generate', 'generate code from model files', (yargs) => {
 

--- a/packages/concerto-tools/package.json
+++ b/packages/concerto-tools/package.json
@@ -42,7 +42,7 @@
     "chai": "4.2.0",
     "chai-as-promised": "7.1.1",
     "chai-things": "0.2.0",
-    "eslint": "5.8.0",
+    "eslint": "6.0.1",
     "jsdoc": "3.6.3",
     "license-check-and-add": "2.3.6",
     "mocha": "6.1.4",


### PR DESCRIPTION
Signed-off-by: Jerome Simeon <jeromesimeon@me.com>

# Issue #81 
CLI help uses the concerto name.

