### PR TITLE
feature(core) Stricter validation for atomic values

### DIFF
--- a/packages/concerto-core/lib/serializer/jsonpopulator.js
+++ b/packages/concerto-core/lib/serializer/jsonpopulator.js
@@ -222,17 +222,41 @@ class JSONPopulator {
             }
             break;
         case 'Integer':
-        case 'Long':
-            result = this.ergo ? parseInt(json.nat) : parseInt(json);
+        case 'Long': {
+            const num = this.ergo ? json.nat : json;
+            if (typeof num === 'number') {
+                if (Math.trunc(num) !== num) {
+                    throw new ValidationException(`Expected value ${JSON.stringify(json)} to be of type ${field.getType()}`);
+                } else {
+                    result = num;
+                }
+            } else {
+                throw new ValidationException(`Expected value ${JSON.stringify(json)} to be of type ${field.getType()}`);
+            }
+        }
             break;
-        case 'Double':
-            result = parseFloat(json);
+        case 'Double': {
+            if (typeof json === 'number') {
+                result = parseFloat(json);
+            } else {
+                throw new ValidationException(`Expected value ${JSON.stringify(json)} to be of type ${field.getType()}`);
+            }
+        }
             break;
-        case 'Boolean':
-            result = (json === true || json === 'true');
+        case 'Boolean': {
+            if (typeof json === 'boolean') {
+                result = json;
+            } else {
+                throw new ValidationException(`Expected value ${JSON.stringify(json)} to be of type ${field.getType()}`);
+            }
+        }
             break;
         case 'String':
-            result = json.toString();
+            if (typeof json === 'string') {
+                result = json;
+            } else {
+                throw new ValidationException(`Expected value ${JSON.stringify(json)} to be of type ${field.getType()}`);
+            }
             break;
         default: {
             // everything else should be an enumerated value...

--- a/packages/concerto-core/lib/serializer/jsonpopulator.js
+++ b/packages/concerto-core/lib/serializer/jsonpopulator.js
@@ -214,12 +214,17 @@ class JSONPopulator {
         let result = null;
 
         switch(field.getType()) {
-        case 'DateTime':
+        case 'DateTime': {
             if (Moment.isMoment(json)) {
                 result = json;
             } else {
-                result = new Moment.parseZone(json);
+                // Uses strict mode
+                result = new Moment.parseZone(json, Moment.ISO_8601, true);
             }
+            if (!result.isValid()) {
+                throw new ValidationException(`Expected value ${JSON.stringify(json)} to be of type ${field.getType()}`);
+            }
+        }
             break;
         case 'Integer':
         case 'Long': {

--- a/packages/concerto-core/lib/serializer/resourcevalidator.js
+++ b/packages/concerto-core/lib/serializer/resourcevalidator.js
@@ -299,12 +299,16 @@ class ResourceValidator {
                     invalid = true;
                 }
                 break;
-            case 'Double':
             case 'Long':
             case 'Integer':
+            case 'Double': {
                 if(dataType !== 'number') {
                     invalid = true;
                 }
+                if (!isFinite(obj)) {
+                    invalid = true;
+                }
+            }
                 break;
             case 'Boolean':
                 if(dataType !== 'boolean') {
@@ -421,7 +425,11 @@ class ResourceValidator {
         else {
             if(value) {
                 try {
-                    value = JSON.stringify(value);
+                    if (typeof value === 'number' && !isFinite(value)) {
+                        value = value.toString();
+                    } else {
+                        value = JSON.stringify(value);
+                    }
                 }
                 catch(err) {
                     value = value.toString();

--- a/packages/concerto-core/test/serializer/jsongenerator.js
+++ b/packages/concerto-core/test/serializer/jsongenerator.js
@@ -135,7 +135,7 @@ describe('JSONGenerator', () => {
             ergoJsonGenerator.convertToJSON({ getType: () => { return 'Integer'; } }, 123456).nat.should.equal(123456);
         });
 
-        it('should pass through a double object', () => {
+        it('should pass through a finite double object', () => {
             jsonGenerator.convertToJSON({ getType: () => { return 'Double'; } }, 3.142).should.equal(3.142);
         });
 

--- a/packages/concerto-core/test/serializer/jsonpopulator.js
+++ b/packages/concerto-core/test/serializer/jsonpopulator.js
@@ -115,6 +115,14 @@ describe('JSONPopulator', () => {
             value.format('YYYY-MM-DDTHH:mm:ss.SSS[Z]').should.equal(Moment.parseZone('2016-10-20T05:34:03.000Z').format('YYYY-MM-DDTHH:mm:ss.SSS[Z]'));
         });
 
+        it('should not convert to dates from invalid moments', () => {
+            let field = sinon.createStubInstance(Field);
+            field.getType.returns('DateTime');
+            (() => {
+                jsonPopulator.convertToObject(field, 'foo');
+            }).should.throw(ValidationException, /Expected value "foo" to be of type DateTime/);
+        });
+
         it('should not convert to integers from strings', () => {
             let field = sinon.createStubInstance(Field);
             field.getType.returns('Integer');

--- a/packages/concerto-core/test/serializer/jsonpopulator.js
+++ b/packages/concerto-core/test/serializer/jsonpopulator.js
@@ -123,12 +123,52 @@ describe('JSONPopulator', () => {
             }).should.throw(ValidationException, /Expected value "foo" to be of type DateTime/);
         });
 
+        it('should not convert to dates from null', () => {
+            let field = sinon.createStubInstance(Field);
+            field.getType.returns('DateTime');
+            (() => {
+                jsonPopulator.convertToObject(field, null);
+            }).should.throw(ValidationException, /Expected value null to be of type DateTime/);
+        });
+
+        it('should not convert to dates from undefined', () => {
+            let field = sinon.createStubInstance(Field);
+            field.getType.returns('DateTime');
+            (() => {
+                jsonPopulator.convertToObject(field, undefined);
+            }).should.throw(ValidationException, /Expected value undefined to be of type DateTime/);
+        });
+
+        it('should not convert to dates when not in ISO 8601 format', () => {
+            let field = sinon.createStubInstance(Field);
+            field.getType.returns('DateTime');
+            (() => {
+                jsonPopulator.convertToObject(field, 'December 17, 1995 03:24:00');
+            }).should.throw(ValidationException, /Expected value "December 17, 1995 03:24:00" to be of type DateTime/);
+        });
+
         it('should not convert to integers from strings', () => {
             let field = sinon.createStubInstance(Field);
             field.getType.returns('Integer');
             (() => {
                 jsonPopulator.convertToObject(field, '32768');
             }).should.throw(ValidationException, /Expected value "32768" to be of type Integer/);
+        });
+
+        it('should not convert to integer from null', () => {
+            let field = sinon.createStubInstance(Field);
+            field.getType.returns('Integer');
+            (() => {
+                jsonPopulator.convertToObject(field, null);
+            }).should.throw(ValidationException, /Expected value null to be of type Integer/);
+        });
+
+        it('should not convert to integer from undefined', () => {
+            let field = sinon.createStubInstance(Field);
+            field.getType.returns('Integer');
+            (() => {
+                jsonPopulator.convertToObject(field, undefined);
+            }).should.throw(ValidationException, /Expected value undefined to be of type Integer/);
         });
 
         it('should convert to integers from numbers', () => {
@@ -148,6 +188,22 @@ describe('JSONPopulator', () => {
             }).should.throw(ValidationException, /Expected value "32768" to be of type Long/);
         });
 
+        it('should not convert to long from null', () => {
+            let field = sinon.createStubInstance(Field);
+            field.getType.returns('Long');
+            (() => {
+                jsonPopulator.convertToObject(field, null);
+            }).should.throw(ValidationException, /Expected value null to be of type Long/);
+        });
+
+        it('should not convert to long from undefined', () => {
+            let field = sinon.createStubInstance(Field);
+            field.getType.returns('Long');
+            (() => {
+                jsonPopulator.convertToObject(field, undefined);
+            }).should.throw(ValidationException, /Expected value undefined to be of type Long/);
+        });
+
         it('should convert to longs from numbers', () => {
             let field = sinon.createStubInstance(Field);
             field.getType.returns('Long');
@@ -157,7 +213,7 @@ describe('JSONPopulator', () => {
             value.should.equal(32768);
         });
 
-        it('should convert to longs from numbers that are not integers', () => {
+        it('should not convert to longs from numbers that are not integers', () => {
             let field = sinon.createStubInstance(Field);
             field.getType.returns('Long');
             (() => {
@@ -171,6 +227,22 @@ describe('JSONPopulator', () => {
             (() => {
                 jsonPopulator.convertToObject(field, '32.768');
             }).should.throw(ValidationException, /Expected value "32.768" to be of type Double/);
+        });
+
+        it('should not convert to double from null', () => {
+            let field = sinon.createStubInstance(Field);
+            field.getType.returns('Double');
+            (() => {
+                jsonPopulator.convertToObject(field, null);
+            }).should.throw(ValidationException, /Expected value null to be of type Double/);
+        });
+
+        it('should not convert to double from undefined', () => {
+            let field = sinon.createStubInstance(Field);
+            field.getType.returns('Double');
+            (() => {
+                jsonPopulator.convertToObject(field, undefined);
+            }).should.throw(ValidationException, /Expected value undefined to be of type Double/);
         });
 
         it('should convert to doubles from numbers', () => {
@@ -203,6 +275,22 @@ describe('JSONPopulator', () => {
             }).should.throw(ValidationException, /Expected value 32.768 to be of type Boolean/);
         });
 
+        it('should not convert to boolean from null', () => {
+            let field = sinon.createStubInstance(Field);
+            field.getType.returns('Boolean');
+            (() => {
+                jsonPopulator.convertToObject(field, null);
+            }).should.throw(ValidationException, /Expected value null to be of type Boolean/);
+        });
+
+        it('should not convert to boolean from undefined', () => {
+            let field = sinon.createStubInstance(Field);
+            field.getType.returns('Boolean');
+            (() => {
+                jsonPopulator.convertToObject(field, undefined);
+            }).should.throw(ValidationException, /Expected value undefined to be of type Boolean/);
+        });
+
         it('should convert to strings from strings', () => {
             let field = sinon.createStubInstance(Field);
             field.getType.returns('String');
@@ -216,6 +304,22 @@ describe('JSONPopulator', () => {
             (() => {
                 jsonPopulator.convertToObject(field, 32.768);
             }).should.throw(ValidationException, /Expected value 32.768 to be of type String/);
+        });
+
+        it('should not convert to string from null', () => {
+            let field = sinon.createStubInstance(Field);
+            field.getType.returns('String');
+            (() => {
+                jsonPopulator.convertToObject(field, null);
+            }).should.throw(ValidationException, /Expected value null to be of type String/);
+        });
+
+        it('should not convert to string from undefined', () => {
+            let field = sinon.createStubInstance(Field);
+            field.getType.returns('String');
+            (() => {
+                jsonPopulator.convertToObject(field, undefined);
+            }).should.throw(ValidationException, /Expected value undefined to be of type String/);
         });
 
     });

--- a/packages/concerto-core/test/serializer/resourcevalidator.js
+++ b/packages/concerto-core/test/serializer/resourcevalidator.js
@@ -74,6 +74,7 @@ describe('ResourceValidator', function () {
     import org.acme.l1.Person
     asset Vehicle extends Base  {
       o Integer numberOfWheels
+      o Double milage
     }
     participant PrivateOwner identified by employeeId extends Person {
       o String employeeId
@@ -414,6 +415,7 @@ describe('ResourceValidator', function () {
             vehicle.$identifier = ''; // empty the identifier
             vehicle.model = 'Ford';
             vehicle.numberOfWheels = 4;
+            vehicle.milage = 3.14;
             const typedStack = new TypedStack(vehicle);
             const assetDeclaration = modelManager.getType('org.acme.l3.Car');
             const parameters = { stack : typedStack, 'modelManager' : modelManager, rootResourceIdentifier : 'ABC' };
@@ -421,6 +423,21 @@ describe('ResourceValidator', function () {
             (function () {
                 assetDeclaration.accept(resourceValidator,parameters );
             }).should.throw(/has an empty identifier/);
+        });
+
+        it('should reject a Double which is not finite', function () {
+            const vehicle = factory.newResource('org.acme.l3', 'Car', 'foo');
+            vehicle.$identifier = '42';
+            vehicle.model = 'Ford';
+            vehicle.numberOfWheels = 4;
+            vehicle.milage = NaN; // NaN
+            const typedStack = new TypedStack(vehicle);
+            const assetDeclaration = modelManager.getType('org.acme.l3.Car');
+            const parameters = { stack : typedStack, 'modelManager' : modelManager, rootResourceIdentifier : 'ABC' };
+
+            (() => {
+                assetDeclaration.accept(resourceValidator,parameters);
+            }).should.throw(/Model violation in instance org.acme.l3.Car#42 field milage has value NaN/);
         });
 
         it('should report undeclared field if not identifiable', () => {


### PR DESCRIPTION
Signed-off-by: Jerome Simeon <jeromesimeon@me.com>

# Issue #157 & #158 

A stricter validation/serialization semantics for atomic types and values in CTO models.

### Changes
- #157 Atomic values in the JSON have to be strictly of the type declared in the model. E.g., `true` validates against `Boolean` but `"true"` does not. E.g., `3.14` validates against `Double` but does not validate against `Integer` or `Long`. E.g., `"1"` validates against `String` but `1` does not.
- #158 Serializing non-finite Doubles (`NaN` or `Infinity` or `-Infinity`) throws a validation error
- Updates the tests accordingly

### Flags
- This is a breaking change
- The PR is against a new `release-0.83` branch
