### PR TITLE
feat: support for externalizing decorators #393

### DIFF
--- a/packages/concerto-core/api.txt
+++ b/packages/concerto-core/api.txt
@@ -15,6 +15,12 @@ class Concerto {
    + string getNamespace(obj) 
 }
    + object setCurrentTime() 
+class DecoratorManager {
+   + void decorateModels(ModelManager,decoratorCommandSet) 
+   + Boolean isMatch(string|,string) 
+   + void applyDecorator(Decorated,string,Decorator) 
+   + void executeCommand(ClassDeclaration,command) 
+}
 class Factory {
    + string newId() 
    + void constructor(ModelManager) 

--- a/packages/concerto-core/changelog.txt
+++ b/packages/concerto-core/changelog.txt
@@ -24,13 +24,14 @@
 # Note that the latest public API is documented using JSDocs and is available in api.txt.
 #
 
-Version 1.2.2 {971ab49db13d87551db109316e5b59eb} 2021-11-24
+Version 1.2.2 {284a6d4fc38376999bed02a7c9bbecd1} 2021-11-24
 - Remove custom instanceof and add methods to check runtime type
 - Remove support for Node 12
 - Generate Typescript definitions from JSDoc
 - Parser directly constructs metamodel instance
 - Convert MetaModel to a class for Typescript + Webpack compatability
 - Update Acorn to latest and refactor the JavaScript parser so we can use static class members
+- Add DecoratorManager
 
 Version 1.2.2 {b19318bb094e5da7bdff192cf9a3b4f2} 2021-08-12
 - Fixes to metamodel, including terminology changes

--- a/packages/concerto-core/index.js
+++ b/packages/concerto-core/index.js
@@ -78,6 +78,8 @@ module.exports.ModelUtil = require('./lib/modelutil');
 // ModelLoader
 module.exports.ModelLoader = require('./lib/modelloader');
 
+// DecoratorManager
+module.exports.DecoratorManager = require('./lib/decoratormanager');
 
 // DateTimeUtil
 module.exports.DateTimeUtil = require('./lib/datetimeutil');

--- a/packages/concerto-core/lib/decoratormanager.js
+++ b/packages/concerto-core/lib/decoratormanager.js
@@ -1,0 +1,100 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const Decorator = require('./introspect/decorator');
+
+/**
+ * Utility functions to work with
+ * [DecoratorCommandSet](https://models.accordproject.org/concerto/decorators.cto)
+ * @memberof module:concerto-core
+ */
+class DecoratorManager {
+    /**
+     * Applies all the decorator commands from the DecoratorCommandSet
+     * to the ModelManager. Note that the ModelManager is modifed.
+     * @param {ModelManager} modelManager the model manager
+     * @param {*} decoratorCommandSet the DecoratorCommandSet object
+     */
+    static decorateModels(modelManager, decoratorCommandSet) {
+        let declarations = [];
+        modelManager.getModelFiles().forEach(mf => {
+            const decls = mf.getAllDeclarations();
+            declarations = declarations.concat(decls);
+        });
+        declarations.forEach(decl => {
+            decoratorCommandSet.commands.forEach(command => {
+                this.executeCommand(decl, command);
+            });
+        });
+    }
+
+    /**
+     * Compares two values
+     * @param {string | null} test the value to test (lhs)
+     * @param {string} value the value to compare (rhs)
+     * @returns {Boolean} true if the lhs is falsy or test === value
+     */
+    static isMatch(test, value) {
+        return test ? test === value : true;
+    }
+
+    /**
+     * Applies a decorator to a decorated model element.
+     * @param {Decorated} decorated the type to apply the decorator to
+     * @param {string} type the command type
+     * @param {Decorator} newDecorator the decorator to add
+     */
+    static applyDecorator(decorated, type, newDecorator) {
+        if (type === 'UPSERT') {
+            decorated.upsertDecorator(newDecorator.getName(), newDecorator);
+        }
+        else if (type === 'APPEND') {
+            decorated.addDecorator(newDecorator);
+        }
+        else {
+            throw new Error(`Unknown command type ${type}`);
+        }
+    }
+
+    /**
+     * Executes a Command against a ClassDeclaration, adding
+     * decorators to the ClassDeclaration, or its properties, as required.
+     * @param {ClassDeclaration} declaration the class declaration
+     * @param {*} command the Command object from the
+     * org.accordproject.decoratorcommands model
+     */
+    static executeCommand(declaration, command) {
+        const { target, decorator, type } = command;
+        if (this.isMatch(target.namespace, declaration.getNamespace()) &&
+            this.isMatch(target.declaration, declaration.getName())) {
+            if (!target.property && !target.type) {
+                const newDecorator = new Decorator(declaration, decorator);
+                this.applyDecorator(declaration, type, newDecorator);
+            }
+            else {
+                declaration.getProperties().forEach(property => {
+                    if (this.isMatch(target.property, property.getName()) &&
+                        this.isMatch(target.type, property.getType())) {
+                        const newDecorator = new Decorator(property, decorator);
+                        this.applyDecorator(property, type, newDecorator);
+                    }
+                });
+            }
+        }
+    }
+}
+
+module.exports = DecoratorManager;

--- a/packages/concerto-core/lib/introspect/decorated.js
+++ b/packages/concerto-core/lib/introspect/decorated.js
@@ -141,6 +141,34 @@ class Decorated {
 
         return null;
     }
+
+    /**
+     * Upserts (updates if existing, if not inserts) a decorator.
+     * @param {string} name the name of the decorator
+     * @param {Decorator} newDecorator the new decorator
+     */
+    upsertDecorator(name, newDecorator) {
+        let updated = false;
+        for(let n=0; n < this.decorators.length; n++) {
+            let decorator = this.decorators[n];
+            if(decorator.getName() === name) {
+                this.decorators[n] = newDecorator;
+                updated = true;
+            }
+        }
+
+        if(!updated) {
+            this.decorators.push(newDecorator);
+        }
+    }
+
+    /**
+     * Adds a decorator.
+     * @param {Decorator} newDecorator the new decorator
+     */
+    addDecorator(newDecorator) {
+        this.decorators.push(newDecorator);
+    }
 }
 
 module.exports = Decorated;

--- a/packages/concerto-core/test/data/decoratorcommands/decorators.cto
+++ b/packages/concerto-core/test/data/decoratorcommands/decorators.cto
@@ -1,0 +1,54 @@
+
+/**
+ * DecoratorCommandSet defines a set of instructions to add or update decorators
+ * on model elements.
+ */
+namespace org.accordproject.decoratorcommands
+
+import concerto.metamodel.Decorator from https://models.accordproject.org/concerto/metamodel@0.3.0.cto
+
+/**
+ * A reference to an existing named & versioned DecoratorCommandSet
+ */
+concept DecoratorCommandSetReference {
+    o String name
+    o String version
+}
+
+/**
+ * Whether to upsert or append the decorator
+ */
+enum CommandType {
+    o UPSERT
+    o APPEND
+}
+
+/**
+ * Which models elements to add the decorator to. Any null
+ * elements are 'wildcards'. 
+ */
+concept CommandTarget {
+    o String namespace optional
+    o String declaration optional
+    o String property optional
+    o String type optional 
+}
+
+/**
+ * Applies a decorator to a given target
+ */
+concept Command {
+    o CommandTarget target
+    o Decorator decorator
+    o CommandType type
+}
+
+/**
+ * A named and versioned set of commands. Includes are supported for modularity/reuse.
+ */
+concept DecoratorCommandSet {
+    o String name
+    o String version
+    o DecoratorCommandSetReference[] includes optional
+    o Command[] commands
+}

--- a/packages/concerto-core/test/data/decoratorcommands/test.cto
+++ b/packages/concerto-core/test/data/decoratorcommands/test.cto
@@ -1,0 +1,9 @@
+namespace test
+
+@Editable
+concept Person {
+    @Custom
+    o String firstName
+    o String lastName
+    o String bio
+}

--- a/packages/concerto-core/test/data/decoratorcommands/web.json
+++ b/packages/concerto-core/test/data/decoratorcommands/web.json
@@ -1,0 +1,53 @@
+{
+    "$class" : "org.accordproject.decoratorcommands.DecoratorCommandSet",
+    "name" : "web",
+    "version": "1.0.0",
+    "commands" : [
+        {
+            "$class" : "org.accordproject.decoratorcommands.Command",
+            "type" : "UPSERT",
+            "target" : {
+                "$class" : "org.accordproject.decoratorcommands.CommandTarget",
+                "type" : "String"
+            },
+            "decorator" : {
+                "$class" : "concerto.metamodel.Decorator",
+                "name" : "Form",
+                "arguments" : [
+                    {
+                        "$class" : "concerto.metamodel.DecoratorString",
+                        "value" : "inputType"
+                    },
+                    {
+                        "$class" : "concerto.metamodel.DecoratorString",
+                        "value" : "text"
+                    }
+                ]
+            }
+        },
+        {
+            "$class" : "org.accordproject.decoratorcommands.Command",
+            "type" : "UPSERT",
+            "target" : {
+                "$class" : "org.accordproject.decoratorcommands.CommandTarget",
+                "namespace" : "test",
+                "declaration" : "Person",
+                "property" : "bio"
+            },
+            "decorator" : {
+                "$class" : "concerto.metamodel.Decorator",
+                "name" : "Form",
+                "arguments" : [
+                    {
+                        "$class" : "concerto.metamodel.DecoratorString",
+                        "value" : "inputType"
+                    },
+                    {
+                        "$class" : "concerto.metamodel.DecoratorString",
+                        "value" : "textArea"
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/packages/concerto-core/test/decoratormanager.js
+++ b/packages/concerto-core/test/decoratormanager.js
@@ -1,0 +1,92 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const DecoratorManager = require('../lib/decoratormanager');
+const ModelManager = require('../lib/modelmanager');
+
+const chai = require('chai');
+require('chai').should();
+chai.use(require('chai-things'));
+chai.use(require('chai-as-promised'));
+
+describe('DecoratorManager', () => {
+
+    beforeEach(() => {
+    });
+
+    afterEach(() => {
+    });
+
+    describe('#isMatch', function() {
+        it('should match null', async function() {
+            DecoratorManager.isMatch( null, 'one').should.be.true;
+        });
+
+        it('should match undefined', async function() {
+            DecoratorManager.isMatch( undefined, 'one').should.be.true;
+        });
+
+        it('should match token', async function() {
+            DecoratorManager.isMatch( 'one', 'one').should.be.true;
+        });
+
+        it('should not match token', async function() {
+            DecoratorManager.isMatch( 'one', 'two').should.be.false;
+        });
+    });
+
+    describe('#decorateModels', function() {
+        it('should add decorator', async function() {
+            const decoratorModelManager = new ModelManager();
+            // validate the decorator model
+            const decoratorModelText = fs.readFileSync('./test/data/decoratorcommands/decorators.cto', 'utf-8');
+            decoratorModelManager.addModelFile(decoratorModelText, 'decorators.cto', true);
+            decoratorModelManager.updateExternalModels();
+
+            // load a model to decorate
+            const testModelManager = new ModelManager();
+            const modelText = fs.readFileSync('./test/data/decoratorcommands/test.cto', 'utf-8');
+            testModelManager.addModelFile(modelText, 'test.cto');
+
+            const dcs = fs.readFileSync('./test/data/decoratorcommands/web.json', 'utf-8');
+            DecoratorManager.decorateModels( testModelManager, JSON.parse(dcs));
+            const decl = testModelManager.getType('test.Person');
+            decl.should.not.be.null;
+
+            decl.getDecorator('Editable').should.not.be.null;
+
+            const firstNameProperty = decl.getProperty('firstName');
+            firstNameProperty.should.not.be.null;
+
+            const decoratorFormFirstName = firstNameProperty.getDecorator('Form');
+            decoratorFormFirstName.should.not.be.null;
+            decoratorFormFirstName.getArguments()[0].should.equal('inputType');
+            decoratorFormFirstName.getArguments()[1].should.equal('text');
+
+            const decoratorCustomFirstName = firstNameProperty.getDecorator('Custom');
+            decoratorCustomFirstName.should.not.be.null;
+
+            const bioProperty = decl.getProperty('bio');
+            bioProperty.should.not.be.null;
+            const decoratorBio = bioProperty.getDecorator('Form');
+            decoratorBio.should.not.be.null;
+            decoratorBio.getArguments()[0].should.equal('inputType');
+            decoratorBio.getArguments()[1].should.equal('textArea');
+        });
+    });
+
+});


### PR DESCRIPTION
Signed-off-by: Dan Selman <danscode@selman.org>

# Closes #393 

Adds a `DecoratorManager` class which can be used to load a JSON file containing a specification of decorators to be applied to model elements, and then to apply them to a `ModelManager`.

### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
- <ONE>
- <TWO>

### Flags
<!--- Provide context or concerns a reviewer should be aware of -->
- <ONE>
- <TWO>

### Screenshots or Video
<!--- Provide an easily accessible demonstration of the changes, if applicable -->

### Related Issues
- Issue #<NUMBER>
- Pull Request #<NUMBER>

### Author Checklist
- [ ] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [ ] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ ] Merging to `master` from `fork:branchname`
