### PR TITLE
fix(types): correct model manager type for concerto method

### DIFF
--- a/packages/concerto-core/api.txt
+++ b/packages/concerto-core/api.txt
@@ -35,9 +35,9 @@ class BaseModelManager {
    + void getAst(boolean?) 
 }
 class Concerto {
-   + void constructor(modelManager) 
+   + void constructor(ModelManager) 
    + void validate(obj,options?) throws Error
-   + void getModelManager() 
+   + ModelManager getModelManager() 
    + boolean isObject(obj) 
    + void getTypeDeclaration(obj) 
    + string getIdentifier(obj) 

--- a/packages/concerto-core/changelog.txt
+++ b/packages/concerto-core/changelog.txt
@@ -24,6 +24,9 @@
 # Note that the latest public API is documented using JSDocs and is available in api.txt.
 #
 
+Version 2.0.1 {62a8de0d35789bbe523269e4e29cd8e6} 2022-04-25
+- Correct type for Concerto.getModelManager()
+
 Version 2.0.0-alpha.1 {292b93fc879d3b0c3969711b24312ffd} 2022-03-30
 - Remove custom instanceof and add methods to check runtime type
 - Remove support for Node 12

--- a/packages/concerto-core/lib/concerto.js
+++ b/packages/concerto-core/lib/concerto.js
@@ -16,8 +16,16 @@
 
 const URIJS = require('urijs');
 const RESOURCE_SCHEME = 'resource';
-const TypedStack = require('@accordproject/concerto-util').TypedStack;
+const { TypedStack } = require('@accordproject/concerto-util');
 const ObjectValidator = require('./serializer/objectvalidator');
+
+// Types needed for TypeScript generation.
+/* eslint-disable no-unused-vars */
+/* istanbul ignore next */
+if (global === undefined) {
+    const ModelManager = require('./modelmanager');
+}
+/* eslint-enable no-unused-vars */
 
 /**
  * Runtime API for Concerto.
@@ -28,7 +36,7 @@ const ObjectValidator = require('./serializer/objectvalidator');
 class Concerto {
     /**
      * Create a Concerto instance.
-     * @param {*} modelManager - The this.modelManager to use for validation etc.
+     * @param {ModelManager} modelManager - The this.modelManager to use for validation etc.
      */
     constructor(modelManager) {
         this.modelManager = modelManager;
@@ -50,7 +58,7 @@ class Concerto {
 
     /**
      * Returns the model manager
-     * @returns {*} the model manager associated with this Concerto class
+     * @returns {ModelManager} the model manager associated with this Concerto class
      */
     getModelManager() {
         return this.modelManager;

--- a/packages/concerto-core/types/lib/concerto.d.ts
+++ b/packages/concerto-core/types/lib/concerto.d.ts
@@ -8,10 +8,10 @@ export = Concerto;
 declare class Concerto {
     /**
      * Create a Concerto instance.
-     * @param {*} modelManager - The this.modelManager to use for validation etc.
+     * @param {ModelManager} modelManager - The this.modelManager to use for validation etc.
      */
-    constructor(modelManager: any);
-    modelManager: any;
+    constructor(modelManager: ModelManager);
+    modelManager: ModelManager;
     /**
      * Validates the instance against its model.
      * @param {*} obj the input object
@@ -21,9 +21,9 @@ declare class Concerto {
     validate(obj: any, options?: any): void;
     /**
      * Returns the model manager
-     * @returns {*} the model manager associated with this Concerto class
+     * @returns {ModelManager} the model manager associated with this Concerto class
      */
-    getModelManager(): any;
+    getModelManager(): ModelManager;
     /**
      * Returns true if the input object is a Concerto object
      * @param {*} obj the input object
@@ -99,3 +99,4 @@ declare class Concerto {
      */
     getNamespace(obj: any): string;
 }
+import ModelManager = require("./modelmanager");


### PR DESCRIPTION
The Concerto class currently uses`{*}` as the type for `getModelManager`, which results in `any` being generated for the TypeScript types. This change corrects the code to reference the `ModelManager` class instead. 

Signed-off-by: Simon Stone <Simon.Stone@docusign.com>