### PR TITLE
Update javavisitor.js

### DIFF
--- a/packages/concerto-tools/lib/codegen/fromcto/java/javavisitor.js
+++ b/packages/concerto-tools/lib/codegen/fromcto/java/javavisitor.js
@@ -362,7 +362,7 @@ public abstract class Resource
     toJavaType(type) {
         switch(type) {
         case 'DateTime':
-            return 'java.util.Date';
+            return 'java.time.Instant';
         case 'Boolean':
             return 'boolean';
         case 'String':


### PR DESCRIPTION
- # Issue #101 
CTO concepts making use of the DateTime atomic types should generate Java classes with fields using java.time.Instant instead of java.util.Date .


### Changes
- Date to time.Instant .
