### PR TITLE
feat(*): add custom resource factories

### DIFF
--- a/packages/concerto-core/api.txt
+++ b/packages/concerto-core/api.txt
@@ -65,6 +65,8 @@ class Factory {
    + Relationship newRelationship(String,String,String) throws TypeNotFoundException
    + Resource newTransaction(String,String,String?,Object?,String?,boolean?) 
    + Resource newEvent(String,String,String?,Object?,String?,boolean?) 
+   + void addResourceFactory(string,string,ResourceFactory) 
+   + ResourceFactory getResourceFactory(string,string) 
 }
 class AssetDeclaration extends IdentifiedDeclaration {
    + void constructor(ModelFile,Object) throws IllegalModelException
@@ -197,6 +199,12 @@ class RelationshipDeclaration extends Property {
 class TransactionDeclaration extends IdentifiedDeclaration {
    + void constructor(ModelFile,Object) throws IllegalModelException
    + string declarationKind() 
+}
+class CustomResource extends Resource {
+   + void constructor(unknown) 
+   + void setPropertyValue(string,string) throws Error
+   + void addArrayValue(string,string) throws Error
+   + void validate() throws Error
 }
 class Identifiable extends Typed {
    ~ void constructor(ModelManager,ClassDeclaration,string,string,string,string) 

--- a/packages/concerto-core/changelog.txt
+++ b/packages/concerto-core/changelog.txt
@@ -24,9 +24,10 @@
 # Note that the latest public API is documented using JSDocs and is available in api.txt.
 #
 
-Version 2.3.0 {28dd70fd922b3b8b491216661796b95b} 2022-06-21
+Version 2.3.0 {eb82de7f5b776322992eb778807ca0b0} 2022-06-21
 - Fix TypeScript types for MetaModel
 - Fix TypeScript types for ModelManager
+- Add resource factories to Factory, and CustomResource class
 
 Version 2.2.0 {3d3fc2a6b3cd623b807ca0c4fc53680d} 2022-06-01
 - Fix TypeScript types for ModelLoader

--- a/packages/concerto-core/index.js
+++ b/packages/concerto-core/index.js
@@ -53,6 +53,7 @@ const Typed = require('./lib/model/typed');
 const Identifiable = require('./lib/model/identifiable');
 const Relationship = require('./lib/model/relationship');
 const Resource = require('./lib/model/resource');
+const CustomResource = require('./lib/model/customresource');
 
 // Factory
 const Factory = require('./lib/factory');
@@ -117,6 +118,7 @@ module.exports = {
     Identifiable,
     Relationship,
     Resource,
+    CustomResource,
     Factory,
     Globalize,
     Introspector,

--- a/packages/concerto-core/lib/model/customresource.js
+++ b/packages/concerto-core/lib/model/customresource.js
@@ -1,0 +1,131 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const { TypedStack } = require('@accordproject/concerto-util');
+const Resource = require('./resource');
+
+/**
+ * CustomResource is a Resource that is designed to be extended by
+ * generated client classes.
+ * @abstract
+ */
+class CustomResource extends Resource {
+    /**
+     * Constructor.
+     * @param {unknown} opaque Opaque data
+     */
+    constructor(opaque) {
+        // These properties are internals and should not be exposed to the caller.
+        const { modelManager, classDeclaration, ns, type, id, timestamp, resourceValidator } = opaque;
+        super(modelManager, classDeclaration, ns, type, id, timestamp);
+        this.$validator = resourceValidator;
+    }
+
+    /**
+     * Sets a property. If validation is enabled, then the property value is first validated
+     * to ensure that it does not violate the model.
+     * @param {string} propName - the name of the field
+     * @param {string} value - the value of the property
+     * @throws {Error} if the value is not compatible with the model definition for the field
+     */
+    setPropertyValue(propName, value) {
+        // Shortcut if validation not enabled.
+        if (!this.$validator) {
+            super.setPropertyValue(propName,value);
+            return;
+        }
+
+        let classDeclaration = this.getClassDeclaration();
+        let field = classDeclaration.getProperty(propName);
+
+        if (!field) {
+            throw new Error('The instance with id ' +
+                this.getIdentifier() + ' trying to set field ' +
+                propName + ' which is not declared in the model.');
+        }
+
+        const parameters = {};
+        parameters.stack = new TypedStack(value);
+        parameters.modelManager = this.getModelManager();
+        parameters.rootResourceIdentifier = this.getFullyQualifiedIdentifier();
+        field.accept(this.$validator, parameters);
+        super.setPropertyValue(propName,value);
+    }
+
+    /**
+     * Adds an array property value. If validation is enabled, then the property value is
+     * first validated to ensure that it does not violate the model.
+     * @param {string} propName - the name of the field
+     * @param {string} value - the value of the property
+     * @throws {Error} if the value is not compatible with the model definition for the field
+     */
+    addArrayValue(propName, value) {
+        // Shortcut if validation not enabled.
+        if (!this.$validator) {
+            super.addArrayValue(propName,value);
+            return;
+        }
+
+        let classDeclaration = this.getClassDeclaration();
+        let field = classDeclaration.getProperty(propName);
+
+        if (!field) {
+            throw new Error('The instance with id ' +
+                this.getIdentifier() + ' trying to set field ' +
+                propName + ' which is not declared in the model.');
+        }
+
+        if (!field.isArray()) {
+            throw new Error('The instance with id ' +
+                this.getIdentifier() + ' trying to add array item ' +
+                propName + ' which is not declared as an array in the model.');
+        }
+
+        const parameters = {};
+        let newArray = [];
+        if(this[propName]) {
+            newArray = this[propName].slice(0);
+        }
+        newArray.push(value);
+        parameters.stack = new TypedStack(newArray);
+        parameters.modelManager = this.getModelManager();
+        parameters.rootResourceIdentifier = this.getFullyQualifiedIdentifier();
+        field.accept(this.$validator, parameters);
+        super.addArrayValue(propName, value);
+    }
+
+    /**
+     * Validates the instance against its model. If validation is not enabled, then an error
+     * will be thrown.
+     *
+     * @throws {Error} - if the instance if invalid with respect to the model
+     */
+    validate() {
+        // Throw error if validation not enabled.
+        if (!this.$validator) {
+            throw new Error('validation is not enabled');
+        }
+
+        const classDeclaration = this.getClassDeclaration();
+        const parameters = {};
+        parameters.stack = new TypedStack(this);
+        parameters.modelManager = this.getModelManager();
+        parameters.rootResourceIdentifier = this.getFullyQualifiedIdentifier();
+        classDeclaration.accept(this.$validator, parameters);
+    }
+}
+
+module.exports = CustomResource;

--- a/packages/concerto-core/types/index.d.ts
+++ b/packages/concerto-core/types/index.d.ts
@@ -20,6 +20,7 @@ import Typed = require("./lib/model/typed");
 import Identifiable = require("./lib/model/identifiable");
 import Relationship = require("./lib/model/relationship");
 import Resource = require("./lib/model/resource");
+import CustomResource = require("./lib/model/customresource");
 import Factory = require("./lib/factory");
 import Globalize = require("./lib/globalize");
 import Introspector = require("./lib/introspect/introspector");
@@ -36,4 +37,4 @@ export const version: {
     name: string;
     version: string;
 };
-export { SecurityException, IllegalModelException, TypeNotFoundException, Decorator, DecoratorFactory, DecoratorManager, ClassDeclaration, IdentifiedDeclaration, AssetDeclaration, ConceptDeclaration, EnumValueDeclaration, EventDeclaration, ParticipantDeclaration, TransactionDeclaration, Property, Field, EnumDeclaration, RelationshipDeclaration, Typed, Identifiable, Relationship, Resource, Factory, Globalize, Introspector, ModelFile, ModelManager, Serializer, ModelUtil, ModelLoader, DateTimeUtil, Concerto, MetaModel };
+export { SecurityException, IllegalModelException, TypeNotFoundException, Decorator, DecoratorFactory, DecoratorManager, ClassDeclaration, IdentifiedDeclaration, AssetDeclaration, ConceptDeclaration, EnumValueDeclaration, EventDeclaration, ParticipantDeclaration, TransactionDeclaration, Property, Field, EnumDeclaration, RelationshipDeclaration, Typed, Identifiable, Relationship, Resource, CustomResource, Factory, Globalize, Introspector, ModelFile, ModelManager, Serializer, ModelUtil, ModelLoader, DateTimeUtil, Concerto, MetaModel };

--- a/packages/concerto-core/types/lib/factory.d.ts
+++ b/packages/concerto-core/types/lib/factory.d.ts
@@ -19,6 +19,7 @@ declare class Factory {
      */
     constructor(modelManager: ModelManager);
     modelManager: ModelManager;
+    resourceFactories: {};
     /**
      * Create a new Resource with a given namespace, type name and id
      * @param {String} ns - the namespace of the Resource
@@ -130,7 +131,28 @@ declare class Factory {
      * @return {Object} InstanceGenerator options.
      */
     private parseGenerateOptions;
+    /**
+     * Add a resource factory for the specified namespace and type.
+     * @param {string} ns The namespace
+     * @param {string} type The type
+     * @param {ResourceFactory} resourceFactory The resource factory.
+     */
+    addResourceFactory(ns: string, type: string, resourceFactory: ResourceFactory): void;
+    /**
+     * Get the resource factory for the specified namespace and type.
+     * @param {string} ns The namespace
+     * @param {string} type The type
+     * @returns {ResourceFactory} The resource factory.
+     */
+    getResourceFactory(ns: string, type: string): ResourceFactory;
+}
+declare namespace Factory {
+    export { ResourceFactory };
 }
 import ModelManager = require("./modelmanager");
 import Resource = require("./model/resource");
 import Relationship = require("./model/relationship");
+/**
+ * A resource factory is called to create a resource.
+ */
+type ResourceFactory = (opaque: unknown) => Resource;

--- a/packages/concerto-core/types/lib/model/customresource.d.ts
+++ b/packages/concerto-core/types/lib/model/customresource.d.ts
@@ -1,0 +1,22 @@
+export = CustomResource;
+/**
+ * CustomResource is a Resource that is designed to be extended by
+ * generated client classes.
+ * @abstract
+ */
+declare class CustomResource extends Resource {
+    /**
+     * Constructor.
+     * @param {unknown} opaque Opaque data
+     */
+    constructor(opaque: unknown);
+    $validator: any;
+    /**
+     * Validates the instance against its model. If validation is not enabled, then an error
+     * will be thrown.
+     *
+     * @throws {Error} - if the instance if invalid with respect to the model
+     */
+    validate(): void;
+}
+import Resource = require("./resource");


### PR DESCRIPTION
Introduce a new facility that allows a user to extend Concerto's built in resource type (as a "custom" resource), and have instances of that type created by Concerto's built in factory methods.

For example, given a model:

```
namespace com.example

asset MyAsset {
  o String value
}
```

... a user can define a TypeScript class, with their own property definitions and custom functions:

```
import { CustomResource } from '@accordproject/concerto-core';

class MyAsset extends CustomResource {
  value: string;

  getValue() {
    return this.value;
  }

  setValue(value: string) {
    this.value = value;
  }
}
```

... a user can register that TypeScript class with a factory:

```
import { Factory } from '@accordproject/concerto-core';

const factory = new Factory(/* ... */);
factory.addResourceFactory('com.example', 'MyAsset', opaque => new MyAsset(opaque));
```

... and then when a user uses that factory, they get instances of that TypeScript class instead of the built-in Resource class:

```
const resource = factory.newResource('com.example', 'MyAsset', '1234');
if (resource instanceof MyAsset) {
  console.log('woohoo!', resource.getValue());
}
```