### PR TITLE
docs(README & CONTRIBUTING): updated slack link to discord's - #369

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,8 +4,7 @@
 We'd love for you to contribute to our source code and to make Concerto technology even better than it is today! Please refer to the [Accord Project Contribution guidelines][apcontribute] we'd like you to follow.
 
 ## Concerto Specific Information
-The main channel for support with Concerto is the [Concerto Slack Channel][apconcertoslack] on the [Accord Project slack][apslack].
+The main channel for support with Concerto is the Concerto Discord Channel on the [Accord Project Dsicord Community][apdiscord].
 
 [apcontribute]: https://github.com/accordproject/techdocs/blob/master/CONTRIBUTING.md
-[apslack]: https://accord-project-slack-signup.herokuapp.com	
-[apconcertoslack]: https://accord-project.slack.com/archives/CAZRP6FDY
+[apdiscord]: https://discord.com/invite/Zm99SKhhtA	

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ The Accord Project technology is being developed as open source. All the softwar
 
 Find out what’s coming on our [blog][apblog].
 
-Join the Accord Project Technology Working Group [Slack channel][apslack] to get involved!
+Join the Accord Project Technology Working Group [Discord Community][apdiscord] to get involved!
 
 For code contributions, read our [CONTRIBUTING guide][contributing] and information for [DEVELOPERS][developers].
 
@@ -109,7 +109,7 @@ Copyright 2018-2019 Clause, Inc. All trademarks are the property of their respec
 [apmain]: https://accordproject.org/ 
 [apblog]: https://medium.com/@accordhq
 [apdoc]: https://docs.accordproject.org/
-[apslack]: https://accord-project-slack-signup.herokuapp.com
+[apdiscord]: https://discord.com/invite/Zm99SKhhtA
 
 [contributing]: https://github.com/accordproject/concerto/blob/master/CONTRIBUTING.md
 [developers]: https://github.com/accordproject/concerto/blob/master/DEVELOPERS.md


### PR DESCRIPTION
# Closes #369
Updated the Accord Project community link in the docs from the old & inactive Slack link to the new Discord server link