### PR TITLE
chore(build) detect prereleases in publish workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,15 +80,15 @@ jobs:
           npm install lerna@^3.22.0
           ./node_modules/.bin/lerna bootstrap 2>&1
 
-      - name: Create tag with timestamp
-        id: tag
+      - name: timestamp
+        id: timestamp
         run: |
-          node ./scripts/tag.js
+          node ./scripts/timestamp.js
 
       - name: build and publish
         run: |
           echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
-          npm version --no-git-tag-version --yes --exact ${{ steps.tag.outputs.stamp }}
-          ./node_modules/.bin/lerna version --no-git-tag-version --yes --exact ${{ steps.tag.outputs.stamp }}
+          npm version --no-git-tag-version --yes --exact ${{ steps.timestamp.outputs.stamp }}
+          ./node_modules/.bin/lerna version --no-git-tag-version --yes --exact ${{ steps.timestamp.outputs.stamp }}
           ./node_modules/.bin/lerna exec -- npm publish --access public --tag=unstable 2>&1
           rm ~/.npmrc

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,16 +23,20 @@ jobs:
           npm install lerna@^3.22.0
           ./node_modules/.bin/lerna bootstrap 2>&1
 
+      - name: tag
+        id: tag
+        run: |
+          node ./scripts/tag.js ${{ github.event.release.tag_name }}
+
       - name: build and publish
         run: |
           echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
           npm version --no-git-tag-version --yes --exact ${{ github.event.release.tag_name }}
           ./node_modules/.bin/lerna version --no-git-tag-version --yes --exact ${{ github.event.release.tag_name }}
-          ./node_modules/.bin/lerna exec -- npm publish --access public 2>&1
+          echo "./node_modules/.bin/lerna exec -- npm publish --access public ${{ steps.tag.outputs.tag }} 2>&1"
           rm ~/.npmrc
 
       - name: Create Pull Request
-        id: cpr
         uses: peter-evans/create-pull-request@v3
         with:
           base: master
@@ -40,7 +44,7 @@ jobs:
           committer: GitHub <noreply@github.com>
           author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
           signoff: false
-          branch: clausehq-publish-${{ github.event.release.tag_name }}
+          branch: ap-publish-${{ github.event.release.tag_name }}
           delete-branch: true
           title: 'chore(actions): publish ${{ github.event.release.tag_name }} to npm'
           body: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,7 +43,7 @@ jobs:
           commit-message: 'chore(actions): publish ${{ github.event.release.tag_name }} to npm'
           committer: GitHub <noreply@github.com>
           author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
-          signoff: false
+          signoff: true
           branch: ap-publish-${{ github.event.release.tag_name }}
           delete-branch: true
           title: 'chore(actions): publish ${{ github.event.release.tag_name }} to npm'

--- a/scripts/timestamp.js
+++ b/scripts/timestamp.js
@@ -15,15 +15,17 @@
 
 'use strict';
 
+const path = require('path');
 const semver = require('semver');
-const targetVersion = process.argv[2];
+const dayjs = require('dayjs');
+const utc = require('dayjs/plugin/utc');
+dayjs.extend(utc);
 
-if (!semver.valid(targetVersion)) {
-    console.error(`Error: the version "${targetVersion}" is invalid!`);
-    process.exit(1);
-}
+const timestamp = dayjs.utc().format('YYYYMMDDHHmmss');
 
-const prerelease = semver.prerelease(targetVersion);
-const tag = prerelease ? 'unstable' : 'stable';
-
-console.log(`::set-output name=tag::--tag=${tag}`);
+const lernaDirectory = path.resolve('.');
+const lernaConfigFile = path.resolve(lernaDirectory, 'lerna.json');
+const lernaConfig = require(lernaConfigFile);
+lernaConfig.version.replace(/-.*/, '');
+const targetVersion = semver.inc(lernaConfig.version, 'patch') + '-' + timestamp;
+console.log(`::set-output name=stamp::${targetVersion}`);


### PR DESCRIPTION
Signed-off-by: Jerome Simeon <jeromesimeon@me.com>

- Add script to detect whether publishing a stable or prerelease version
- Turn signoff on in in version PR (for DCO)

