### PR TITLE
docs(*): update markdown files and fix typos - I65

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,7 +57,7 @@ If you would like to implement a new feature then consider what kind of change i
   [GitHub issue][github-issues] that clearly outlines the changes and benefits of the feature.
 * **Small Changes** can directly be crafted and submitted to the [GitHub Repository][github]
   as a Pull Request. See the section about [Pull Request Submission Guidelines][contribute.submitpr], and
-  for detailed information the [core development documentation][developers].
+  for detailed information read the [core development documentation][developers].
 
 ### <a name="docs"></a> Want a Doc Fix?
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,7 +93,7 @@ make it easier to understand and categorize the issue.
 Before you submit your pull request consider the following guidelines:
 
 * Ensure there is an open [Issue][github-issues] for what you will be working on. If there is not, open one up by going through [these guidelines][contribute.submit].
-* Search [GitHub][pulls] for an open or closed Pull Request that relates to your submission. You don't want to duplicate effort.
+* Search for an open or closed [Pull Request][pulls] that relates to your submission. You don't want to duplicate effort.
 * Create the [development environment][developers.setup]
 * Make your changes in a new git branch:
 
@@ -111,7 +111,7 @@ Before you submit your pull request consider the following guidelines:
 * Follow our [Coding Rules][developers.rules].
 * Ensure you provide a DCO sign-off for your commits using the -s option of git commit. For more information see [how this works][dcohow].
 * If the changes affect public APIs, change or add relevant [documentation][developers.documentation].
-* Run the [unit][developers.unit-tests] test suite, and ensure that all tests pass.
+* Run the [unit test suite][developers.unit-tests], and ensure that all tests pass.
 
 * Commit your changes using a descriptive commit message that follows our [commit message conventions][developers.commits]. Adherence to the [commit message conventions][developers.commits] is required, because release notes are automatically generated from these messages.
 
@@ -121,7 +121,7 @@ Before you submit your pull request consider the following guidelines:
 
   Note: the optional commit `-a` command line option will automatically "add" and "rm" edited files.
 
-* Before creating the Pull Request, ensure your branch sits on top of master (as opposed to branch off a branch). This ensures the reviewer will need only minimal effort to integrate your work by fast-fowarding master:
+* Before creating the Pull Request, ensure your branch sits on top of master (as opposed to branch off a branch). This ensures the reviewer will need only minimal effort to integrate your work by fast-forwarding master:
 
   ```text
     git rebase upstream/master
@@ -139,8 +139,8 @@ Before you submit your pull request consider the following guidelines:
     git push origin name-issue-tracker-short-description
   ```
 
-* In GitHub, send a pull request to `cicero:master` by following our [pull request conventions][developers.pullrequest]. This will trigger the check of the [Contributor License Agreement][contribute.cla] and the Travis integration.
-* If you find that the Travis integration has failed, look into the logs on Travis to find out if your changes caused test failures, the commit message was malformed etc. If you find that the tests failed or times out for unrelated reasons, you can ping a team member so that the build can be restarted.
+* In GitHub, send a pull request to `concerto:master` by following our [pull request conventions][developers.pullrequest]. This will trigger the check of the [Contributor License Agreement][contribute.cla] and the Travis integration.
+* If you find that the Travis integration has failed, look into the logs on Travis to find out if your changes caused test failures, the commit message was malformed etc. If you find that the tests failed or timed out for unrelated reasons, you can ping a team member so that the build can be restarted.
 * If we suggest changes, then:
   * Make the required updates.
   * Re-run the test suite to ensure tests are still passing.
@@ -154,7 +154,7 @@ Before you submit your pull request consider the following guidelines:
     git push origin name-issue-tracker-short-description -f
     ```
 
-    This is generally easier to follow, but seperate commits are useful if the Pull Request contains iterations that might be interesting to see side-by-side.
+    This is generally easier to follow, but separate commits are useful if the Pull Request contains iterations that might be interesting to see side-by-side.
 
 That's it! Thank you for your contribution!
 

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -35,7 +35,7 @@ Afterwards, go ahead and [fork][github-forking] the
 
 ### Building Concerto
 
-To build Concerto, you clone the source code repository and use lerna to build:
+To build Concerto, clone the source code repository and use lerna to build:
 
 ```shell
 # Clone your Github repository:
@@ -139,7 +139,7 @@ The subject contains succinct description of the change:
 * no dot (.) at the end
 
 ### Footer
-The footer should contain [reference GitHub Issues that this commit addresses][github-issues].
+The footer should contain [reference GitHub Issues][github-issues] that this commit addresses.
 
 ## <a name="pullrequests"></a> GitHub Pull Request Guidelines
 Pull Requests should consist of a complete addition to the code which contains value. 

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -21,7 +21,7 @@
 4.
 
 ## Existing issues
-<!-- Have you searched for any existing issues or are their any similar issues that you've found? -->
+<!-- Have you searched for any existing issues or are there any similar issues that you've found? -->
 - [ ] [Stack Overflow issues](http://stackoverflow.com/tags/concerto)
 - [ ] [GitHub Issues](https://github.com/accordproject/concerto/issues)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-﻿<h1 align="center">Concerto
+<h1 align="center">Concerto
 </h1> 
 <p align="center">
   <a href="https://travis-ci.org/accordproject/concerto"><img src="https://travis-ci.org/accordproject/concerto.svg?branch=master" alt="Build Status"></a>
@@ -364,7 +364,7 @@ Accord Project documentation files are made available under the [Creative Common
 Copyright 2018-2019 Clause, Inc. All trademarks are the property of their respective owners. See [LF Projects Trademark Policy](https://lfprojects.org/policies/trademark-policy/).
 
 [linuxfound]: https://www.linuxfoundation.org
-[charter]: https://github.com/accordproject/cicero/blob/master/CHARTER.md
+[charter]: https://github.com/accordproject/concerto/blob/master/CHARTER.md
 [apmain]: https://accordproject.org/ 
 [apworkgroup]: https://calendar.google.com/calendar/event?action=TEMPLATE&tmeid=MjZvYzIzZHVrYnI1aDVzbjZnMHJqYmtwaGlfMjAxNzExMTVUMjEwMDAwWiBkYW5AY2xhdXNlLmlv&tmsrc=dan%40clause.io
 [apblog]: https://medium.com/@accordhq
@@ -381,8 +381,8 @@ Copyright 2018-2019 Clause, Inc. All trademarks are the property of their respec
 [doccicero]: https://docs.accordproject.org/docs/basic-use.html
 [docstudio]: https://docs.accordproject.org/docs/advanced-latedelivery.html
 
-[contributing]: https://github.com/accordproject/cicero/blob/master/CONTRIBUTING.md
-[developers]: https://github.com/accordproject/cicero/blob/master/DEVELOPERS.md
+[contributing]: https://github.com/accordproject/concerto/blob/master/CONTRIBUTING.md
+[developers]: https://github.com/accordproject/concerto/blob/master/DEVELOPERS.md
 
-[apache]: https://github.com/accordproject/template-studio-v2/blob/master/LICENSE
+[apache]: https://github.com/accordproject/concerto/blob/master/LICENSE
 [creativecommons]: http://creativecommons.org/licenses/by/4.0/


### PR DESCRIPTION
Signed-off-by: Michael Zhou <myz227@nyu.edu>

<OVERALL SUMMARY OF PULL REQUEST>
Updated markdown files by correcting for incorrect markdown links, integrating existing links into new markdown, and ensuring consistency in markdown style. Also fixes typos, grammar, and punctuation errors in documentation. All tests confirmed to pass.

### Changes
- Modified markdown to be more appropriate with content of associated links
- Fixed typos and miscellaneous errors in punctuation and grammar

### Related Issues
- [Cicero Template Library Issue #257](accordproject/cicero-template-library#257)
- Pull Request [#280](accordproject/cicero-template-library#280)