### PR TITLE
fix(publish) Micro-publish to npm should be tagged unstable

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: unit
+name: build
 
 on:
   push:
@@ -90,5 +90,5 @@ jobs:
           echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
           npm version --no-git-tag-version --yes --exact ${{ steps.tag.outputs.stamp }}
           ./node_modules/.bin/lerna version --no-git-tag-version --yes --exact ${{ steps.tag.outputs.stamp }}
-          ./node_modules/.bin/lerna exec -- npm publish --access public 2>&1
+          ./node_modules/.bin/lerna exec -- npm publish --access public --tag=unstable 2>&1
           rm ~/.npmrc


### PR DESCRIPTION
Signed-off-by: Jerome Simeon <jeromesimeon@me.com>

### Changes

- Bug fix: micro-publish to npm should be tagged with `unstable`

### Flags

- "latest" is also fixed in npm, pointing correctly again to `8.11`

https://www.npmjs.com/package/@accordproject/concerto-cli
https://www.npmjs.com/package/@accordproject/concerto-core
https://www.npmjs.com/package/@accordproject/concerto-tools