### PR TITLE
fix(dep) semver is a dependency for concerto-core

### DIFF
--- a/packages/concerto-core/package.json
+++ b/packages/concerto-core/package.json
@@ -51,7 +51,6 @@
     "moxios": "0.4.0",
     "nyc": "15.1.0",
     "pegjs": "0.10.0",
-    "semver": "7.3.5",
     "sinon": "10.0.0",
     "sinon-chai": "3.6.0",
     "tmp-promise": "3.0.2",
@@ -66,6 +65,7 @@
     "json-colorizer": "2.2.2",
     "lorem-ipsum": "2.0.3",
     "randexp": "0.5.3",
+    "semver": "7.3.5",
     "slash": "3.0.0",
     "urijs": "1.19.7",
     "uuid": "3.4.0"


### PR DESCRIPTION
Signed-off-by: jeromesimeon <jeromesimeon@me.com>

# Closes #309 

### Changes

- `semver` moved from `devDependencies` to `dependencies` in `@accordproject/concerto-core`

### Flags

Tested with the micro-publish:
```
zsh-5.8$ npm install -g @accordproject/concerto-cli@1.1.1-20210811120929 
npm WARN deprecated uuid@3.4.0: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
/Users/jerome.simeon/.nvm/versions/node/v14.16.1/bin/concerto -> /Users/jerome.simeon/.nvm/versions/node/v14.16.1/lib/node_modules/@accordproject/concerto-cli/index.js
+ @accordproject/concerto-cli@1.1.1-20210811120929
added 3 packages from 2 contributors and updated 3 packages in 6.512s
zsh-5.8$ concerto -help
concerto <cmd> [args]

Commands:
  concerto validate  validate JSON against model files
  concerto compile   generate code for a target platform
  concerto get       save local copies of external model dependencies
  concerto import    import a cto string into its metamodel
  concerto export    export a metamodel to cto syntax

Options:
      --version  Show version number                                   [boolean]
  -v, --verbose                                                 [default: false]
      --help     Show help                                             [boolean]

# Please specify a command
```

