### PR TITLE
feature(util): Add label utility functions

### DIFF
--- a/packages/concerto-util/index.js
+++ b/packages/concerto-util/index.js
@@ -39,3 +39,6 @@ module.exports.Logger = require('./lib/logger');
 
 // TypedStack
 module.exports.TypedStack = require('./lib/typedstack');
+
+// Label
+module.exports.Label = require('./lib/label');

--- a/packages/concerto-util/lib/label.js
+++ b/packages/concerto-util/lib/label.js
@@ -1,0 +1,48 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+/**
+ * Inserts correct spacing and capitalization to a camelCase label
+ * @param {string} labelName - the label text to be transformed
+ * @returns {string} - The label text formatted for rendering
+ */
+function labelToSentence(labelName = '') {
+    return labelName
+        .replace(/([a-z])([A-Z])/g, '$1 $2')
+        .replace(/([A-Z])([a-z])/g, ' $1$2')
+        .replace(/ +/g, ' ')
+        .replace(/^./, str => str.toUpperCase())
+        .trim();
+}
+
+/**
+ * Create a camelCase label from a sentence
+ * @param {string} sentence - the sentence
+ * @returns {string} - The camelCase label
+ */
+function sentenceToLabel(sentence = '') {
+    const split = sentence.split(/[^A-Za-z0-9_-]+/);
+    split.forEach((word, index) => {
+        split[index] = split[index].replace(/^./, str => str.toUpperCase());
+    });
+    const joined = split.join('');
+    return joined.replace(/^./, str => str.toLowerCase());
+}
+
+module.exports = {
+    labelToSentence,
+    sentenceToLabel,
+};

--- a/packages/concerto-util/lib/modelwriter.js
+++ b/packages/concerto-util/lib/modelwriter.js
@@ -32,7 +32,6 @@ function writeModelsToFileSystem(files, path, options = {}) {
     const opts = Object.assign({
         includeExternalModels: true,
     }, options);
-    console.log(JSON.stringify(opts));
     files.forEach(function (file) {
         if (file.external && !opts.includeExternalModels) {
             return;

--- a/packages/concerto-util/test/label.js
+++ b/packages/concerto-util/test/label.js
@@ -1,0 +1,58 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const { labelToSentence, sentenceToLabel } = require('../lib/label');
+
+require('chai').should();
+
+describe('Label', function () {
+
+    describe('#labelToSentence', function() {
+        it('should create a sentence', function() {
+            labelToSentence('fullName').should.equal('Full Name');
+        });
+
+        it('should handle null', function() {
+            labelToSentence().should.equal('');
+        });
+
+    });
+
+    describe('#sentenceToLabel', function() {
+        it('should create a sentence', function() {
+            sentenceToLabel('Full Name').should.equal('fullName');
+        });
+
+        it('should handle null', function() {
+            sentenceToLabel().should.equal('');
+        });
+
+    });
+
+    describe('#roundtrip', function() {
+        it('should rountrip a label', function() {
+            const label = 'fullNameOrEmailAddress';
+            sentenceToLabel(label).should.equal(label);
+        });
+    });
+
+    describe('#notroundtrip', function() {
+        it('should not always rountrip a sentence', function() {
+            const sentence = 'It\'s really not that hard!';
+            sentenceToLabel(sentence).should.not.equal(sentence);
+        });
+    });
+});

--- a/packages/concerto-util/test/label.js
+++ b/packages/concerto-util/test/label.js
@@ -25,6 +25,10 @@ describe('Label', function () {
             labelToSentence('fullName').should.equal('Full Name');
         });
 
+        it('should create a sentence for a longer label', function() {
+            labelToSentence('fullNameOrEmailAddress').should.equal('Full Name Or Email Address');
+        });
+
         it('should handle null', function() {
             labelToSentence().should.equal('');
         });
@@ -32,8 +36,12 @@ describe('Label', function () {
     });
 
     describe('#sentenceToLabel', function() {
-        it('should create a sentence', function() {
+        it('should create a label', function() {
             sentenceToLabel('Full Name').should.equal('fullName');
+        });
+
+        it('should create a label for a longer sentence', function() {
+            sentenceToLabel('Full name or email address').should.equal('fullNameOrEmailAddress');
         });
 
         it('should handle null', function() {


### PR DESCRIPTION
Signed-off-by: Jerome Simeon <Jerome.Simeon@docusign.com>

# Closes #374 

### Changes

- New `Label` utilities to convert Concerto identifiers to sentences and back

### Flags

- Replaces and extends proposed PR in #378 