### PR TITLE
fix(*): correct versions and workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
-    
+
       - run: npm ci
       - run: npm run build --if-present
       - run: npm test
@@ -80,9 +80,9 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: 14.x
-    
-      - name: Build
-        run: npx lerna bootstrap
+
+      - run: npm ci
+      - run: npm run build --if-present
 
       - name: timestamp
         id: timestamp

--- a/packages/concerto-types/package.json
+++ b/packages/concerto-types/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@accordproject/concerto-types",
-    "version": "2.2.0",
+    "version": "2.2.1",
     "description": "Types for the Concerto Modeling Language",
     "homepage": "https://github.com/accordproject/concerto",
     "engines": {
@@ -32,10 +32,10 @@
     "author": "accordproject.org",
     "license": "Apache-2.0",
     "devDependencies": {
-        "@accordproject/concerto-core": "2.2.0",
-        "@accordproject/concerto-metamodel": "2.2.0",
-        "@accordproject/concerto-tools": "2.2.0",
-        "@accordproject/concerto-util": "2.2.0",
+        "@accordproject/concerto-core": "2.2.1",
+        "@accordproject/concerto-metamodel": "2.2.1",
+        "@accordproject/concerto-tools": "2.2.1",
+        "@accordproject/concerto-util": "2.2.1",
         "eslint": "8.2.0",
         "license-check-and-add": "2.3.6",
         "npm-run-all": "4.1.5",


### PR DESCRIPTION
The package publishing workflow only does a `npm ci` at the moment, and not a `npm run build` like the other workflows - this change uses the same combination of steps everywhere.

Also, the package versions in the new `concerto-types` package are wrong - this change updates them to 2.2.1.