### PR TITLE
Use java.time.Instant | Solves #101

### DIFF
--- a/packages/concerto-tools/lib/codegen/fromcto/java/javavisitor.js
+++ b/packages/concerto-tools/lib/codegen/fromcto/java/javavisitor.js
@@ -362,7 +362,7 @@ public abstract class Resource
     toJavaType(type) {
         switch(type) {
         case 'DateTime':
-            return 'java.util.Date';
+            return 'java.util.Instant';
         case 'Boolean':
             return 'boolean';
         case 'String':

--- a/packages/concerto-tools/lib/codegen/fromcto/java/javavisitor.js
+++ b/packages/concerto-tools/lib/codegen/fromcto/java/javavisitor.js
@@ -362,7 +362,7 @@ public abstract class Resource
     toJavaType(type) {
         switch(type) {
         case 'DateTime':
-            return 'java.util.Instant';
+            return 'java.time.Instant';
         case 'Boolean':
             return 'boolean';
         case 'String':


### PR DESCRIPTION
# Issue #101 <NUMBER HERE>
<OVERALL SUMMARY OF PULL REQUEST>
use Java.time rather than the older (and considered poorly designed) Java.util.date