### PR TITLE
fix(build) use 'latest' tag rather than 'stable' for publication

### DIFF
--- a/scripts/tag.js
+++ b/scripts/tag.js
@@ -24,6 +24,6 @@ if (!semver.valid(targetVersion)) {
 }
 
 const prerelease = semver.prerelease(targetVersion);
-const tag = prerelease ? 'unstable' : 'stable';
+const tag = prerelease ? 'unstable' : 'latest';
 
 console.log(`::set-output name=tag::--tag=${tag}`);


### PR DESCRIPTION
Signed-off-by: Jerome Simeon <jeromesimeon@me.com>

### Changes
- To properly publish new releases, we need to use the `latest` tag rather than simply `stable`
