### PR TITLE
feat(models): allow prerelease concerto versions to match (resolves #326)

### DIFF
--- a/packages/concerto-core/lib/introspect/modelfile.js
+++ b/packages/concerto-core/lib/introspect/modelfile.js
@@ -564,7 +564,7 @@ class ModelFile {
      */
     isCompatibleVersion() {
         if (this.ast.version) {
-            if (semver.satisfies(packageJson.version, this.ast.version.value)) {
+            if (semver.satisfies(packageJson.version, this.ast.version.value, { includePrerelease: true })) {
                 this.concertoVersion = this.ast.version.value;
             } else {
                 throw new Error(`ModelFile expects Concerto version ${this.ast.version.value} but this is ${packageJson.version}`);

--- a/packages/concerto-core/test/data/model/versionValid.cto
+++ b/packages/concerto-core/test/data/model/versionValid.cto
@@ -12,7 +12,7 @@
  * limitations under the License.
  */
 
-concerto version "^1.0.0-alpha.0"
+concerto version "^1.0.0"
 
 // define the namespace for this model
 namespace org.acme

--- a/packages/concerto-core/test/introspect/concertoVersion.js
+++ b/packages/concerto-core/test/introspect/concertoVersion.js
@@ -18,6 +18,8 @@ const ModelFile = require('../../lib/introspect/modelfile');
 const ModelManager = require('../../lib/modelmanager');
 const fs = require('fs');
 const path = require('path');
+const sinon = require('sinon');
+const pkgJSON = require('../../package.json');
 
 const chai = require('chai');
 chai.should();
@@ -36,6 +38,7 @@ describe('ModelFile', () => {
     });
 
     afterEach(() => {
+        sinon.restore();
     });
 
     describe('#concertoVersion', () => {
@@ -48,7 +51,15 @@ describe('ModelFile', () => {
 
         it('should return when concerto version is compatible with model', () => {
             let mf = new ModelFile(modelManager, versionValid);
-            mf.getConcertoVersion().should.equal('^1.0.0-alpha.0');
+            mf.getConcertoVersion().should.equal('^1.0.0');
+        });
+
+        it('should return when concerto version is compatible with model with a pre-release version', () => {
+            const version = pkgJSON.version;
+            const newVersion = `${version}-unittest.${new Date().getTime()}`;
+            sinon.replace(pkgJSON, 'version', newVersion);
+            let mf = new ModelFile(modelManager, versionValid);
+            mf.getConcertoVersion().should.equal('^1.0.0');
         });
 
         it('should return when model has no concerto version range', () => {


### PR DESCRIPTION
Update model file parsing to enable the specified Concerto version range (for example, `concerto version "^1.0.0"`) to match a pre-release version of Concerto (for example, `1.1.3-20210826140311`). This fixes the pain point in issue #326 by making it possible to install `@accordproject/concerto-core@unstable` and use it without changing your model files to match.