### PR TITLE
fix(ts) Make ModelManager.getType call public in TypeScript

### DIFF
--- a/packages/concerto-core/types/index.d.ts
+++ b/packages/concerto-core/types/index.d.ts
@@ -309,7 +309,7 @@ declare module '@accordproject/concerto-core' {
     getModelFile(namespace: string): ModelFile | null;
     private getModelFileByFileName(fileName: string): ModelFile | null;
     getNamespaces(): string[];
-    private getType(qualifiedName: string): ClassDeclaration;
+    getType(qualifiedName: string): ClassDeclaration;
     getSystemTypes(): ClassDeclaration[];
     getAssetDeclarations(): AssetDeclaration[];
     getTransactionDeclarations(): TransactionDeclaration[];


### PR DESCRIPTION
Signed-off-by: jeromesimeon <jeromesimeon@me.com>

### Changes

- Small adjustment to typescript API: `ModelManager.getType()` is useful to have publicly available

