### PR TITLE
fix(core) Add instanceof alternatives for Serializer and Factory objects

### DIFF
--- a/packages/concerto-core/api.txt
+++ b/packages/concerto-core/api.txt
@@ -14,6 +14,7 @@ class Factory {
    + Relationship newRelationship(String,String,String) throws TypeNotFoundException
    + Resource newTransaction(String,String,String,Object,String,boolean,boolean) 
    + Resource newEvent(String,String,String,Object,String,boolean,boolean) 
+   + boolean hasInstance(object) 
 }
 class AssetDeclaration extends ClassDeclaration {
    + void constructor(ModelFile,Object) throws IllegalModelException
@@ -216,4 +217,5 @@ class Serializer {
    + void setDefaultOptions(Object) 
    + Object toJSON(Resource,Object,boolean,boolean,boolean,boolean,boolean) throws Error
    + Resource fromJSON(Object,Object,boolean,boolean) 
+   + boolean hasInstance(object) 
 }

--- a/packages/concerto-core/changelog.txt
+++ b/packages/concerto-core/changelog.txt
@@ -24,6 +24,9 @@
 # Note that the latest public API is documented using JSDocs and is available in api.txt.
 #
 
+Version 0.82.5 {d4d49fabba1c6ce465c446e2dccad488} 2019-11-10
+- Add instance of alternatives to Factory and Serializer
+
 Version 0.82.1 {dee013e99a3c2d6acc4eddfb00aad2a2} 2019-10-22
 - Make several constructors public
 - Add model loader utility class

--- a/packages/concerto-core/lib/factory.js
+++ b/packages/concerto-core/lib/factory.js
@@ -53,6 +53,7 @@ class Factory {
      */
     constructor(modelManager) {
         this.modelManager = modelManager;
+        this._isFactory = true;
     }
 
     /**
@@ -317,6 +318,17 @@ class Factory {
         return generateParams;
     }
 
+
+    /**
+     * Alternative instanceof that is reliable across different module instances
+     * @see https://github.com/hyperledger/composer-concerto/issues/47
+     *
+     * @param {object} object - The object to test against
+     * @returns {boolean} - True, if the object is an instance of a Factory
+     */
+    static [Symbol.hasInstance](object){
+        return typeof object !== 'undefined' && object !== null && Boolean(object._isFactory);
+    }
 }
 
 module.exports = Factory;

--- a/packages/concerto-core/lib/serializer.js
+++ b/packages/concerto-core/lib/serializer.js
@@ -55,6 +55,7 @@ class Serializer {
         this.factory = factory;
         this.modelManager = modelManager;
         this.defaultOptions = Object.assign({}, baseDefaultOptions);
+        this._isSerializer = true;
     }
 
     /**
@@ -187,6 +188,17 @@ class Serializer {
         }
 
         return resource;
+    }
+
+    /**
+     * Alternative instanceof that is reliable across different module instances
+     * @see https://github.com/hyperledger/composer-concerto/issues/47
+     *
+     * @param {object} object - The object to test against
+     * @returns {boolean} - True, if the object is an instance of a Serializer
+     */
+    static [Symbol.hasInstance](object){
+        return typeof object !== 'undefined' && object !== null && Boolean(object._isSerializer);
     }
 }
 


### PR DESCRIPTION
Signed-off-by: Jerome Simeon <jeromesimeon@me.com>

# Issue #47 

This is a leftover fix for #47. Although it was closed, some of the tests in Accord Project Cicero use instance of on either `Factory` or `Serializer`. This should provide for a more reliable way to test those.
