### PR TITLE
fix(core) Remove  option on factory API

### DIFF
--- a/packages/concerto-core/api.txt
+++ b/packages/concerto-core/api.txt
@@ -26,11 +26,11 @@ class Concerto {
 }
 class Factory {
    + void constructor(ModelManager) 
-   + Resource newResource(String,String,String,Object,boolean,String,boolean,boolean) throws TypeNotFoundException
+   + Resource newResource(String,String,String,Object,boolean,String,boolean) throws TypeNotFoundException
    + Resource newConcept(String,String,String,Object,boolean,String,boolean) throws TypeNotFoundException
    + Relationship newRelationship(String,String,String) throws TypeNotFoundException
-   + Resource newTransaction(String,String,String,Object,String,boolean,boolean) 
-   + Resource newEvent(String,String,String,Object,String,boolean,boolean) 
+   + Resource newTransaction(String,String,String,Object,String,boolean) 
+   + Resource newEvent(String,String,String,Object,String,boolean) 
    + boolean hasInstance(object) 
 }
 class AssetDeclaration extends IdentifiedDeclaration {

--- a/packages/concerto-core/changelog.txt
+++ b/packages/concerto-core/changelog.txt
@@ -24,8 +24,9 @@
 # Note that the latest public API is documented using JSDocs and is available in api.txt.
 #
 
-Version 1.0.0-alpha.5 {05c2a5a3d15e05dd1e4430d0e655c9dd} 2021-04-08
+Version 1.0.0-alpha.5 {446997953e3ac90783ff9d492a8e7fdc} 2021-04-08
 - Support Concerto version pragma at the beginning of model files
+- Remove allowEmptyId option in factory API
 
 Version 1.0.0-alpha.4 {3b7ebc06a536a5e81624225c7b0079ee} 2021-04-08
 - Allow optional UTC offset for validating DateTime values

--- a/packages/concerto-core/lib/factory.js
+++ b/packages/concerto-core/lib/factory.js
@@ -69,8 +69,6 @@ class Factory {
      * <dt>empty</dt><dd>return a resource instance with empty property values.</dd></dl>
      * @param {boolean} [options.includeOptionalFields] - if <code>options.generate</code>
      * is specified, whether optional fields should be generated.
-     * @param {boolean} [options.allowEmptyId] - if <code>options.allowEmptyId</code>
-     * is specified as true, a zero length string for id is allowed (allows it to be filled in later).
      * @return {Resource} the new instance
      * @throws {TypeNotFoundException} if the type is not registered with the ModelManager
      */
@@ -102,14 +100,12 @@ class Factory {
                 }));
             }
 
-            if(!(options.allowEmptyId && id==='')) {
-                if(id.trim().length === 0) {
-                    let formatter = Globalize.messageFormatter('factory-newinstance-missingidentifier');
-                    throw new Error(formatter({
-                        namespace: ns,
-                        type: type
-                    }));
-                }
+            if(id.trim().length === 0) {
+                let formatter = Globalize.messageFormatter('factory-newinstance-missingidentifier');
+                throw new Error(formatter({
+                    namespace: ns,
+                    type: type
+                }));
             }
         } else if(id) {
             throw new Error('Type is not identifiable ' + classDecl.getFullyQualifiedName());
@@ -192,8 +188,6 @@ class Factory {
      * <dt>empty</dt><dd>return a resource instance with empty property values.</dd></dl>
      * @param {boolean} [options.includeOptionalFields] - if <code>options.generate</code>
      * is specified, whether optional fields should be generated.
-     * @param {boolean} [options.allowEmptyId] - if <code>options.allowEmptyId</code>
-     * is specified as true, a zero length string for id is allowed (allows it to be filled in later).
      * @return {Resource} A resource for the new transaction.
      */
     newTransaction(ns, type, id, options) {
@@ -224,8 +218,6 @@ class Factory {
      * <dt>empty</dt><dd>return a resource instance with empty property values.</dd></dl>
      * @param {boolean} [options.includeOptionalFields] - if <code>options.generate</code>
      * is specified, whether optional fields should be generated.
-     * @param {boolean} [options.allowEmptyId] - if <code>options.allowEmptyId</code>
-     * is specified as true, a zero length string for id is allowed (allows it to be filled in later).
      * @return {Resource} A resource for the new event.
      */
     newEvent(ns, type, id, options) {

--- a/packages/concerto-core/test/factory.js
+++ b/packages/concerto-core/test/factory.js
@@ -73,12 +73,7 @@ describe('Factory', function() {
 
     describe('#newResource', function() {
 
-        it('should not throw creating a new instance with a zero length string as the ID if the option to allowEmptyId is set to boolean true', function() {
-            const resource = factory.newResource(namespace, assetName, '', {allowEmptyId: true});
-            resource.assetId.should.equal('');
-        });
-
-        it('should throw creating a new instance with a non-zero length string as the ID if the option to allowEmptyId is not set to boolean true', function() {
+        it('should throw creating a new instance with a non-zero length string as the ID', function() {
             (() => {
                 factory.newResource(namespace, assetName, '     ', {});
             }).should.throw(/Missing identifier/);
@@ -95,19 +90,6 @@ describe('Factory', function() {
                 factory.newResource(namespace, assetName, '     ');
             }).should.throw(/Missing identifier/);
         });
-
-        it('should throw creating a new instance with an ID that is just whitespace if the option to allowEmptyId is not set to boolean true', function() {
-            (() => {
-                factory.newResource(namespace, assetName, '     ', {allowEmptyId: 'true'});
-            }).should.throw(/Missing identifier/);
-        });
-
-        it('should throw creating a new instance with an ID that is just whitespace if the option to allowEmptyId is set to boolean true', function() {
-            (() => {
-                factory.newResource(namespace, assetName, '     ', {allowEmptyId: true});
-            }).should.throw(/Missing identifier/);
-        });
-
 
         it('should throw creating an abstract asset', function() {
             (() => {


### PR DESCRIPTION
Signed-off-by: Jerome Simeon <jeromesimeon@me.com>

# Closes #248 

Remove unused and inconsistent `allowEmptyId` option on factory API.

### Changes
- Remove `allowEmptyId` option

