### PR TITLE
Fix for issue #89: Add ctoSystem option to CLI, other CLI improvements

### DIFF
--- a/packages/concerto-cli/README.md
+++ b/packages/concerto-cli/README.md
@@ -32,6 +32,7 @@ Options:
   --verbose, -v                                                 [default: false]
   --help         Show help                                             [boolean]
   --sample       sample JSON to validate       [string] [default: "sample.json"]
+  --ctoSystem    system model to be used                                [string]
   --ctoFiles     array of CTO files                       [array] [default: "."]
 ```
 
@@ -49,6 +50,7 @@ Options:
   --version          Show version number                               [boolean]
   --verbose, -v                                                 [default: false]
   --help             Show help                                         [boolean]
+  --ctoSystem        system model to be used                            [string]
   --ctoFiles         array of CTO files                   [array] [default: "."]
   --format           format of the code to generate
                                                 [string] [default: "JSONSchema"]
@@ -101,10 +103,11 @@ concerto get
 save local copies of external model dependencies
 
 Options:
-  --version      Show version number                                   [boolean]
+  --version          Show version number                               [boolean]
   --verbose, -v                                                 [default: false]
-  --help         Show help                                             [boolean]
-  --ctoFiles     array of local CTO files                 [array] [default: "."]
-  --out          output directory path                  [string] [default: "./"]
+  --help             Show help                                         [boolean]
+  --ctoFiles         array of local CTO files             [array] [default: "."]
+  --ctoSystem        system model to be used                            [string]
+  --outputDirectory  output directory path              [string] [default: "./"]
 ```
 

--- a/packages/concerto-cli/index.js
+++ b/packages/concerto-cli/index.js
@@ -43,7 +43,7 @@ require('yargs')
             Logger.info(`validate sample in ${argv.format} against the models ${argv.ctoFiles}`);
         }
 
-        return Commands.validate(argv.sample, argv.ctoSystem, argv.ctoFiles)
+        return Commands.validate(argv.sample, argv.ctoFiles)
             .then((result) => {
                 Logger.info(result);
             })
@@ -78,7 +78,7 @@ require('yargs')
             Logger.info(`generate code in format ${argv.format} from the models ${argv.ctoFiles} into directory ${argv.outputDirectory}`);
         }
 
-        return Commands.generate(argv.format, argv.ctoFiles, argv.outputDirectory)
+        return Commands.generate(argv.format, argv.ctoSystem, argv.ctoFiles, argv.outputDirectory)
             .then((result) => {
                 Logger.info(result);
             })

--- a/packages/concerto-cli/index.js
+++ b/packages/concerto-cli/index.js
@@ -20,7 +20,7 @@ const Commands = require('./lib/commands');
 
 require('yargs')
     .scriptName('concerto')
-    .usage('$0 <cmd> [manager] [args]')
+    .usage('$0 <cmd> [args]')
     .command('validate', 'validate JSON against model files', (yargs) => {
         yargs.option('sample', {
             describe: 'sample JSON to validate',
@@ -30,7 +30,6 @@ require('yargs')
         yargs.option('ctoSystem', {
             describe: 'system model to be used',
             type: 'string'
-            default: 'org.accordproject.base.cto'
         });
         yargs.option('ctoFiles', {
             describe: 'array of CTO files',
@@ -43,7 +42,7 @@ require('yargs')
             Logger.info(`validate sample in ${argv.format} against the models ${argv.ctoFiles}`);
         }
 
-        return Commands.validate(argv.sample, argv.ctoFiles)
+        return Commands.validate(argv.sample, argv.ctoSystem, argv.ctoFiles)
             .then((result) => {
                 Logger.info(result);
             })
@@ -55,7 +54,6 @@ require('yargs')
         yargs.option('ctoSystem', {
             describe: 'system model to be used',
             type: 'string'
-            default: 'org.accordproject.base.cto'
         });
         yargs.option('ctoFiles', {
             describe: 'array of CTO files',
@@ -93,6 +91,10 @@ require('yargs')
             array: true,
             default: '.'
         });
+        yargs.option('ctoSystem', {
+            describe: 'system model to be used',
+            type: 'string'
+        });
         yargs.option('outputDirectory', {
             describe: 'output directory path',
             type: 'string',
@@ -103,7 +105,10 @@ require('yargs')
             Logger.info(`Saving external models from ${argv.ctoFiles} into directory: ${argv.outputDirectory}`);
         }
 
-        return Commands.getExternalModels(argv.ctoFiles, argv.outputDirectory)
+        return Commands.getExternalModels(argv.ctoSystem, argv.ctoFiles, argv.outputDirectory)
+            .then((result) => {
+                Logger.info(result);
+            })
             .catch((err) => {
                 Logger.error(err.message);
             });

--- a/packages/concerto-cli/index.js
+++ b/packages/concerto-cli/index.js
@@ -20,12 +20,17 @@ const Commands = require('./lib/commands');
 
 require('yargs')
     .scriptName('concerto')
-    .usage('$0 <cmd> [args]')
+    .usage('$0 <cmd> [manager] [args]')
     .command('validate', 'validate JSON against model files', (yargs) => {
         yargs.option('sample', {
             describe: 'sample JSON to validate',
             type: 'string',
             default: 'sample.json'
+        });
+        yargs.option('ctoSystem', {
+            describe: 'system model to be used',
+            type: 'string'
+            default: 'org.accordproject.base.cto'
         });
         yargs.option('ctoFiles', {
             describe: 'array of CTO files',
@@ -38,7 +43,7 @@ require('yargs')
             Logger.info(`validate sample in ${argv.format} against the models ${argv.ctoFiles}`);
         }
 
-        return Commands.validate(argv.sample, argv.ctoFiles)
+        return Commands.validate(argv.sample, argv.ctoSystem, argv.ctoFiles)
             .then((result) => {
                 Logger.info(result);
             })
@@ -47,6 +52,11 @@ require('yargs')
             });
     })
     .command('generate', 'generate code from model files', (yargs) => {
+        yargs.option('ctoSystem', {
+            describe: 'system model to be used',
+            type: 'string'
+            default: 'org.accordproject.base.cto'
+        });
         yargs.option('ctoFiles', {
             describe: 'array of CTO files',
             type: 'string',

--- a/packages/concerto-cli/lib/commands.js
+++ b/packages/concerto-cli/lib/commands.js
@@ -15,6 +15,7 @@
 'use strict';
 
 const fs = require('fs');
+const mkdirp = require('mkdirp');
 
 const { ModelManager, Factory, Serializer } = require('@accordproject/concerto-core');
 const ModelFile = require('@accordproject/concerto-core').ModelFile;
@@ -29,7 +30,7 @@ const PlantUMLVisitor = CodeGen.PlantUMLVisitor;
 const TypescriptVisitor = CodeGen.TypescriptVisitor;
 const XmlSchemaVisitor = CodeGen.XmlSchemaVisitor;
 
-const systemModel = `namespace org.accordproject.base
+const defaultSystemContent = `namespace org.accordproject.base
 abstract asset Asset {  }
 abstract participant Participant {  }
 abstract transaction Transaction identified by transactionId {
@@ -38,6 +39,7 @@ abstract transaction Transaction identified by transactionId {
 abstract event Event identified by eventId {
   o String eventId
 }`;
+const defaultSystemName = `@org.accordproject.base`
 
 /**
  * Utility class that implements the commands exposed by the CLI.
@@ -47,38 +49,87 @@ abstract event Event identified by eventId {
 class Commands {
 
     /**
+     * Add model file
+     * 
+     * @param {object} modelFileLoader the model loader
+     * @param {object} modelManager the model manager
+     * @param {string} ctoFile the model file
+     * @param {boolean} system whether this is a system model
+     * @return {object} the model manager
+     */
+    static async addModel(modelFileLoader, modelManager, ctoFile, system) {
+        let modelFile = null;
+        if (system && !ctoFile) {
+            modelFile = new ModelFile(modelManager, defaultSystemContent, defaultSystemName, true);
+        } else if(modelFileLoader.accepts(ctoFile)) {
+            modelFile = await modelFileLoader.load(ctoFile);
+        } else {
+            const content = fs.readFileSync(ctoFile, 'utf8');
+            modelFile = new ModelFile(modelManager, content, ctoFile);
+        }
+
+        if (system) {
+            modelManager.addModelFile(modelFile, modelFile.getName(), false, true);
+        } else {
+            modelManager.addModelFile(modelFile, modelFile.getName(), true, false);
+        }
+
+        return modelManager;
+    }
+    
+    /**
+     * Load system and models in a new model manager
+     * 
+     * @param {string} ctoSystemFile the system model
+     * @param {string[]} ctoFiles the CTO files (can be local file paths or URLs)
+     * @return {object} the model manager
+     */
+    static async loadModelManager(ctoSystemFile, ctoFiles) {
+        let modelManager = new ModelManager();
+        const modelFileLoader = new DefaultModelFileLoader(modelManager);
+
+        // Load system model
+        modelManager = await Commands.addModel(modelFileLoader,modelManager,ctoSystemFile,true);
+
+        // Load user models
+        for( let ctoFile of ctoFiles ) {
+            modelManager = await Commands.addModel(modelFileLoader,modelManager,ctoFile,false);
+        }
+
+        // Validate update models
+        await modelManager.updateExternalModels();
+        return modelManager;
+    }
+
+    /**
      * Validate a sample JSON against the model
      *
      * @param {string} sample the sample to validate
+     * @param {string} ctoSystem the system model
      * @param {string[]} ctoFiles the CTO files to convert to code
      * @returns {string} serialized form of the validated JSON
      */
-    static async validate(sample, ctoFiles, out) {
+    static async validate(sample, ctoSystemFile, ctoFiles, out) {
         const json = JSON.parse(fs.readFileSync(sample, 'utf8'));
 
-        const modelManager = new ModelManager();
+        const modelManager = await Commands.loadModelManager(ctoSystemFile, ctoFiles);
         const factory = new Factory(modelManager);
         const serializer = new Serializer(factory, modelManager);
 
-        const modelFiles = ctoFiles.map((ctoFile) => {
-            return fs.readFileSync(ctoFile, 'utf8');
-        });
-        modelManager.addModelFiles(modelFiles, ctoFiles, true);
-        await modelManager.updateExternalModels();
         const object = serializer.fromJSON(json);
         return JSON.stringify(serializer.toJSON(object));
     }
 
-    static async generate(format, ctoSystem, ctoFiles, outputDirectory) {
-
-        const modelManager = new ModelManager();
-        modelManager.addModelFile(systemModel, ctoSystem, false, true);
-
-        const modelFiles = ctoFiles.map((ctoFile) => {
-            return fs.readFileSync(ctoFile, 'utf8');
-        });
-        modelManager.addModelFiles(modelFiles, ctoFiles, true);
-        await modelManager.updateExternalModels();
+    /**
+     * Generate code from models for a given format
+     *
+     * @param {string} the format of the code to generate
+     * @param {string} ctoSystem the system model
+     * @param {string[]} ctoFiles the CTO files to convert to code
+     * @param {string} outputDirectory the output directory
+     */
+    static async generate(format, ctoSystemFile, ctoFiles, outputDirectory) {
+        const modelManager = await Commands.loadModelManager(ctoSystemFile, ctoFiles);
 
         let visitor = null;
 
@@ -107,7 +158,7 @@ class Commands {
             let parameters = {};
             parameters.fileWriter = new FileWriter(outputDirectory);
             modelManager.accept(visitor, parameters);
-            return `Generated ${format} code.`;
+            return `Generated ${format} code in '${outputDirectory}'.`;
         }
         else {
             return 'Unrecognized code generator: ' + format;
@@ -118,28 +169,15 @@ class Commands {
      * Fetches all external for a set of models dependencies and
      * saves all the models to a target directory
      *
+     * @param {string} ctoSystemFile the system model
      * @param {string[]} ctoFiles the CTO files (can be local file paths or URLs)
      * @param {string} outputDirectory the output directory
      */
-    static async getExternalModels(ctoFiles, outputDirectory) {
-
-        const modelManager = new ModelManager();
-        const modelFileLoader = new DefaultModelFileLoader(modelManager);
-
-        for( let ctoFile of ctoFiles ) {
-            let modelFile = null;
-            if(modelFileLoader.accepts(ctoFile)) {
-                modelFile = await modelFileLoader.load(ctoFile);
-            } else {
-                const content = fs.readFileSync(ctoFile, 'utf8');
-                modelFile = new ModelFile(modelManager, content, ctoFile);
-            }
-
-            modelManager.addModelFile(modelFile, modelFile.getName(), true);
-        }
-
-        await modelManager.updateExternalModels();
+    static async getExternalModels(ctoSystemFile, ctoFiles, outputDirectory) {
+        const modelManager = await Commands.loadModelManager(ctoSystemFile, ctoFiles);
+        mkdirp.sync(outputDirectory);
         modelManager.writeModelsToFileSystem(outputDirectory);
+        return `Loaded external models in '${outputDirectory}'.`;
     }
 }
 

--- a/packages/concerto-cli/lib/commands.js
+++ b/packages/concerto-cli/lib/commands.js
@@ -29,6 +29,16 @@ const PlantUMLVisitor = CodeGen.PlantUMLVisitor;
 const TypescriptVisitor = CodeGen.TypescriptVisitor;
 const XmlSchemaVisitor = CodeGen.XmlSchemaVisitor;
 
+const systemModel = `namespace org.accordproject.base
+abstract asset Asset {  }
+abstract participant Participant {  }
+abstract transaction Transaction identified by transactionId {
+  o String transactionId
+}
+abstract event Event identified by eventId {
+  o String eventId
+}`;
+
 /**
  * Utility class that implements the commands exposed by the CLI.
  * @class
@@ -59,9 +69,10 @@ class Commands {
         return JSON.stringify(serializer.toJSON(object));
     }
 
-    static async generate(format, ctoFiles, outputDirectory) {
+    static async generate(format, ctoSystem, ctoFiles, outputDirectory) {
 
         const modelManager = new ModelManager();
+        modelManager.addModelFile(systemModel, ctoSystem, false, true);
 
         const modelFiles = ctoFiles.map((ctoFile) => {
             return fs.readFileSync(ctoFile, 'utf8');

--- a/packages/concerto-cli/test/models/org.hyperledger.composer.system.cto
+++ b/packages/concerto-cli/test/models/org.hyperledger.composer.system.cto
@@ -1,0 +1,311 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+namespace org.hyperledger.composer.system
+
+/**
+ * Abstract system asset that all assets extend.
+ * Has no properties, and is soley used as a basis to model other assets.
+ */
+@docs('asset.md')
+abstract asset Asset {  }
+
+/**
+ * Abstract system participant that all participants extend.
+ * Has no properties, and is soley used as a basis to model other assets.
+ */
+@docs('participant.md')
+abstract participant Participant {   }
+
+/**
+ * Abstract transaction that all transactions, including system ones, extend.
+ *
+ * Has two properties that are used set and are accessible in all transactions.
+ *
+ *
+ * @param {String} transactionId Identifier for this transaction
+ */
+@docs('transaction.md')
+abstract transaction Transaction identified by transactionId {
+  o String transactionId
+}
+
+/**
+ * Abstract event that all events, including system ones, extend.
+ *
+ * Has two properties that are used set and are accessible in all transactions.
+ *
+ * @param {String} eventId Identifier for this event
+ */
+@docs('event.md')
+abstract event Event identified by eventId {
+  o String eventId
+}
+
+/**
+ * Abstract Registry asset, that is used as the basis for all types of registries.
+ *
+ * @param {String} registryId identity
+ * @param {String} name Name of the registry
+ * @param {String} type type of the registry
+ * @param {Boolean} system Is this a system registry?
+ */
+@docs('registry.md')
+abstract asset Registry identified by registryId {
+  o String registryId
+  o String name
+  o String type
+  o Boolean system
+}
+
+/**
+ * AssetRegistry extends the Registry to define the type that of all registries
+ * that are primarily intended for storing Assets.
+ *
+ */
+@docs('assetRegistry.md')
+asset AssetRegistry extends Registry { }
+
+/**
+ * ParticipantRegistry extends the Registry to define the type that of all registries
+ * that are primarily intended for storing Participants
+ */
+@docs('participantRegistry.md')
+asset ParticipantRegistry extends Registry { }
+
+/**
+ * TransactionRegistry extends the Registry to define the type that of all registries
+ * that are primarily intended for storing Transactions
+ */
+@docs('transactionRegistry.md')
+asset TransactionRegistry extends Registry { }
+
+
+/**
+ * Asset to represent the idea of a Business Network.
+ * All actions will require participants to have access to this Asset. Failure to have at least *READ* access
+ * will mean that participants are unable to access the network.
+ *
+ * Participants who are authorized administrators, can be granted *UPDATE* and/or *DELETE* permissions
+
+ * @param {String} networkId of the business network
+ */
+@docs('network.md')
+asset Network identified by networkId {
+  o String networkId
+  o String runtimeVersion
+}
+
+/**
+ * A predefined participant that can be given the authority to adiminister the Business Network
+ *
+ * @param {String} participantId Identifier fields of the participant
+ */
+@docs('networkAdmin.md')
+participant NetworkAdmin identified by participantId {
+    o String participantId
+}
+
+// -----------------------------------------------------------------------------
+// Historian
+
+/**
+ * Asset to represent each historian registry entry
+ *
+ * @param {String} transactionId Using the transaction id as the uuid
+ * @param {Transaction} transactionInvoked Relationship to transaction
+ * @param {Participant} participantInvoking Participant who invoked this transaction
+ * @param {Identity} identityUsed The identity that was used by the participant
+ * @param {Event[]} eventsEmitted The events that were emitted by this transactionId
+ * @param {DateTime} transactionTimestamp Use the transaction's timestamp
+ */
+@docs('historian.md')
+@docsuri('Composer Documentation','../business-network/historian')
+asset HistorianRecord identified by transactionId {
+  o String        transactionId
+  o String        transactionType
+  --> Transaction transactionInvoked
+  --> Participant participantInvoking  optional
+  --> Identity    identityUsed         optional
+  o Event[]       eventsEmitted        optional
+  o DateTime      transactionTimestamp
+}
+
+// -----------------------------------------------------------------------------
+// System transactions that act on Registries of any type
+/**
+ * An abstract definition of a transaction that affects a registry in some way
+ * @param {Registry} targetRegistry Registry that will be manipulated
+ */
+@docs('registryTransaction.md')
+abstract transaction RegistryTransaction {
+  --> Registry targetRegistry
+}
+
+/**
+ * An abstract definition of a transaction that affects assets in a registry in some way
+ * @param {Asset[]} resources Resources that will be manipulated
+ */
+@docs('assetTransaction.md')
+abstract transaction AssetTransaction extends RegistryTransaction {
+   o Asset[] resources
+}
+
+/**
+ * An abstract definition of a transaction that affects participants in a registry in some way
+ * @param {Participant[]} resources participants that will be manipulated
+ */
+@docs('participantTransaction.md')
+abstract transaction ParticipantTransaction extends RegistryTransaction {
+  o Participant[] resources
+}
+
+/**
+ * Transaction that will add asset(s) to a registry
+ */
+transaction AddAsset extends AssetTransaction { }
+
+/**
+ * Transaction that will update asset(s) in a registry
+ */
+transaction UpdateAsset extends AssetTransaction { }
+
+/**
+ * Transaction that will remove asset(s) from a registry
+ * @param {String[]} resourceIds Identifiers of the assets to remove
+ */
+transaction RemoveAsset extends AssetTransaction {
+ o String[] resourceIds
+}
+
+/**
+ * Transaction that will add participants(s) to a registry
+ */
+transaction AddParticipant extends ParticipantTransaction { }
+
+/**
+ * Transaction that will update participants(s) in a registry
+ */
+transaction UpdateParticipant extends ParticipantTransaction { }
+
+/**
+ * Transaction that will remove participants(s) from a registry
+ * @param {String[]} resourceIds Identifiers of the participants to remove
+ */
+transaction RemoveParticipant extends ParticipantTransaction {
+ o String[] resourceIds
+}
+
+
+// -----------------------------------------------------------------------------
+// Identity
+
+/** The valid states of an identity
+ * @enum {ISSUED} identity has been issued
+ * @enum {BOUND} identity has been bound to a participant
+ * @enum {ACTIVATED} identity has been activated
+ * @enum {REVOKED} identity has been revoked
+ */
+@docs('identityState.md')
+enum IdentityState {
+    o ISSUED
+    o BOUND
+    o ACTIVATED
+    o REVOKED
+}
+
+/**
+ * Asset representing the idea of an Identity
+ *
+ * @param {String} identityId   Unique Identifiers
+ * @param {String} name         Name given to this identity
+ * @param {String} issuer       The issuer
+ * @param {String} certificate  The certificate
+ * @param {IdentityState} state      State the identity is in
+ * @param {Participant} participant  Associated participant
+ */
+@docs('identity.md')
+asset Identity identified by identityId {
+    o String identityId
+    o String name
+    o String issuer
+    o String certificate
+    o IdentityState state
+    --> Participant participant
+}
+
+/**
+ * Transaction that will issue the identity
+ * @param {Participant} participant to issue the identity to
+ * @param {String} identityName  name to use for this identity
+ */
+@docs('issueIdentity.md')
+transaction IssueIdentity {
+    --> Participant participant
+    o String identityName
+}
+
+/**
+ * Transaction that will bind the identity
+ * @param {Participant} participant to issue bind identity to
+ * @param {String} certificate to use
+ */
+@docs('bindIdentity.md')
+transaction BindIdentity {
+    --> Participant participant
+    o String certificate
+}
+
+/**
+ * Transaction that will activate the current the identity
+ */
+@docs('activateIdentity.md')
+transaction ActivateCurrentIdentity { }
+
+/**
+ * Transaction that will revoke the identity
+ * @param {Identity} identity to revoke
+ */
+@docs('revokeIdentity.md')
+transaction RevokeIdentity {
+    --> Identity identity
+}
+
+/**
+ * Transaction that will Start a business network
+ * @param {Transaction[]} [bootstrapTransactions] optional transactions to use to bootstrap the network
+ * @param {String} [logLevel] Log level to use optionally
+ *
+ */
+@docs('startBusinessNetwork.md')
+transaction StartBusinessNetwork {
+  o String logLevel optional
+  o Transaction[] bootstrapTransactions optional
+}
+
+/**
+ * Transaction that will Reset a business network. This removes all the data but leaves the structure of the business network intact
+ */
+@docs('resetBusinessNetwork.md')
+transaction ResetBusinessNetwork {
+
+}
+
+/**
+ * Sets the log level of the Business Network runtime to that specified
+ * @param {String} newLogLevel a valid debug string
+ */
+@docs('setLogLevel.md')
+transaction SetLogLevel {
+  o String newLogLevel
+}


### PR DESCRIPTION
# Issue #89 

- Add `--ctoSystem` option to CLI
- Default system is base Accord Project one
- Refactor so system and user models are loaded consistently from disk or URL in the various commands
- Add info output when `cicero get` succeeds

Examples:
```
bash-3.2$ ./index.js get --ctoFiles https://models.accordproject.org/docusign/connect@0.2.0.cto --outputDirectory dsout 
./index.js get --ctoFiles https://models.accordproject.org/docusign/connect@0.2.0.cto --outputDirectory dsout 
13:26:55 - info: Loaded external models in 'dsout'.
bash-3.2$ ./index.js get --ctoSystem ./test/models/org.hyperledger.composer.system.cto --ctoFiles https://models.accordproject.org/docusign/connect@0.2.0.cto --outputDirectory dsout 
./index.js get --ctoSystem ./test/models/org.hyperledger.composer.system.cto --ctoFiles https://models.accordproject.org/docusign/connect@0.2.0.cto --outputDirectory dsout 
13:27:06 - error: Relationship transactionInvoked must be to an asset or participant, but is to org.hyperledger.composer.system.Transaction File './test/models/org.hyperledger.composer.system.cto': line 137 column 3, to line 138 column 3. 
```
