### PR TITLE
fix(types): visitor visit methods should be public

### DIFF
--- a/packages/concerto-tools/lib/codegen/fromcto/csharp/csharpvisitor.js
+++ b/packages/concerto-tools/lib/codegen/fromcto/csharp/csharpvisitor.js
@@ -32,7 +32,6 @@ class CSharpVisitor {
      * @param {Object} thing - the object being visited
      * @param {Object} parameters  - the parameter
      * @return {Object} the result of visiting or null
-     * @private
      */
     visit(thing, parameters) {
         if (thing.isModelManager?.()) {

--- a/packages/concerto-tools/lib/codegen/fromcto/golang/golangvisitor.js
+++ b/packages/concerto-tools/lib/codegen/fromcto/golang/golangvisitor.js
@@ -32,7 +32,7 @@ class GoLangVisitor {
      * @param {Object} thing - the object being visited
      * @param {Object} parameters  - the parameter
      * @return {Object} the result of visiting or null
-     * @private
+     * @public
      */
     visit(thing, parameters) {
         if (thing.isModelManager?.()) {

--- a/packages/concerto-tools/lib/codegen/fromcto/graphql/graphqlvisitor.js
+++ b/packages/concerto-tools/lib/codegen/fromcto/graphql/graphqlvisitor.js
@@ -40,7 +40,7 @@ class GraphQLVisitor {
     * @param {Object} thing - the object being visited
     * @param {Object} parameters  - the parameter
     * @return {Object} the result of visiting or null
-    * @private
+    * @public
     */
     visit(thing, parameters) {
         if (thing.isModelManager?.()) {

--- a/packages/concerto-tools/lib/codegen/fromcto/java/javavisitor.js
+++ b/packages/concerto-tools/lib/codegen/fromcto/java/javavisitor.js
@@ -40,7 +40,7 @@ class JavaVisitor {
      * @param {Object} thing - the object being visited
      * @param {Object} parameters  - the parameter
      * @return {Object} the result of visiting or null
-     * @private
+     * @public
      */
     visit(thing, parameters) {
         if (thing.isModelManager?.()) {
@@ -83,14 +83,14 @@ public abstract class Resource
 {
     public abstract String getID();
     private String $id;
-    
+
     @JsonProperty("$id")
     public String get$id() {
-        return $id; 
+        return $id;
     }
     @JsonProperty("$id")
     public void set$id(String i) {
-        $id = i; 
+        $id = i;
     }
 
 }

--- a/packages/concerto-tools/lib/codegen/fromcto/jsonschema/jsonschemavisitor.js
+++ b/packages/concerto-tools/lib/codegen/fromcto/jsonschema/jsonschemavisitor.js
@@ -75,7 +75,7 @@ class JSONSchemaVisitor {
      * @param {Object} thing - the object being visited
      * @param {Object} parameters - the parameter
      * @return {Object} the result of visiting or null
-     * @private
+     * @public
      */
     visit(thing, parameters) {
         if (thing.isModelManager?.()) {

--- a/packages/concerto-tools/lib/codegen/fromcto/loopback/loopbackvisitor.js
+++ b/packages/concerto-tools/lib/codegen/fromcto/loopback/loopbackvisitor.js
@@ -52,7 +52,7 @@ class LoopbackVisitor {
      * @param {Object} thing - the object being visited
      * @param {Object} parameters - the parameter
      * @return {Object} the result of visiting or null
-     * @private
+     * @public
      */
     visit(thing, parameters) {
         if (thing.isModelManager?.()) {

--- a/packages/concerto-tools/lib/codegen/fromcto/plantuml/plantumlvisitor.js
+++ b/packages/concerto-tools/lib/codegen/fromcto/plantuml/plantumlvisitor.js
@@ -30,7 +30,7 @@ class PlantUMLVisitor {
      * @param {Object} thing - the object being visited
      * @param {Object} parameters  - the parameter
      * @return {Object} the result of visiting or null
-     * @private
+     * @public
      */
     visit(thing, parameters) {
         if (thing.isModelManager?.()) {

--- a/packages/concerto-tools/lib/codegen/fromcto/typescript/typescriptvisitor.js
+++ b/packages/concerto-tools/lib/codegen/fromcto/typescript/typescriptvisitor.js
@@ -33,7 +33,7 @@ class TypescriptVisitor {
      * @param {Object} thing - the object being visited
      * @param {Object} parameters  - the parameter
      * @return {Object} the result of visiting or null
-     * @private
+     * @public
      */
     visit(thing, parameters) {
         if (thing.isModelManager?.()) {

--- a/packages/concerto-tools/lib/codegen/fromcto/xmlschema/xmlschemavisitor.js
+++ b/packages/concerto-tools/lib/codegen/fromcto/xmlschema/xmlschemavisitor.js
@@ -32,7 +32,7 @@ class XmlSchemaVisitor {
      * @param {Object} thing - the object being visited
      * @param {Object} parameters  - the parameter
      * @return {Object} the result of visiting or null
-     * @private
+     * @public
      */
     visit(thing, parameters) {
         if (thing.isModelManager?.()) {

--- a/packages/concerto-tools/types/lib/codegen/fromcto/csharp/csharpvisitor.d.ts
+++ b/packages/concerto-tools/types/lib/codegen/fromcto/csharp/csharpvisitor.d.ts
@@ -14,9 +14,8 @@ declare class CSharpVisitor {
      * @param {Object} thing - the object being visited
      * @param {Object} parameters  - the parameter
      * @return {Object} the result of visiting or null
-     * @private
      */
-    private visit;
+    visit(thing: any, parameters: any): any;
     /**
      * Visitor design pattern
      * @param {ModelManager} modelManager - the object being visited

--- a/packages/concerto-tools/types/lib/codegen/fromcto/golang/golangvisitor.d.ts
+++ b/packages/concerto-tools/types/lib/codegen/fromcto/golang/golangvisitor.d.ts
@@ -15,9 +15,9 @@ declare class GoLangVisitor {
      * @param {Object} thing - the object being visited
      * @param {Object} parameters  - the parameter
      * @return {Object} the result of visiting or null
-     * @private
+     * @public
      */
-    private visit;
+    public visit(thing: any, parameters: any): any;
     /**
      * Visitor design pattern
      * @param {ModelManager} modelManager - the object being visited

--- a/packages/concerto-tools/types/lib/codegen/fromcto/graphql/graphqlvisitor.d.ts
+++ b/packages/concerto-tools/types/lib/codegen/fromcto/graphql/graphqlvisitor.d.ts
@@ -21,9 +21,9 @@ declare class GraphQLVisitor {
     * @param {Object} thing - the object being visited
     * @param {Object} parameters  - the parameter
     * @return {Object} the result of visiting or null
-    * @private
+    * @public
     */
-    private visit;
+    public visit(thing: any, parameters: any): any;
     /**
     * Visitor design pattern
     * @param {ModelManager} modelManager - the object being visited

--- a/packages/concerto-tools/types/lib/codegen/fromcto/java/javavisitor.d.ts
+++ b/packages/concerto-tools/types/lib/codegen/fromcto/java/javavisitor.d.ts
@@ -15,9 +15,9 @@ declare class JavaVisitor {
      * @param {Object} thing - the object being visited
      * @param {Object} parameters  - the parameter
      * @return {Object} the result of visiting or null
-     * @private
+     * @public
      */
-    private visit;
+    public visit(thing: any, parameters: any): any;
     /**
      * Visitor design pattern
      * @param {ModelManager} modelManager - the object being visited

--- a/packages/concerto-tools/types/lib/codegen/fromcto/jsonschema/jsonschemavisitor.d.ts
+++ b/packages/concerto-tools/types/lib/codegen/fromcto/jsonschema/jsonschemavisitor.d.ts
@@ -42,9 +42,9 @@ declare class JSONSchemaVisitor {
      * @param {Object} thing - the object being visited
      * @param {Object} parameters - the parameter
      * @return {Object} the result of visiting or null
-     * @private
+     * @public
      */
-    private visit;
+    public visit(thing: any, parameters: any): any;
     /**
      * Visitor design pattern
      * @param {ModelManager} modelManager - the object being visited

--- a/packages/concerto-tools/types/lib/codegen/fromcto/plantuml/plantumlvisitor.d.ts
+++ b/packages/concerto-tools/types/lib/codegen/fromcto/plantuml/plantumlvisitor.d.ts
@@ -15,9 +15,9 @@ declare class PlantUMLVisitor {
      * @param {Object} thing - the object being visited
      * @param {Object} parameters  - the parameter
      * @return {Object} the result of visiting or null
-     * @private
+     * @public
      */
-    private visit;
+    public visit(thing: any, parameters: any): any;
     /**
      * Visitor design pattern
      * @param {ModelManager} modelManager - the object being visited

--- a/packages/concerto-tools/types/lib/codegen/fromcto/typescript/typescriptvisitor.d.ts
+++ b/packages/concerto-tools/types/lib/codegen/fromcto/typescript/typescriptvisitor.d.ts
@@ -15,9 +15,9 @@ declare class TypescriptVisitor {
      * @param {Object} thing - the object being visited
      * @param {Object} parameters  - the parameter
      * @return {Object} the result of visiting or null
-     * @private
+     * @public
      */
-    private visit;
+    public visit(thing: any, parameters: any): any;
     /**
      * Visitor design pattern
      * @param {ModelManager} modelManager - the object being visited

--- a/packages/concerto-tools/types/lib/codegen/fromcto/xmlschema/xmlschemavisitor.d.ts
+++ b/packages/concerto-tools/types/lib/codegen/fromcto/xmlschema/xmlschemavisitor.d.ts
@@ -15,9 +15,9 @@ declare class XmlSchemaVisitor {
      * @param {Object} thing - the object being visited
      * @param {Object} parameters  - the parameter
      * @return {Object} the result of visiting or null
-     * @private
+     * @public
      */
-    private visit;
+    public visit(thing: any, parameters: any): any;
     /**
      * Visitor design pattern
      * @param {ModelManager} modelManager - the object being visited


### PR DESCRIPTION
The visitor `visit` methods should be public, as these can be called from outside of the class.