### PR TITLE
fix(core): Regression in update external models not returning model files

### DIFF
--- a/packages/concerto-core/changelog.txt
+++ b/packages/concerto-core/changelog.txt
@@ -24,7 +24,7 @@
 # Note that the latest public API is documented using JSDocs and is available in api.txt.
 #
 
-Version 1.2.2 {ee5fa0479fe2720d720ac500b1b3ead8} 2021-11-24
+Version 2.0.0-alpha.1 {ee5fa0479fe2720d720ac500b1b3ead8} 2021-11-24
 - Remove custom instanceof and add methods to check runtime type
 - Remove support for Node 12
 - Generate Typescript definitions from JSDoc

--- a/packages/concerto-core/lib/basemodelmanager.js
+++ b/packages/concerto-core/lib/basemodelmanager.js
@@ -315,19 +315,20 @@ class BaseModelManager {
             fileDownloader = new FileDownloader(new DefaultFileLoader(this.processFile), (file) => MetaModelUtil.getExternalImports(file.ast));
         }
 
-        const externalModelFiles = await fileDownloader.downloadExternalDependencies(this.getModelFiles(), options);
+        const externalModels = await fileDownloader.downloadExternalDependencies(this.getModelFiles(), options);
         const originalModelFiles = {};
         Object.assign(originalModelFiles, this.modelFiles);
 
         try {
-            externalModelFiles.forEach((file) => {
+            const externalModelFiles = [];
+            externalModels.forEach((file) => {
                 const mf = new ModelFile(this, file.ast, file.definitions, file.fileName);
                 const existing = this.modelFiles[mf.getNamespace()];
 
                 if (existing) {
-                    this.updateModelFile(mf, mf.getName(), true); // disable validation
+                    externalModelFiles.push(this.updateModelFile(mf, mf.getName(), true)); // disable validation
                 } else {
-                    this.addModelFile(mf, null, mf.getName(), true); // disable validation
+                    externalModelFiles.push(this.addModelFile(mf, null, mf.getName(), true)); // disable validation
                 }
             });
 

--- a/packages/concerto-core/test/data/model/versionValid.cto
+++ b/packages/concerto-core/test/data/model/versionValid.cto
@@ -12,7 +12,7 @@
  * limitations under the License.
  */
 
-concerto version "^1.0.0"
+concerto version ">= 1.0.0"
 
 // define the namespace for this model
 namespace org.acme

--- a/packages/concerto-core/test/introspect/concertoVersion.js
+++ b/packages/concerto-core/test/introspect/concertoVersion.js
@@ -51,7 +51,7 @@ describe('ModelFile', () => {
 
         it('should return when concerto version is compatible with model', () => {
             let mf = ParserUtil.newModelFile(modelManager, versionValid);
-            mf.getConcertoVersion().should.equal('^1.0.0');
+            mf.getConcertoVersion().should.equal('>= 1.0.0');
         });
 
         it('should return when concerto version is compatible with model with a pre-release version', () => {
@@ -59,7 +59,7 @@ describe('ModelFile', () => {
             const newVersion = `${version}-unittest.${new Date().getTime()}`;
             sinon.replace(pkgJSON, 'version', newVersion);
             let mf = ParserUtil.newModelFile(modelManager, versionValid);
-            mf.getConcertoVersion().should.equal('^1.0.0');
+            mf.getConcertoVersion().should.equal('>= 1.0.0');
         });
 
         it('should return when model has no concerto version range', () => {


### PR DESCRIPTION
Signed-off-by: Jerome Simeon <jeromesimeon@me.com>

### Changes

- This fixes a regression in Concerto `2.0.0-alpha.1` where `ModelManager.updateExternalModels` no longer returned the set of external models as model files.
- Also fixes tests for concerto versions so they pass for the new release

