### PR TITLE
feature(core): Setting custom logs folder with environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ To install the command-line interface:
 npm install -g @accordproject/concerto-cli
 ```
 
+You may also set a custom folder to keep the log files by setting the following environment variable:
+
+```
+export CONCERTO_LOG_FOLDER_PATH="/tmp"
+```
+
 ---
 
 <p align="center">

--- a/packages/concerto-core/lib/logger.js
+++ b/packages/concerto-core/lib/logger.js
@@ -15,11 +15,16 @@
 'use strict';
 
 const winston = require('winston');
-const { LEVEL, MESSAGE } = require('triple-beam');
+const {
+    LEVEL,
+    MESSAGE
+} = require('triple-beam');
 const jsonStringify = require('fast-safe-stringify');
 const jsome = require('jsome');
 const fs = require('fs');
 const env = process.env.NODE_ENV || 'development';
+const logsFolder = process.env.CONCERTO_LOG_FOLDER_PATH || '';
+const path = require('path');
 const tsFormat = () => (new Date()).toLocaleTimeString();
 
 /**
@@ -38,19 +43,19 @@ function isJSON(str) {
 
 jsome.params.lintable = true;
 
-const jsonColor =  winston.format(info => {
+const jsonColor = winston.format(info => {
     const padding = info.padding && info.padding[info.level] || '';
 
-    if(info[LEVEL] === 'error' && info.stack) {
+    if (info[LEVEL] === 'error' && info.stack) {
         info[MESSAGE] = `${tsFormat()} - ${info.level}:${padding} ${info.message}\n${info.stack}`;
         return info;
     }
 
     if (info[LEVEL] === 'info' || info[LEVEL] === 'warn') {
-        if(typeof info.message === 'object') {
+        if (typeof info.message === 'object') {
             info[MESSAGE] = `${tsFormat()} - ${info.level}:${padding}\n${jsome.getColoredString(info.message, null, 2)}`;
-        } else if(isJSON(info.message)) {
-            info[MESSAGE] =`${tsFormat()} - ${info.level}:${padding}\n${jsome.getColoredString(JSON.parse(info.message), null, 2)}`;
+        } else if (isJSON(info.message)) {
+            info[MESSAGE] = `${tsFormat()} - ${info.level}:${padding}\n${jsome.getColoredString(JSON.parse(info.message), null, 2)}`;
         } else {
             info[MESSAGE] = `${tsFormat()} - ${info.level}:${padding} ${info.message}`;
         }
@@ -106,7 +111,7 @@ let logger = winston.createLogger({
 
 // Only write log files to disk if we're running in development
 // and not in a browser (webpack or browserify)
-const setupLogger = ((process,env,logDir) => {
+const setupLogger = ((process, env, logDir) => {
     if (env === 'development' && !process.browser) {
         // Create the log directory if it does not exist
         if (!fs.existsSync(logDir)) {
@@ -121,8 +126,8 @@ const setupLogger = ((process,env,logDir) => {
     }
 });
 
-const logDir = 'log';
-setupLogger(process,env,logDir);
+const logDir = logsFolder ? path.normalize(logsFolder + '/log') : 'log';
+setupLogger(process, env, logDir);
 logger.setup = setupLogger;
 logger.entry = logger.debug;
 logger.exit = logger.debug;


### PR DESCRIPTION
Signed-off-by: Nikolay Vlasov <vlason@amazon.com>

# Issue #183
Introduced a new environment variable called `CONCERTO_LOG_FOLDER_PATH` to set a custom log path for concerto.

### Changes
- Added a new environment variables and the way the logs directory path is set in `concerto-core/lib/logger.js`
  - Updated the readme with a note on how to set the variable.

### Flags
- This modification is needed to make concerto compatible with Amazon Lambda function on AWS cloud.

### Related Issues
- Issue #183 