### PR TITLE
fix(tools): add imports for direct classes for TypeScript union

### DIFF
--- a/packages/concerto-cli/lib/commands.js
+++ b/packages/concerto-cli/lib/commands.js
@@ -145,32 +145,32 @@ class Commands {
 
         let visitor = null;
 
-        switch(target) {
-        case 'Go':
+        switch(target.toLowerCase()) {
+        case 'go':
             visitor = new GoLangVisitor();
             break;
-        case 'PlantUML':
+        case 'plantuml':
             visitor = new PlantUMLVisitor();
             break;
-        case 'Typescript':
+        case 'typescript':
             visitor = new TypescriptVisitor();
             break;
-        case 'Java':
+        case 'java':
             visitor = new JavaVisitor();
             break;
-        case 'JSONSchema':
+        case 'jsonschema':
             visitor = new JSONSchemaVisitor();
             break;
-        case 'XMLSchema':
+        case 'xmlschema':
             visitor = new XmlSchemaVisitor();
             break;
-        case 'GraphQL':
+        case 'graphq':
             visitor = new GraphQLVisitor();
             break;
-        case 'CSharp':
+        case 'csharp':
             visitor = new CSharpVisitor();
             break;
-        case 'OData':
+        case 'odata':
             visitor = new ODataVisitor();
             break;
         }

--- a/packages/concerto-tools/test/codegen/fromcto/typescript/typescriptvisitor.js
+++ b/packages/concerto-tools/test/codegen/fromcto/typescript/typescriptvisitor.js
@@ -303,6 +303,62 @@ describe('TypescriptVisitor', function () {
 
             acceptSpy.withArgs(typescriptVisitor, param).calledTwice.should.be.ok;
         });
+
+        it('should write lines for the imports of direct subclasses that are not in the same namespace', () => {
+            let acceptSpy = sinon.spy();
+
+            let mockSubclassDeclaration1 = sinon.createStubInstance(ClassDeclaration);
+            mockSubclassDeclaration1.isClassDeclaration.returns(true);
+            mockSubclassDeclaration1.getProperties.returns([]);
+            mockSubclassDeclaration1.getNamespace.returns('org.acme.subclasses');
+            mockSubclassDeclaration1.getName.returns('ImportedDirectSubclass');
+
+            let mockSubclassDeclaration2 = sinon.createStubInstance(ClassDeclaration);
+            mockSubclassDeclaration2.isClassDeclaration.returns(true);
+            mockSubclassDeclaration2.getProperties.returns([]);
+            mockSubclassDeclaration2.getNamespace.returns('org.acme.subclasses');
+            mockSubclassDeclaration2.getName.returns('ImportedDirectSubclass2');
+
+            let mockSubclassDeclaration3 = sinon.createStubInstance(ClassDeclaration);
+            mockSubclassDeclaration3.isClassDeclaration.returns(true);
+            mockSubclassDeclaration3.getProperties.returns([]);
+            mockSubclassDeclaration3.getNamespace.returns('org.acme');
+            mockSubclassDeclaration3.getName.returns('LocalDirectSubclass');
+
+            let mockClassDeclaration = sinon.createStubInstance(ClassDeclaration);
+            mockClassDeclaration.isClassDeclaration.returns(true);
+            mockClassDeclaration.getProperties.returns([]);
+            mockClassDeclaration.getDirectSubclasses.returns([
+                mockSubclassDeclaration1, mockSubclassDeclaration2, mockSubclassDeclaration3
+            ]);
+            mockClassDeclaration.accept = acceptSpy;
+
+            let mockModelManager = sinon.createStubInstance(ModelManager);
+            mockModelManager.isModelManager.returns(true);
+
+            let mockModelFile = sinon.createStubInstance(ModelFile);
+            mockModelFile.isModelFile.returns(true);
+            mockModelFile.getNamespace.returns('org.acme');
+            mockModelFile.getAllDeclarations.returns([
+                mockClassDeclaration,
+                mockSubclassDeclaration2
+            ]);
+            mockModelFile.getImports.returns([]);
+            mockModelFile.getModelManager.returns(mockModelManager);
+
+            typescriptVisitor.visitModelFile(mockModelFile, param);
+
+            param.fileWriter.openFile.withArgs('org.acme.ts').calledOnce.should.be.ok;
+            param.fileWriter.writeLine.callCount.should.deep.equal(5);
+            param.fileWriter.writeLine.getCall(0).args.should.deep.equal([0, '/* eslint-disable @typescript-eslint/no-empty-interface */']);
+            param.fileWriter.writeLine.getCall(1).args.should.deep.equal([0, '// Generated code for namespace: org.acme']);
+            param.fileWriter.writeLine.getCall(2).args.should.deep.equal([0, '\n// imports']);
+            param.fileWriter.writeLine.getCall(3).args.should.deep.equal([0, 'import {\n\tIImportedDirectSubclass,\n\tIImportedDirectSubclass2\n} from \'./org.acme.subclasses\';']);
+            param.fileWriter.writeLine.getCall(4).args.should.deep.equal([0, '\n// interfaces']);
+            param.fileWriter.closeFile.calledOnce.should.be.ok;
+
+            acceptSpy.withArgs(typescriptVisitor, param).calledOnce.should.be.ok;
+        });
     });
 
     describe('visitEnumDeclaration', () => {


### PR DESCRIPTION
### Changes
- This PR fixes a bug introduces in #429 where the code generation for TypeScript creates a Union type for direct subclasses did not import interfaces from other files.
- This PR also loosens the validation on targets in `concerto-cli`. Previously, we would only accept `Typescript` (and not `TypeScript`). We now allow any capitalisation of the target by first converting the parameter to lower case.

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [x] Merging to `master` from `fork:branchname`
