### PR TITLE
fix(*): wrong error getting fully qualified type name

### DIFF
--- a/packages/concerto-core/lib/introspect/modelfile.js
+++ b/packages/concerto-core/lib/introspect/modelfile.js
@@ -381,6 +381,9 @@ class ModelFile {
                 // check whether type is defined in another file
                 const fqn = this.resolveImport(type);
                 const modelFile = this.getModelManager().getModelFile(ModelUtil.getNamespace(fqn));
+                if (!modelFile) {
+                    return null;
+                }
                 return modelFile.getLocalType(fqn).getFullyQualifiedName();
             }
         }


### PR DESCRIPTION
Fix a bad error message which occurs when calling `getFullyQualifiedTypeName()` when the type of the property relies on an imported namespace that is not present in the model manager.

Error before this change:
`11:19:28 - ERROR: Cannot read properties of undefined (reading 'getLocalType')`

Error after this change:
`11:21:07 - ERROR: Failed to find fully qualified type name for property common with type Common`