### PR TITLE
chore(CI) Align github workflows with cicero

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,7 +76,7 @@ jobs:
       - notify
 
     name: Publish to npm
-    if: ${{ success() && github.event_name == 'push'}}
+    if: ${{ success() && github.event_name == 'push' && github.repository_owner == 'accordproject' }}
     runs-on: ubuntu-latest
 
     outputs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: build
+name: Build
 
 on:
   push:
@@ -7,47 +7,57 @@ on:
       - master
 
 jobs:
-  unit-tests:
+  build:
+    name: Unit Tests
+
     strategy:
       matrix:
+        node-version:
+          - 12.x
+          - 14.x
         os:
           - ubuntu-latest
           - windows-latest
-
-    name: Unit Tests
+          - macOS-latest
 
     runs-on: ${{ matrix.os }}
-
-    outputs:
-      job-status: ${{ job.status }}
 
     steps:
       - name: git checkout
         uses: actions/checkout@v2
 
-      - name: lerna install
-        run: |
-          npm install lerna@^3.22.0
-          ./node_modules/.bin/lerna bootstrap 2>&1
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+    
+      - name: use cache 
+        uses: actions/cache@v2
+        with:
+          path: |
+            node_modules
+            */*/node_modules
+          key: ${{ matrix.os }}-${{ matrix.node-version }}-${{ hashFiles('**/package-lock.json') }}
 
-      - name: run unit tests
-        run: |
-          npm run test
+      - name: Build
+        run: npx lerna bootstrap
+
+      - name: Run unit tests
+        run: npm test
 
       - name: Calculate code coverage
-        run: |
-          npm run coverage
+        run: npm run coverage
 
       - name: Coveralls
         uses: coverallsapp/github-action@master
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          flag-name: ${{matrix.os}}
+          flag-name: ${{ matrix.os }}
           parallel: true
 
   notify:
     needs:
-      - unit-tests
+      - build
 
     name: Code Coverage
     if: ${{ success() }}
@@ -62,6 +72,7 @@ jobs:
 
   publish:
     needs:
+      - build
       - notify
 
     name: Publish to npm
@@ -75,10 +86,13 @@ jobs:
       - name: git checkout
         uses: actions/checkout@v2
 
-      - name: lerna install
-        run: |
-          npm install lerna@^3.22.0
-          ./node_modules/.bin/lerna bootstrap 2>&1
+      - name: Use Node.js 14.x
+        uses: actions/setup-node@v1
+        with:
+          node-version: 14.x
+    
+      - name: Build
+        run: npx lerna bootstrap
 
       - name: timestamp
         id: timestamp
@@ -87,8 +101,7 @@ jobs:
 
       - name: build and publish
         run: |
-          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
+          npm config set //registry.npmjs.org/:_authToken ${{ secrets.NPM_TOKEN }}
           npm version --no-git-tag-version --yes --exact ${{ steps.timestamp.outputs.stamp }}
-          ./node_modules/.bin/lerna version --no-git-tag-version --yes --exact ${{ steps.timestamp.outputs.stamp }}
-          ./node_modules/.bin/lerna exec -- npm publish --access public --tag=unstable 2>&1
-          rm ~/.npmrc
+          npx lerna version --no-git-tag-version --yes --exact ${{ steps.timestamp.outputs.stamp }}
+          npx lerna exec -- npm publish --access public --ignore-scripts --tag=unstable 2>&1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: publish
+name: Publish
 
 on:
   release:
@@ -8,20 +8,18 @@ on:
 jobs:
   publish:
     name: Publish to npm
-
     runs-on: ubuntu-latest
-
-    outputs:
-      job-status: ${{ job.status }}
 
     steps:
       - name: git checkout
         uses: actions/checkout@v2
 
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 14
+
       - name: lerna install
-        run: |
-          npm install lerna@^3.22.0
-          ./node_modules/.bin/lerna bootstrap 2>&1
+        run: npx lerna bootstrap
 
       - name: tag
         id: tag
@@ -30,13 +28,12 @@ jobs:
 
       - name: build and publish
         run: |
-          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
+          npm config set //registry.npmjs.org/:_authToken ${{ secrets.NPM_TOKEN }}
           npm version --no-git-tag-version --yes --exact ${{ github.event.release.tag_name }}
-          ./node_modules/.bin/lerna version --no-git-tag-version --yes --exact ${{ github.event.release.tag_name }}
-          ./node_modules/.bin/lerna exec -- npm publish --access public ${{ steps.tag.outputs.tag }} 2>&1
-          rm ~/.npmrc
+          npx lerna version --no-git-tag-version --yes --exact ${{ github.event.release.tag_name }}
+          npx lerna exec -- npm publish --access public ${{ steps.tag.outputs.tag }} 2>&1
 
-      - name: Create Pull Request
+      - name: Create PR to increment version
         uses: peter-evans/create-pull-request@v3
         with:
           base: master
@@ -48,9 +45,9 @@ jobs:
           delete-branch: true
           title: 'chore(actions): publish ${{ github.event.release.tag_name }} to npm'
           body: |
-            # NPM Publish
+            # Increment Versions
 
-            Publish build to NPM
+            Update the package.json version numbers after publishing to NPM.
           assignees: ${{ github.actor }}
           reviewers: ${{ github.actor }}
           draft: false

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,15 +8,17 @@ on:
 jobs:
   publish:
     name: Publish to npm
+    if: ${{ github.repository_owner == 'accordproject' }}
     runs-on: ubuntu-latest
 
     steps:
       - name: git checkout
         uses: actions/checkout@v2
 
-      - uses: actions/setup-node@v1
+      - name: Use Node.js 14.x
+        uses: actions/setup-node@v1
         with:
-          node-version: 14
+          node-version: 14.x
 
       - name: lerna install
         run: npx lerna bootstrap

--- a/packages/concerto-core/test/introspect/loaders/jobqueue.js
+++ b/packages/concerto-core/test/introspect/loaders/jobqueue.js
@@ -154,9 +154,9 @@ describe('JobQueue', function () {
         it('should run all jobs in the queue in order.', function () {
 
             // We use a longer delay in the earlier jobs to make sure the later ones wait
-            const spy1 = sinon.spy(() => delay(20));
-            const spy2 = sinon.spy(() => delay(10));
-            const spy3 = sinon.spy(() => delay(5));
+            const spy1 = sinon.spy(() => delay(10));
+            const spy2 = sinon.spy(() => delay(5));
+            const spy3 = sinon.spy(() => delay(2));
 
             const testJobs = new TestJobQueue();
 
@@ -177,8 +177,8 @@ describe('JobQueue', function () {
             testJobs.addJob('test job');
 
             return Promise.all([
-                expect(delay(startDelay - 10).then(() => testJobs.jobRunning)).to.eventually.be.false,
-                expect(delay(startDelay + 10).then(() => testJobs.jobRunning)).to.eventually.be.true
+                expect(delay(startDelay - 100).then(() => testJobs.jobRunning)).to.eventually.be.false,
+                expect(delay(startDelay + 100).then(() => testJobs.jobRunning)).to.eventually.be.true
             ]);
         });
 
@@ -192,9 +192,8 @@ describe('JobQueue', function () {
             testJobs.addJob('test job 2');
 
             return Promise.all([
-                expect(delay(startDelay + testJobTime + 10).then(() => testJobs.getQueue())).to.eventually.have.lengthOf(1),
-
-                expect(delay(startDelay + testJobTime + 10).then(() => testJobs.getQueue()[0])).to.eventually.equal('test job 2')
+                expect(delay(startDelay + testJobTime + 100).then(() => testJobs.getQueue())).to.eventually.have.lengthOf(1),
+                expect(delay(startDelay + testJobTime + 100).then(() => testJobs.getQueue()[0])).to.eventually.equal('test job 2')
             ]);
         });
 
@@ -210,7 +209,7 @@ describe('JobQueue', function () {
             return Promise.all([
                 expect(delay(testJobTime + (jobDelay / 2)).then(() => testJobs.jobRunning)).to.eventually.be.false,
                 expect(delay(testJobTime + (jobDelay / 2)).then(() => testJobs.getQueue()[0])).to.eventually.equal('test job 2'),
-                expect(delay(testJobTime + jobDelay + 10).then(() => testJobs.jobRunning)).to.eventually.be.true,
+                expect(delay(testJobTime + jobDelay + 100).then(() => testJobs.jobRunning)).to.eventually.be.true,
             ]);
         });
     });


### PR DESCRIPTION
Signed-off-by: Jerome Simeon <jeromesimeon@me.com>

### Why

We need to do a second round of design on CI migration from Travis to GitHub Actions because:
1. we have to variants now with slightly different takes in https://github.com/accordproject/concerto/tree/master/.github/workflows and https://github.com/accordproject/cicero/tree/master/.github/workflows
2. We need to decide which node version we support
3. Better to maintain one well understood version to make our lives easier
4. Travis is being _very_ capricious and the matter feels more urgent than it was a year ago

### Changes

- Consolidate GitHub action workflows for build/testing/publication to npm

### Flags

- Still draft, one key question is when is `lerna` installed and how, but want this PR ready for discussion on Tech WG call

