### PR TITLE
fix(CLI) compile use new 'target' option rather than 'format'

### DIFF
--- a/packages/concerto-cli/index.js
+++ b/packages/concerto-cli/index.js
@@ -76,10 +76,10 @@ require('yargs')
         });
     }, (argv) => {
         if (argv.verbose) {
-            Logger.info(`generate code in format ${argv.format} from models ${argv.ctoFiles} into directory: ${argv.output}`);
+            Logger.info(`generate code for target ${argv.target} from models ${argv.ctoFiles} into directory: ${argv.output}`);
         }
 
-        return Commands.compile(argv.format, argv.ctoSystem, argv.ctoFiles, argv.output)
+        return Commands.compile(argv.target, argv.ctoSystem, argv.ctoFiles, argv.output)
             .then((result) => {
                 Logger.info(result);
             })


### PR DESCRIPTION
Signed-off-by: Jerome Simeon <jeromesimeon@me.com>

# Issue #146 
Fixes `argv` field for the `target` option in the `compile` command.

