### PR TITLE
fix(json-schema) : handle multiple model files

### DIFF
--- a/packages/concerto-tools/lib/codegen/fromcto/jsonschema/jsonschemavisitor.js
+++ b/packages/concerto-tools/lib/codegen/fromcto/jsonschema/jsonschemavisitor.js
@@ -123,10 +123,12 @@ class JSONSchemaVisitor {
 
         // Visit all of the files in the model manager.
         let result = {
-            $schema : 'http://json-schema.org/draft-07/schema#' // default for https://github.com/ajv-validator/ajv
+            $schema : 'http://json-schema.org/draft-07/schema#', // default for https://github.com/ajv-validator/ajv
+            definitions: {}
         };
         modelManager.getModelFiles().forEach((modelFile) => {
-            result = { ... result, ... modelFile.accept(this, parameters) };
+            const schema = modelFile.accept(this, parameters);
+            result.definitions = { ... result.definitions, ... schema.definitions };
         });
 
         if(parameters.rootType) {

--- a/packages/concerto-tools/test/codegen/fromcto/jsonschema/jsonschemavisitor.js
+++ b/packages/concerto-tools/test/codegen/fromcto/jsonschema/jsonschemavisitor.js
@@ -68,8 +68,17 @@ transaction MyRequest extends Base {
   o Money money
   o Color color
 }
-
 `;
+
+const MODEL_SIMPLE_2 = `
+namespace test2
+
+concept Vehicle {
+  o String model
+  o String make
+}
+`;
+
 const MODEL_RECURSIVE_COMPLEX = `
 namespace org.accordproject.ergo.monitor
 
@@ -187,6 +196,18 @@ describe('JSONSchema (samples)', function () {
             const visitor = new JSONSchemaVisitor();
             const schema = modelManager.accept(visitor, { rootType: 'test.MyRequest'});
             expect(schema.properties.money.$ref).equal('#/definitions/test.Money');
+        });
+
+        it('should handle multiple model files', () => {
+            const modelManager = new ModelManager();
+            modelManager.addModelFile( MODEL_SIMPLE );
+            modelManager.addModelFile( MODEL_SIMPLE_2 );
+            const visitor = new JSONSchemaVisitor();
+            const schema = modelManager.accept(visitor, {rootType: 'test.MyRequest' });
+            // console.log(JSON.stringify(schema, null, 2));
+            expect(schema.definitions['test.Money']).to.not.be.undefined;
+            expect(schema.definitions['test2.Vehicle']).to.not.be.undefined;
+            expect(schema.title).equal('MyRequest');
         });
 
         it('should generate regex and bounds', () => {


### PR DESCRIPTION
Signed-off-by: Dan Selman <danscode@selman.org>

Fix an issue in the new JSON Schema generation where the definitions get overwritten by the last model file processed.