### PR TITLE
refactor(imports) clean up import handling from parser

### DIFF
--- a/packages/concerto-core/lib/modelmanager.js
+++ b/packages/concerto-core/lib/modelmanager.js
@@ -287,7 +287,7 @@ abstract concept Event {}
                     try {
                         this.validateModelFiles();
                         return [];
-                    } catch (validationError){
+                    } catch (validationError) {
                         // The validation error tells us the first model that is missing from the model manager, but the dependency download
                         // will fail at the first external model, regardless of whether there is already a local copy.
                         // As a hint to the user we display the URL of the external model that can't be found.

--- a/packages/concerto-core/lib/modelutil.js
+++ b/packages/concerto-core/lib/modelutil.js
@@ -43,59 +43,6 @@ class ModelUtil {
     }
 
     /**
-     * Returns true if the specified name is a wildcard
-     * @param {string} fqn - the source string
-     * @return {boolean} true if the specified name is a wildcard
-     * @private
-     */
-    static isWildcardName(fqn) {
-        return ModelUtil.getShortName(fqn) === '*';
-    }
-
-    /**
-     * Returns true if the specified name is a recusive wildcard
-     * @param {string} fqn - the source string
-     * @return {boolean} true if the specified name is a recusive wildcard
-     * @private
-     */
-    static isRecursiveWildcardName(fqn) {
-        return ModelUtil.getShortName(fqn) === '**';
-    }
-
-    /**
-     * Returns true if a type matches the required fully qualified name. The required
-     * name may be a wildcard or recursive wildcard
-     * @param {Typed} type - the type to test
-     * @param {string} fqn - required fully qualified name
-     * @return {boolean} true if the specified type and namespace match
-     * @private
-     */
-    static isMatchingType(type, fqn) {
-
-        // Instance of type before any complex string operations.
-        if (type.instanceOf(fqn)) {
-            // matching type or subtype
-            return true;
-        }
-
-        let ns = ModelUtil.getNamespace(fqn);
-        let typeNS = type.getNamespace();
-
-        if (ModelUtil.isWildcardName(fqn) && typeNS === ns) {
-            // matching namespace
-        } else if (ModelUtil.isRecursiveWildcardName(fqn) && (typeNS + '.').startsWith(ns + '.')) {
-            // matching recursive namespace
-        } else if (ModelUtil.isRecursiveWildcardName(fqn) && !ns) {
-            // matching root recursive namespace
-        } else {
-            // does not match
-            return false;
-        }
-
-        return true;
-    }
-
-    /**
      * Returns the namespace for a the fully qualified name of a type
      * @param {string} fqn - the fully qualified identifier of a type
      * @return {string} - namespace of the type (everything before the last dot)
@@ -114,6 +61,16 @@ class ModelUtil {
         }
 
         return result;
+    }
+
+    /**
+     * Return the fully qualified name for an import
+     * @param {object} imp - the import
+     * @return {string} - the fully qualified name for that import
+     * @private
+     */
+    static importFullyQualifiedName(imp) {
+        return imp.$class === 'concerto.metamodel.ImportAll' ? `${imp.namespace}.*` : `${imp.namespace}.${imp.name}`;
     }
 
     /**

--- a/packages/concerto-core/test/introspect/modelfile.js
+++ b/packages/concerto-core/test/introspect/modelfile.js
@@ -98,7 +98,7 @@ describe('ModelFile', () => {
             };
             sandbox.stub(parser, 'parse').returns(ast);
             let mf = new ModelFile(modelManager, 'fake definitions');
-            mf.imports.should.deep.equal(['org.freddos.Bar', 'org.doge.Foo', 'concerto.Concept', 'concerto.Asset', 'concerto.Transaction', 'concerto.Participant', 'concerto.Event']);
+            mf.getImports().should.deep.equal(['org.freddos.Bar', 'org.doge.Foo', 'concerto.Concept', 'concerto.Asset', 'concerto.Transaction', 'concerto.Participant', 'concerto.Event']);
         });
 
         it('should call the parser with the definitions and save imports with uris', () => {
@@ -119,7 +119,7 @@ describe('ModelFile', () => {
             };
             sandbox.stub(parser, 'parse').returns(ast);
             let mf = new ModelFile(modelManager, 'fake definitions');
-            mf.imports.should.deep.equal(['org.doge.Foo', 'org.freddos.*', 'concerto.Concept', 'concerto.Asset', 'concerto.Transaction', 'concerto.Participant', 'concerto.Event']);
+            mf.getImports().should.deep.equal(['org.doge.Foo', 'org.freddos.*', 'concerto.Concept', 'concerto.Asset', 'concerto.Transaction', 'concerto.Participant', 'concerto.Event']);
             mf.getImportURI('org.freddos.*').should.equal('https://freddos.org/model.cto');
             (mf.getImportURI('org.doge.Foo') === null).should.be.true;
         });

--- a/packages/concerto-core/test/models/test.js
+++ b/packages/concerto-core/test/models/test.js
@@ -16,7 +16,6 @@
 
 const Factory = require('../../lib/factory');
 const ModelManager = require('../../lib/modelmanager');
-const ModelUtil = require('../../lib/modelutil');
 const RelationshipDeclaration = require('../../lib/introspect/relationshipdeclaration');
 const Serializer = require('../../lib/serializer');
 const TypeNotFoundException = require('../../lib/typenotfoundexception');
@@ -336,8 +335,10 @@ describe('Test Model', function(){
             let modelFile = modelManager.getModelFile('org.acme');
             modelFile.isLocalType('MyParticipant').should.equal(false);
             modelFile.isImportedType('MyParticipant').should.equal(true);
-            let imprts = modelFile.getImports().filter( (element) => {
-                const importNamespace = ModelUtil.getNamespace(element);
+            let imprts = modelFile.getImports().filter((element) => {
+                const split = element.split('.');
+                split.pop();
+                const importNamespace = split.join('.');
                 return modelManager.getModelFile(importNamespace);
             });
             imprts.length.should.equal(6); // XXX Now includes all concerto.* classes
@@ -376,7 +377,9 @@ describe('Test Model', function(){
             modelFile.isLocalType('Business').should.equal(true);
             modelFile.isImportedType('Person').should.equal(true);
             let imprts = modelFile.getImports().filter( (element) => {
-                const importNamespace = ModelUtil.getNamespace(element);
+                const split = element.split('.');
+                split.pop();
+                const importNamespace = split.join('.');
                 return modelManager.getModelFile(importNamespace);
             });
             imprts.length.should.equal(7); // XXX Now includes all concerto.* classes

--- a/packages/concerto-core/test/modelutil.js
+++ b/packages/concerto-core/test/modelutil.js
@@ -16,10 +16,8 @@
 
 const ModelFile = require('../lib/introspect/modelfile');
 const Property = require('../lib/introspect/property');
-const Typed = require('../lib/model/identifiable');
 const ModelManager = require('../lib/modelmanager');
 const ModelUtil = require('../lib/modelutil');
-const Util = require('./composer/composermodelutility');
 
 require('chai').should();
 const sinon = require('sinon');
@@ -57,104 +55,6 @@ describe('ModelUtil', function () {
             ModelUtil.getShortName('Foo').should.equal('Foo');
         });
 
-    });
-
-    describe('#isWildcardName', () => {
-
-        it('should return false for a name without a wildcard', () => {
-            ModelUtil.isWildcardName('Foo').should.be.false;
-        });
-
-        it('should return true for a name with a wildcard', () => {
-            ModelUtil.isWildcardName('*').should.be.true;
-        });
-
-        it('should return false for a fully qualified name without a wildcard', () => {
-            ModelUtil.isWildcardName('org.acme.baz.Foo').should.be.false;
-        });
-
-        it('should return true for a fully qualified name with a wildcard', () => {
-            ModelUtil.isWildcardName('org.acme.baz.*').should.be.true;
-        });
-
-        it('should return false for a fully qualified name with a recursive wildcard', () => {
-            ModelUtil.isWildcardName('org.acme.baz.**').should.be.false;
-        });
-
-    });
-
-    describe('#isRecursiveWildcardName', () => {
-
-        it('should return false for a name without a recursive wildcard', () => {
-            ModelUtil.isRecursiveWildcardName('Foo').should.be.false;
-        });
-
-        it('should return true for a name with a recursive wildcard', () => {
-            ModelUtil.isRecursiveWildcardName('**').should.be.true;
-        });
-
-        it('should return false for a fully qualified name without a recursive wildcard', () => {
-            ModelUtil.isRecursiveWildcardName('org.acme.baz.Foo').should.be.false;
-        });
-
-        it('should return true for a fully qualified name with a recursive wildcard', () => {
-            ModelUtil.isRecursiveWildcardName('org.acme.baz.**').should.be.true;
-        });
-
-        it('should return false for a fully qualified name with a wildcard', () => {
-            ModelUtil.isRecursiveWildcardName('org.acme.baz.*').should.be.false;
-        });
-
-    });
-
-    describe('#isMatchingType', () => {
-
-        let modelManager;
-        let classDecl;
-        let type;
-
-        beforeEach(() => {
-            modelManager = new ModelManager();
-            Util.addComposerModel(modelManager);
-            modelManager.addModelFile(`namespace org.acme.baz
-            asset Foo identified by fooId {
-                o String fooId
-            }`);
-            classDecl = modelManager.getType('org.acme.baz.Foo');
-            type = new Typed(modelManager, classDecl, 'org.acme.baz', 'Foo' );
-        });
-
-        it('should return true for an exact match', () => {
-            ModelUtil.isMatchingType(type, 'org.acme.baz.Foo').should.be.true;
-        });
-
-        it('should return false for a non-match', () => {
-            ModelUtil.isMatchingType(type, 'org.acme.baz.Bar').should.be.false;
-        });
-
-        it('should return true for a wildcard namespace match', () => {
-            ModelUtil.isMatchingType(type, 'org.acme.baz.*').should.be.true;
-        });
-
-        it('should return false for a non-matching wildcard namespace', () => {
-            ModelUtil.isMatchingType(type, 'org.doge.baz.*').should.be.false;
-        });
-
-        it('should return false for an ancestor namespace wildcard match', () => {
-            ModelUtil.isMatchingType(type, 'org.acme.*').should.be.false;
-        });
-
-        it('should return true for a recursive wildcard match', () => {
-            ModelUtil.isMatchingType(type, 'org.acme.**').should.be.true;
-        });
-
-        it('should return false for a non-matching recursive wildcard', () => {
-            ModelUtil.isMatchingType(type, 'org.ac.**').should.be.false;
-        });
-
-        it('should return true for a root recursive wildcard match', () => {
-            ModelUtil.isMatchingType(type, '**').should.be.true;
-        });
     });
 
     describe('#getNamespace', function() {


### PR DESCRIPTION
Signed-off-by: jeromesimeon <jeromesimeon@me.com>

### Changes

This PR cleans up import handling which can be made simpler with the new parser using the Concerto Metamodel. Notably:

- Builds simpler import tables for wildcard and non-wildcard
- Avoid using fully qualified names which have to be parsed again when possible
- Also cleans up what looks like obsolete code in `ModelUtil`

