### PR TITLE
fix(cli) Passes proper options for Ergo validation

### DIFF
--- a/packages/concerto-cli/index.js
+++ b/packages/concerto-cli/index.js
@@ -76,10 +76,10 @@ require('yargs')
                 })
                 .catch((err) => {
                     Logger.info('Input is invalid');
-                    Logger.error(err.message);
+                    Logger.error(err);
                 });
         } catch (err){
-            Logger.error(err.message);
+            Logger.error(err);
             return;
         }
     })

--- a/packages/concerto-cli/lib/commands.js
+++ b/packages/concerto-cli/lib/commands.js
@@ -114,9 +114,9 @@ class Commands {
             concerto.validate(json);
         } else {
             const factory = new Factory(modelManager);
-            const serializer = new Serializer(factory, modelManager, options);
+            const serializer = new Serializer(factory, modelManager);
 
-            const object = serializer.fromJSON(json, options);
+            const object = serializer.fromJSON(json);
             return JSON.stringify(serializer.toJSON(object, options));
         }
     }


### PR DESCRIPTION
Signed-off-by: Jerome Simeon <jeromesimeon@me.com>

# Closes #280

Fixes options handling for CLI validation with `--ergo` option.

### Changes
- Passes ergo option only on `toJSON` output during validation

