### PR TITLE
feat(javaVisitor):used java.time.Instant instead of java.util.Date

### DIFF
--- a/packages/concerto-tools/lib/codegen/fromcto/java/javavisitor.js
+++ b/packages/concerto-tools/lib/codegen/fromcto/java/javavisitor.js
@@ -358,7 +358,7 @@ public abstract class Resource
     toJavaType(type) {
         switch(type) {
         case 'DateTime':
-            return 'java.util.Date';
+            return 'java.time.Instant';
         case 'Boolean':
             return 'boolean';
         case 'String':

--- a/packages/concerto-tools/test/codegen/fromcto/java/javavisitor.js
+++ b/packages/concerto-tools/test/codegen/fromcto/java/javavisitor.js
@@ -675,8 +675,8 @@ describe('JavaVisitor', function () {
     });
 
     describe('toJavaType', () => {
-        it('should return java.util.Date for DateTime', () => {
-            javaVisit.toJavaType('DateTime').should.deep.equal('java.util.Date');
+        it('should return java.time.Instant for DateTime', () => {
+            javaVisit.toJavaType('DateTime').should.deep.equal('java.time.Instant');
         });
 
         it('should return boolean for Boolean', () => {


### PR DESCRIPTION
Signed-off-by: Aniruddha Shriwant <aniruddhashriwant@gmail.com>

<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #101 <CORRESPONDING ISSUE NUMBER>
<!--- Provide an overall summary of the pull request -->

### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
- Changed `java.util.Date` with `java.time.Instant` 


### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [x] Merging to `master` from `fork:branchname`
