### PR TITLE
feat(tools): typescript codegen, protect against circular dependencies

### DIFF
--- a/packages/concerto-tools/lib/codegen/fromcto/typescript/typescriptvisitor.js
+++ b/packages/concerto-tools/lib/codegen/fromcto/typescript/typescriptvisitor.js
@@ -114,6 +114,8 @@ class TypescriptVisitor {
 
                 const subclasses = classDeclaration.getDirectSubclasses();
                 if (subclasses && subclasses.length > 0) {
+                    parameters.fileWriter.writeLine(0, '\n// Warning: Beware of circular dependencies when modifying these imports');
+
                     // Group subclasses by namespace
                     const namespaceBuckets = {};
                     subclasses.map(subclass => {
@@ -127,7 +129,7 @@ class TypescriptVisitor {
                     Object.entries(namespaceBuckets)
                         .filter(([namespace]) => namespace !== modelFile.getNamespace()) // Skip own namespace
                         .map(([namespace, bucket]) => {
-                            parameters.fileWriter.writeLine(0, `import {\n\t${bucket.map(subclass => `I${subclass.getName()}`).join(',\n\t') }\n} from './${namespace}';`);
+                            parameters.fileWriter.writeLine(0, `import type {\n\t${bucket.map(subclass => `I${subclass.getName()}`).join(',\n\t') }\n} from './${namespace}';`);
                         });
                 }
 

--- a/packages/concerto-tools/test/codegen/fromcto/typescript/typescriptvisitor.js
+++ b/packages/concerto-tools/test/codegen/fromcto/typescript/typescriptvisitor.js
@@ -349,12 +349,13 @@ describe('TypescriptVisitor', function () {
             typescriptVisitor.visitModelFile(mockModelFile, param);
 
             param.fileWriter.openFile.withArgs('org.acme.ts').calledOnce.should.be.ok;
-            param.fileWriter.writeLine.callCount.should.deep.equal(5);
+            param.fileWriter.writeLine.callCount.should.deep.equal(6);
             param.fileWriter.writeLine.getCall(0).args.should.deep.equal([0, '/* eslint-disable @typescript-eslint/no-empty-interface */']);
             param.fileWriter.writeLine.getCall(1).args.should.deep.equal([0, '// Generated code for namespace: org.acme']);
             param.fileWriter.writeLine.getCall(2).args.should.deep.equal([0, '\n// imports']);
-            param.fileWriter.writeLine.getCall(3).args.should.deep.equal([0, 'import {\n\tIImportedDirectSubclass,\n\tIImportedDirectSubclass2\n} from \'./org.acme.subclasses\';']);
-            param.fileWriter.writeLine.getCall(4).args.should.deep.equal([0, '\n// interfaces']);
+            param.fileWriter.writeLine.getCall(3).args.should.deep.equal([0, '\n// Warning: Beware of circular dependencies when modifying these imports']);
+            param.fileWriter.writeLine.getCall(4).args.should.deep.equal([0, 'import type {\n\tIImportedDirectSubclass,\n\tIImportedDirectSubclass2\n} from \'./org.acme.subclasses\';']);
+            param.fileWriter.writeLine.getCall(5).args.should.deep.equal([0, '\n// interfaces']);
             param.fileWriter.closeFile.calledOnce.should.be.ok;
 
             acceptSpy.withArgs(typescriptVisitor, param).calledOnce.should.be.ok;


### PR DESCRIPTION
### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
- Uses the `import type` syntax to ensure that circular imports are erased during build of TypeScript files that are generated by `concerto-tools` code generation. https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [x] Merging to `master` from `fork:branchname`
