### PR TITLE
fix(CLI) Some better error messages for missing file and arguments

### DIFF
--- a/packages/concerto-cli/index.js
+++ b/packages/concerto-cli/index.js
@@ -27,8 +27,7 @@ require('yargs')
     .command('validate', 'validate JSON against model files', (yargs) => {
         yargs.option('sample', {
             describe: 'sample JSON to validate',
-            type: 'string',
-            default: 'sample.json'
+            type: 'string'
         });
         yargs.option('ctoSystem', {
             describe: 'system model to be used',
@@ -37,23 +36,29 @@ require('yargs')
         yargs.option('ctoFiles', {
             describe: 'array of CTO files',
             type: 'string',
-            array: true,
-            default: '.'
+            array: true
         });
     }, (argv) => {
         if (argv.verbose) {
             Logger.info(`validate sample in ${argv.sample} against the models ${argv.ctoFiles}`);
         }
 
-        return Commands.validate(argv.sample, argv.ctoSystem, argv.ctoFiles)
-            .then((result) => {
-                Logger.info(result);
-            })
-            .catch((err) => {
-                Logger.error(err.message);
-            });
+        try {
+            argv = Commands.validateValidateArgs(argv);
+            return Commands.validate(argv.sample, argv.ctoSystem, argv.ctoFiles)
+                .then((result) => {
+                    Logger.info(result);
+                })
+                .catch((err) => {
+                    Logger.error(err.message);
+                });
+        } catch (err){
+            Logger.error(err.message);
+            return;
+        }
     })
     .command('compile', 'generate code for a target platform', (yargs) => {
+        yargs.demandOption(['ctoFiles'], 'Please provide at least the CTO files');
         yargs.option('ctoSystem', {
             describe: 'system model to be used',
             type: 'string'
@@ -61,8 +66,7 @@ require('yargs')
         yargs.option('ctoFiles', {
             describe: 'array of CTO files',
             type: 'string',
-            array: true,
-            default: '.'
+            array: true
         });
         yargs.option('target', {
             describe: 'target of the code generation',
@@ -88,11 +92,11 @@ require('yargs')
             });
     })
     .command('get', 'save local copies of external model dependencies', (yargs) => {
+        yargs.demandOption(['ctoFiles'], 'Please provide at least the CTO files');
         yargs.option('ctoFiles', {
             describe: 'array of local CTO files',
             type: 'string',
-            array: true,
-            default: '.'
+            array: true
         });
         yargs.option('ctoSystem', {
             describe: 'system model to be used',

--- a/packages/concerto-cli/test/cli.js
+++ b/packages/concerto-cli/test/cli.js
@@ -33,6 +33,25 @@ describe('cicero-cli', () => {
     const sampleText1 = fs.readFileSync(sample1, 'utf8');
     const sampleText2 = fs.readFileSync(sample2, 'utf8');
 
+    describe('#validateValidateArgs', () => {
+        it('no args specified', () => {
+            process.chdir(path.resolve(__dirname, 'data'));
+            const args  = Commands.validateValidateArgs({
+                _: ['validate'],
+            });
+            args.sample.should.match(/sample.json$/);
+        });
+
+        it('all args specified', () => {
+            process.chdir(path.resolve(__dirname, 'data'));
+            const args  = Commands.validateValidateArgs({
+                _: ['validate'],
+                sample: 'sample1.json'
+            });
+            args.sample.should.match(/sample1.json$/);
+        });
+    });
+
     describe('#validate', () => {
         it('should validate against a model', async () => {
             const result = await Commands.validate(sample1, null, models);
@@ -46,6 +65,30 @@ describe('cicero-cli', () => {
             } catch (err) {
                 err.message.should.equal('Instance undefined invalid enum value true for field CurrencyCode');
             }
+        });
+
+        it('verbose flag specified', () => {
+            process.chdir(path.resolve(__dirname, 'data'));
+            Commands.validateValidateArgs({
+                _: ['validate'],
+                verbose: true
+            });
+        });
+
+        it('bad sample.json', () => {
+            process.chdir(path.resolve(__dirname, 'data'));
+            (() => Commands.validateValidateArgs({
+                _: ['validate'],
+                sample: 'sample_en.json'
+            })).should.throw('A sample.json file is required. Try the --sample flag or create a sample.json file.');
+        });
+
+        it('bad ctoFiles', () => {
+            process.chdir(path.resolve(__dirname, 'data'));
+            (() => Commands.validateValidateArgs({
+                _: ['validate'],
+                ctoFiles: ['missing.cto']
+            })).should.throw('A model.cto file is required. Try the --ctoFiles flag or create a model.cto file.');
         });
     });
 

--- a/packages/concerto-cli/test/data/model.cto
+++ b/packages/concerto-cli/test/data/model.cto
@@ -1,0 +1,26 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Test file for enums
+ */
+namespace org.acme
+
+
+/**
+ * Concrete enum
+ */
+enum ConcreteEnum  {
+  o TEST
+}

--- a/packages/concerto-cli/test/data/sample.json
+++ b/packages/concerto-cli/test/data/sample.json
@@ -1,0 +1,3 @@
+{ "$class" : "org.accordproject.money.MonetaryAmount",
+  "doubleValue" : 12.99,
+  "currencyCode" : "USD" }


### PR DESCRIPTION
Signed-off-by: Jerome Simeon <jeromesimeon@me.com>

# Issue #151 
- Ensure the `--ctoFiles` parameters are being passed
- Provide for a default sample and corresponding error message in `validate`
