### PR TITLE
docs(configmediator): Fix typo in JSDoc

### DIFF
--- a/packages/concerto-core/lib/config/configmediator.js
+++ b/packages/concerto-core/lib/config/configmediator.js
@@ -15,7 +15,7 @@
 'use strict';
 
 /** Prefix to use for all the config names
- * @prvate
+ * @private
 */
 const PREFIX='composer.';
 


### PR DESCRIPTION
Hide this constant from jsdocs generation by fixing a type in the `@private` jsdoc annotation