### PR TITLE
feature(core) Stricter validation for atomic values

### DIFF
--- a/packages/concerto-core/lib/serializer/jsonpopulator.js
+++ b/packages/concerto-core/lib/serializer/jsonpopulator.js
@@ -222,17 +222,41 @@ class JSONPopulator {
             }
             break;
         case 'Integer':
-        case 'Long':
-            result = this.ergo ? parseInt(json.nat) : parseInt(json);
+        case 'Long': {
+            const num = this.ergo ? json.nat : json;
+            if (typeof num === 'number') {
+                if (Math.trunc(num) !== num) {
+                    throw new ValidationException(`Expected value ${JSON.stringify(json)} to be of type ${field.getType()}`);
+                } else {
+                    result = num;
+                }
+            } else {
+                throw new ValidationException(`Expected value ${JSON.stringify(json)} to be of type ${field.getType()}`);
+            }
+        }
             break;
-        case 'Double':
-            result = parseFloat(json);
+        case 'Double': {
+            if (typeof json === 'number') {
+                result = parseFloat(json);
+            } else {
+                throw new ValidationException(`Expected value ${JSON.stringify(json)} to be of type ${field.getType()}`);
+            }
+        }
             break;
-        case 'Boolean':
-            result = (json === true || json === 'true');
+        case 'Boolean': {
+            if (typeof json === 'boolean') {
+                result = json;
+            } else {
+                throw new ValidationException(`Expected value ${JSON.stringify(json)} to be of type ${field.getType()}`);
+            }
+        }
             break;
         case 'String':
-            result = json.toString();
+            if (typeof json === 'string') {
+                result = json;
+            } else {
+                throw new ValidationException(`Expected value ${JSON.stringify(json)} to be of type ${field.getType()}`);
+            }
             break;
         default: {
             // everything else should be an enumerated value...


### PR DESCRIPTION
Signed-off-by: Jerome Simeon <jeromesimeon@me.com>

# Issue #157 

A stricter validation semantics for atomic types and values in CTO models.

### Changes
- Atomic values in the JSON have to be strictly of the type declared in the model. E.g., `true` validates against `Boolean` but `"true"` does not. E.g., `3.14` validates against `Double` but does not validate against `Integer` or `Long`. E.g., `"1"` validates against `String` but `1` does not.
- Updates the tests accordingly

### Flags
- This is a breaking change
- The PR is against a new `release-0.83` branch
