### PR TITLE
feature(core) Expose name resolution to MetaModel API

### DIFF
--- a/packages/concerto-core/api.txt
+++ b/packages/concerto-core/api.txt
@@ -115,6 +115,7 @@ class ModelFileDownloader {
    + object createNameTable() 
    + string resolveName() 
    + object resolveTypeNames() 
+   + object resolveMetaModel() 
    + object enumPropertyToMetaModel() 
    + object decoratorArgToMetaModel() 
    + object decoratorToMetaModel() 

--- a/packages/concerto-core/changelog.txt
+++ b/packages/concerto-core/changelog.txt
@@ -24,9 +24,10 @@
 # Note that the latest public API is documented using JSDocs and is available in api.txt.
 #
 
-Version 1.2.2 {a07bdd68f8dc79691f86852ebeae6786} 2021-08-12
+Version 1.2.2 {b19318bb094e5da7bdff192cf9a3b4f2} 2021-08-12
 - Fixes to metamodel, including terminology changes
 - Ability to roundtrip model manager to metamodel
+- Expose name resolution to MetaModel API
 
 Version 1.1.2 {2c9512d9d90bde289b47942937d252ca} 2021-08-12
 - Add Factory.newId for creating new unique IDs

--- a/packages/concerto-core/lib/introspect/metamodel.js
+++ b/packages/concerto-core/lib/introspect/metamodel.js
@@ -346,6 +346,20 @@ function resolveTypeNames(metaModel, table) {
 }
 
 /**
+ * Resolve the namespace for names in the metamodel
+ * @param {object} modelManager - the ModelManager
+ * @param {object} metaModel - the MetaModel
+ * @return {object} the resolved metamodel
+ */
+function resolveMetaModel(modelManager, metaModel) {
+    const result = JSON.parse(JSON.stringify(metaModel));
+    const nameTable = createNameTable(modelManager, metaModel);
+    // This adds the fully qualified names to the same object
+    resolveTypeNames(result, nameTable);
+    return result;
+}
+
+/**
  * Create metamodel for an enum property
  * @param {object} ast - the AST for the property
  * @return {object} the metamodel for this property
@@ -769,11 +783,9 @@ function modelManagerToMetaModel(modelManager, resolve, validate) {
         models: [],
     };
     modelManager.getModelFiles().forEach((modelFile) => {
-        const metaModel = modelToMetaModel(modelFile.ast, validate);
+        let metaModel = modelToMetaModel(modelFile.ast, validate);
         if (resolve) {
-            const nameTable = createNameTable(modelManager, metaModel);
-            // This adds the fully qualified names to the same object
-            resolveTypeNames(metaModel, nameTable);
+            metaModel = resolveMetaModel(modelManager, metaModel);
         }
         result.models.push(metaModel);
     });
@@ -1059,10 +1071,8 @@ function ctoToMetaModel(model, validate) {
 function ctoToMetaModelAndResolve(modelManager, model, validate) {
     const ast = parser.parse(model);
     const metaModel = modelToMetaModel(ast);
-    const nameTable = createNameTable(modelManager, metaModel);
-    // This adds the fully qualified names to the same object
-    resolveTypeNames(metaModel, nameTable);
-    return metaModel;
+    const result = resolveMetaModel(modelManager, metaModel);
+    return result;
 }
 
 module.exports = {
@@ -1070,6 +1080,7 @@ module.exports = {
     modelFileToMetaModel,
     modelManagerToMetaModel,
     modelManagerFromMetaModel,
+    resolveMetaModel,
     ctoToMetaModel,
     ctoToMetaModelAndResolve,
     ctoFromMetaModel,


### PR DESCRIPTION
Signed-off-by: jeromesimeon <jeromesimeon@me.com>

### Description

Current MetaModel API either imports CTO files into a metamodel instance syntactically or with name import resolution (semantic pass). It can be useful to allow name resolution directly as a function from metamodel instance to metamodel instance.

### Changes

- Expose name resolution on metamodel instance as an API call

