### PR TITLE
fix(*): correct metamodel function return types

### DIFF
--- a/packages/concerto-core/changelog.txt
+++ b/packages/concerto-core/changelog.txt
@@ -24,6 +24,9 @@
 # Note that the latest public API is documented using JSDocs and is available in api.txt.
 #
 
+Version 2.3.0 {f60f35d3c6896c932d64837da74f6e6c} 2022-06-06
+- Fix TypeScript types for MetaModel
+
 Version 2.2.0 {3d3fc2a6b3cd623b807ca0c4fc53680d} 2022-06-01
 - Fix TypeScript types for ModelLoader
 

--- a/packages/concerto-core/lib/introspect/metamodel.js
+++ b/packages/concerto-core/lib/introspect/metamodel.js
@@ -23,7 +23,7 @@ const ModelFile = require('../introspect/modelfile');
 
 /**
  * Create a metamodel manager (for validation against the metamodel)
- * @return {*} the metamodel manager
+ * @return {ModelManager} the metamodel manager
  */
 function newMetaModelManager() {
     const metaModelManager = new ModelManager();
@@ -56,7 +56,7 @@ function validateMetaModel(input) {
  * Import metamodel to a model manager
  * @param {object} metaModel - the metamodel
  * @param {boolean} [validate] - whether to perform validation
- * @return {object} the metamodel for this model manager
+ * @return {ModelManager} the metamodel for this model manager
  */
 function modelManagerFromMetaModel(metaModel, validate = true) {
     // First, validate the JSON metaModel


### PR DESCRIPTION
The return types for `newMetaModelManager` and `modelManagerFromMetaModel` are currently `*` or `object`, neither of which are helpful to TypeScript developers. This change corrects the return types to `ModelManager`.

Signed-off-by: Simon Stone <Simon.Stone@docusign.com>