### PR TITLE
feat(types): Adding union and literal decorators to the typescript generation

### DIFF
--- a/packages/concerto-tools/lib/codegen/fromcto/typescript/typescriptvisitor.js
+++ b/packages/concerto-tools/lib/codegen/fromcto/typescript/typescriptvisitor.js
@@ -231,7 +231,23 @@ class TypescriptVisitor {
         const isEnumRef = field.isPrimitive() ? false
             : field.getParent().getModelFile().getModelManager().getType(field.getFullyQualifiedTypeName()).isEnum();
 
-        parameters.fileWriter.writeLine(1, field.getName() + optional + ': ' + this.toTsType(field.getType(), !isEnumRef) + array + ';');
+        const decorators = field.getDecorators();
+        const hasUnion = decorators?.some(decorator => decorator.getName() === 'union');
+        const hasLiteral = decorators?.some(decorator => decorator.getName() === 'literal');
+        let literal = '';
+        if (hasLiteral) {
+            const decoratorArguments = decorators.find(decorator => decorator.getName() === 'literal').getArguments();
+            decoratorArguments.length > 0 && (literal = ` = ${field.getType()}.${decoratorArguments}`);
+        }
+
+        const tsType = this.toTsType(field.getType(), !isEnumRef && !hasUnion, hasUnion);
+
+        if (literal) {
+            parameters.fileWriter.writeLine(1, field.getName() + literal + ';');
+        } else {
+            parameters.fileWriter.writeLine(1, field.getName() + optional + ': ' + tsType + array + literal + ';');
+        }
+
         return null;
     }
 
@@ -277,10 +293,11 @@ class TypescriptVisitor {
      * everything else is passed through unchanged.
      * @param {string} type  - the concerto type
      * @param {boolean} useInterface  - whether to use an interface type
+     * @param {boolean} useUnion  - whether to use a union type
      * @return {string} the corresponding type in Typescript
      * @private
      */
-    toTsType(type, useInterface) {
+    toTsType(type, useInterface, useUnion) {
         switch (type) {
         case 'DateTime':
             return 'Date';
@@ -294,8 +311,19 @@ class TypescriptVisitor {
             return 'number';
         case 'Integer':
             return 'number';
-        default:
-            return useInterface ? `I${type}` : type;
+        default: {
+            let interfacePrefix = '';
+            let union = '';
+            if (useInterface) {
+                interfacePrefix = 'I';
+            }
+
+            if (useUnion) {
+                union = 'Union';
+            }
+
+            return `${interfacePrefix}${type}${union}`;
+        }
         }
     }
 }

--- a/packages/concerto-tools/test/codegen/fromcto/typescript/typescriptvisitor.js
+++ b/packages/concerto-tools/test/codegen/fromcto/typescript/typescriptvisitor.js
@@ -558,6 +558,59 @@ describe('TypescriptVisitor', function () {
 
             param.fileWriter.writeLine.withArgs(1, 'Bob: IPerson[];').calledOnce.should.be.ok;
         });
+
+        it('should write a line for field name who is decorated with union, setting type to be the union type', () => {
+            const mockField = sinon.createStubInstance(Field);
+            mockField.isPrimitive.returns(false);
+            mockField.getName.returns('unionTest');
+            mockField.getType.returns('Person');
+            mockField.getDecorators.returns([{
+                getName: () => {
+                    return 'union';
+                }
+            }]);
+
+            const mockModelManager = sinon.createStubInstance(ModelManager);
+            const mockModelFile = sinon.createStubInstance(ModelFile);
+            const mockClassDeclaration = sinon.createStubInstance(ClassDeclaration);
+
+            mockModelManager.getType.returns(mockClassDeclaration);
+            mockClassDeclaration.isEnum.returns(false);
+            mockModelFile.getModelManager.returns(mockModelManager);
+            mockClassDeclaration.getModelFile.returns(mockModelFile);
+            mockField.getParent.returns(mockClassDeclaration);
+            typescriptVisitor.visitField(mockField, param);
+
+            param.fileWriter.writeLine.withArgs(1, 'unionTest: PersonUnion;').calledOnce.should.be.ok;
+        });
+
+        it('should write a line for field name who is decorated with literal, setting type to be the enum value', () => {
+            const mockField = sinon.createStubInstance(Field);
+            mockField.isPrimitive.returns(false);
+            mockField.getName.returns('literalTest');
+            mockField.getType.returns('EnumType');
+            mockField.getDecorators.returns([{
+                getName: () => {
+                    return 'literal';
+                },
+                getArguments: () => {
+                    return 'MyEnumValue';
+                }
+            }]);
+
+            const mockModelManager = sinon.createStubInstance(ModelManager);
+            const mockModelFile = sinon.createStubInstance(ModelFile);
+            const mockClassDeclaration = sinon.createStubInstance(ClassDeclaration);
+
+            mockModelManager.getType.returns(mockClassDeclaration);
+            mockClassDeclaration.isEnum.returns(false);
+            mockModelFile.getModelManager.returns(mockModelManager);
+            mockClassDeclaration.getModelFile.returns(mockModelFile);
+            mockField.getParent.returns(mockClassDeclaration);
+            typescriptVisitor.visitField(mockField, param);
+
+            param.fileWriter.writeLine.withArgs(1, 'literalTest = EnumType.MyEnumValue;').calledOnce.should.be.ok;
+        });
     });
 
     describe('visitEnumValueDeclaration', () => {

--- a/packages/concerto-tools/types/lib/codegen/fromcto/typescript/typescriptvisitor.d.ts
+++ b/packages/concerto-tools/types/lib/codegen/fromcto/typescript/typescriptvisitor.d.ts
@@ -79,6 +79,7 @@ declare class TypescriptVisitor {
      * everything else is passed through unchanged.
      * @param {string} type  - the concerto type
      * @param {boolean} useInterface  - whether to use an interface type
+     * @param {boolean} useUnion  - whether to use a union type
      * @return {string} the corresponding type in Typescript
      * @private
      */


### PR DESCRIPTION
<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #429
<!--- Provide an overall summary of the pull request -->

Adds support for the literal and union decorators to the typescript generator so that it correctly handles literal and union generation.

### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
- Adds support for the union decorator to the typescript generator
- Adds support for the literal decorator to the typescript generator

### Flags
<!--- Provide context or concerns a reviewer should be aware of -->
N/A?

### Screenshots or Video
N/A?

### Related Issues
- Issue #429
- Pull Request #431

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [x] Merging to `master` from `fork:branchname`
