### PR TITLE
feat(codegen): Improve JSON Schema to Concerto inference

### DIFF
--- a/packages/concerto-tools/lib/codegen/fromJsonSchema/cto/inferModel.js
+++ b/packages/concerto-tools/lib/codegen/fromJsonSchema/cto/inferModel.js
@@ -191,7 +191,9 @@ function inferConcept(definition, context) {
         // https://json-schema.org/understanding-json-schema/reference/numeric.html#range
         if (['Double', 'Long', 'Integer'].includes(type)) {
             if (propertyDefinition.minimum || propertyDefinition.exclusiveMaximum) {
-                validator = ` range=[${propertyDefinition.minimum || ''},${propertyDefinition.exclusiveMaximum || ''}]`;
+                const min = propertyDefinition.minimum || '';
+                const exclusiveMax = propertyDefinition.exclusiveMaximum || '';
+                validator = ` range=[${min},${exclusiveMax}]`;
             }
         } else if (type === 'String' && propertyDefinition.pattern) {
             validator = ` regex=/${propertyDefinition.pattern}/`;

--- a/packages/concerto-tools/schema.json
+++ b/packages/concerto-tools/schema.json
@@ -1,0 +1,10 @@
+{
+    "type": "object",
+    "properties": {
+        "name": { "type": "string" },
+        "children": {
+            "type": "array",
+            "items": { "$ref": "#" }
+        }
+    }
+}

--- a/packages/concerto-tools/test/codegen/fromJsonSchema/cto/data/2020-schema.json
+++ b/packages/concerto-tools/test/codegen/fromJsonSchema/cto/data/2020-schema.json
@@ -1,0 +1,34 @@
+{
+    "$id": "https://example.com/arrays.schema.json",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "description": "A representation of a person, company, organization, or place",
+    "type": "object",
+    "properties": {
+        "fruits": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        },
+        "vegetables": {
+            "type": "array",
+            "items": { "$ref": "#/$defs/veggie" }
+        }
+    },
+    "$defs": {
+        "veggie": {
+            "type": "object",
+            "required": ["veggieName", "veggieLike"],
+            "properties": {
+                "veggieName": {
+                    "type": "string",
+                    "description": "The name of the vegetable."
+                },
+                "veggieLike": {
+                    "type": "boolean",
+                    "description": "Do I like this vegetable?"
+                }
+            }
+        }
+    }
+}

--- a/packages/concerto-tools/test/codegen/fromJsonSchema/cto/data/modifiers-schema.json
+++ b/packages/concerto-tools/test/codegen/fromJsonSchema/cto/data/modifiers-schema.json
@@ -13,13 +13,21 @@
         },
         "latitude": {
             "type": "number",
-            "minimum": -90,
+            "exclusiveMinimum": -90,
             "maximum": 90
         },
         "longitude": {
             "type": "number",
             "minimum": -180,
-            "maximum": 180
+            "exclusiveMaximum": 180
+        },
+        "elevation": {
+            "type": "number",
+            "minimum": -11034
+        },
+        "yearDiscovered": {
+            "type": "integer",
+            "exclusiveMaximum": 2022
         }
     }
 }

--- a/packages/concerto-tools/test/codegen/fromJsonSchema/cto/data/modifiers-schema.json
+++ b/packages/concerto-tools/test/codegen/fromJsonSchema/cto/data/modifiers-schema.json
@@ -1,0 +1,25 @@
+{
+    "$id": "https://example.com/geographical-location.schema.json",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "Longitude and Latitude Values",
+    "description": "A geographical coordinate.",
+    "required": ["latitude", "longitude"],
+    "type": "object",
+    "properties": {
+        "name": {
+            "type": "string",
+            "default": "home",
+            "pattern": "[\\w\\s]+"
+        },
+        "latitude": {
+            "type": "number",
+            "minimum": -90,
+            "maximum": 90
+        },
+        "longitude": {
+            "type": "number",
+            "minimum": -180,
+            "maximum": 180
+        }
+    }
+}

--- a/packages/concerto-tools/test/codegen/fromJsonSchema/cto/inferModel.js
+++ b/packages/concerto-tools/test/codegen/fromJsonSchema/cto/inferModel.js
@@ -151,8 +151,10 @@ import org.accordproject.time.* from https://models.accordproject.org/time@0.2.0
 
 concept Geographical_location {
    o String name default="home" regex=/[\\w\\s]+/ optional
-   o Double latitude range=[-90,]
-   o Double longitude range=[-180,]
+   o Double latitude
+   o Double longitude range=[-180,180]
+   o Double elevation range=[-11034,] optional
+   o Integer yearDiscovered range=[,2022] optional
 }
 
 `);


### PR DESCRIPTION
### Changes
- Adds support for 2019 draft, draft-06 and draft-07 of JSON Schema.
- Adds detection and support for 2020-12 draft of JSON Schema (this is not backwards compatible with previous drafts).
- Adds support for `pattern`, `minimum` and `exclusiveMaximum` modifiers.
- Adds support for recursive definitions in JSON Schema.
- Adds support for `$defs` in addition to `definitions`
- Adds inference for namespace and root type name from the `$id` property

I feel that this is starting to stablise and could be considered for inclusion in the public API and CLI.

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [x] Merging to `master` from `fork:branchname`
