### PR TITLE
feat(tools): improved C# code generation

### DIFF
--- a/packages/concerto-cli/index.js
+++ b/packages/concerto-cli/index.js
@@ -105,6 +105,16 @@ require('yargs')
             type: 'string',
             default: './output/'
         });
+        yargs.option('useSystemTextJson', {
+            describe: 'Compile for System.Text.Json library',
+            type: 'boolean',
+            default: false
+        });
+        yargs.option('useNewtonsoftJson', {
+            describe: 'Compile for Newtonsoft.Json library',
+            type: 'boolean',
+            default: false
+        });
     }, (argv) => {
         if (argv.verbose) {
             Logger.info(`generate code for target ${argv.target} from models ${argv.model} into directory: ${argv.output}`);
@@ -112,6 +122,8 @@ require('yargs')
 
         const options = {};
         options.offline = argv.offline;
+        options.useSystemTextJson = argv.useSystemTextJson;
+        options.useNewtonsoftJson = argv.useNewtonsoftJson;
         return Commands.compile(argv.target, argv.model, argv.output, options)
             .then((result) => {
                 Logger.info(result);

--- a/packages/concerto-cli/index.js
+++ b/packages/concerto-cli/index.js
@@ -106,14 +106,18 @@ require('yargs')
             default: './output/'
         });
         yargs.option('useSystemTextJson', {
-            describe: 'Compile for System.Text.Json library',
+            describe: 'Compile for System.Text.Json library (`csharp` target only)',
             type: 'boolean',
             default: false
         });
         yargs.option('useNewtonsoftJson', {
-            describe: 'Compile for Newtonsoft.Json library',
+            describe: 'Compile for Newtonsoft.Json library (`csharp` target only)',
             type: 'boolean',
             default: false
+        });
+        yargs.option('namespacePrefix', {
+            describe: 'A prefix to add to all namespaces (`csharp` target only)',
+            type: 'string',
         });
     }, (argv) => {
         if (argv.verbose) {
@@ -124,6 +128,7 @@ require('yargs')
         options.offline = argv.offline;
         options.useSystemTextJson = argv.useSystemTextJson;
         options.useNewtonsoftJson = argv.useNewtonsoftJson;
+        options.namespacePrefix = argv.namespacePrefix;
         return Commands.compile(argv.target, argv.model, argv.output, options)
             .then((result) => {
                 Logger.info(result);

--- a/packages/concerto-cli/lib/commands.js
+++ b/packages/concerto-cli/lib/commands.js
@@ -139,9 +139,17 @@ class Commands {
      * @param {string} output the output directory
      * @param {object} options - optional parameters
      * @param {boolean} [options.offline] - do not resolve external models
+     * @param {boolean} [options.useSystemTextJson] - compile for System.Text.Json library
+     * @param {boolean} [options.useNewtonsoftJson] - compile for Newtonsoft.Json library
      */
     static async compile(target, ctoFiles, output, options) {
-        const modelManager = await ModelLoader.loadModelManager(ctoFiles, options);
+        const modelManagerOptions = { offline: options && options.offline };
+        const visitorOptions = {
+            useSystemTextJson: options && options.useSystemTextJson,
+            useNewtonsoftJson: options && options.useNewtonsoftJson
+        };
+
+        const modelManager = await ModelLoader.loadModelManager(ctoFiles, modelManagerOptions);
 
         let visitor = null;
 
@@ -176,7 +184,7 @@ class Commands {
         }
 
         if(visitor) {
-            let parameters = {};
+            let parameters = visitorOptions;
             parameters.fileWriter = new FileWriter(output);
             modelManager.accept(visitor, parameters);
             return `Compiled to ${target} in '${output}'.`;

--- a/packages/concerto-cli/lib/commands.js
+++ b/packages/concerto-cli/lib/commands.js
@@ -146,7 +146,8 @@ class Commands {
         const modelManagerOptions = { offline: options && options.offline };
         const visitorOptions = {
             useSystemTextJson: options && options.useSystemTextJson,
-            useNewtonsoftJson: options && options.useNewtonsoftJson
+            useNewtonsoftJson: options && options.useNewtonsoftJson,
+            namespacePrefix: options && options.namespacePrefix
         };
 
         const modelManager = await ModelLoader.loadModelManager(ctoFiles, modelManagerOptions);

--- a/packages/concerto-tools/lib/codegen/fromcto/csharp/csharpvisitor.js
+++ b/packages/concerto-tools/lib/codegen/fromcto/csharp/csharpvisitor.js
@@ -84,6 +84,12 @@ class CSharpVisitor {
             parameters.useSystemTextJson = true;
         }
 
+        // Ensure non-empty string, that is separated by a period
+        let namespacePrefix = parameters.namespacePrefix ? parameters.namespacePrefix : '';
+        if (namespacePrefix !== '' && namespacePrefix.slice(-1) !== '.'){
+            namespacePrefix += '.';
+        }
+
         parameters.fileWriter.openFile(modelFile.getNamespace() + '.cs');
         parameters.fileWriter.writeLine(0, 'using System;');
 
@@ -97,12 +103,12 @@ class CSharpVisitor {
             parameters.fileWriter.writeLine(0, 'using NewtonsoftConcerto = Concerto.Serialization.Newtonsoft;');
         }
 
-        parameters.fileWriter.writeLine(0, `namespace Concerto.Models.${modelFile.getNamespace()} {`);
+        parameters.fileWriter.writeLine(0, `namespace ${namespacePrefix}${modelFile.getNamespace()} {`);
 
         modelFile.getImports().map(importString => ModelUtil.getNamespace(importString)).filter(namespace => namespace !== modelFile.getNamespace()) // Skip own namespace.
             .filter((v, i, a) => a.indexOf(v) === i) // Remove any duplicates from direct imports
             .forEach(namespace => {
-                parameters.fileWriter.writeLine(1, `using Concerto.Models.${namespace};`);
+                parameters.fileWriter.writeLine(1, `using ${namespacePrefix}${namespace};`);
             });
 
         modelFile.getAllDeclarations().forEach((decl) => {
@@ -278,10 +284,10 @@ class CSharpVisitor {
 
         if (modifiedPropertyName !== propertyName){
             if (parameters?.useSystemTextJson){
-                annotations += `[JsonPropertyName("${propertyName}")]\n\t`;
+                annotations += `[JsonPropertyName("${propertyName}")]\n\t\t`;
             }
             if (parameters?.useNewtonsoftJson){
-                annotations += `[NewtonsoftJson.JsonProperty("${propertyName}")]\n\t`;
+                annotations += `[NewtonsoftJson.JsonProperty("${propertyName}")]\n\t\t`;
             }
         }
 

--- a/packages/concerto-tools/test/codegen/fromcto/csharp/csharpvisitor.js
+++ b/packages/concerto-tools/test/codegen/fromcto/csharp/csharpvisitor.js
@@ -223,17 +223,96 @@ describe('CSharpVisitor', function () {
             csharpVisitor.visitModelFile(mockModelFile, param);
 
             param.fileWriter.openFile.withArgs('org.acme.cs').calledOnce.should.be.ok;
-            param.fileWriter.writeLine.callCount.should.equal(7);
+            param.fileWriter.writeLine.callCount.should.equal(8);
             param.fileWriter.writeLine.getCall(0).args.should.deep.equal([0, 'using System;']);
             param.fileWriter.writeLine.getCall(1).args.should.deep.equal([0, 'using System.Text.Json.Serialization;']);
-            param.fileWriter.writeLine.getCall(2).args.should.deep.equal([0, 'namespace org.acme {']);
-            param.fileWriter.writeLine.getCall(3).args.should.deep.equal([1, 'using org.org1;']);
-            param.fileWriter.writeLine.getCall(4).args.should.deep.equal([1, 'using org.org2;']);
-            param.fileWriter.writeLine.getCall(5).args.should.deep.equal([1, 'using super;']);
-            param.fileWriter.writeLine.getCall(6).args.should.deep.equal([0, '}']);
+            param.fileWriter.writeLine.getCall(2).args.should.deep.equal([0, 'using Concerto.Serialization;']);
+            param.fileWriter.writeLine.getCall(3).args.should.deep.equal([0, 'namespace Concerto.Models.org.acme {']);
+            param.fileWriter.writeLine.getCall(4).args.should.deep.equal([1, 'using Concerto.Models.org.org1;']);
+            param.fileWriter.writeLine.getCall(5).args.should.deep.equal([1, 'using Concerto.Models.org.org2;']);
+            param.fileWriter.writeLine.getCall(6).args.should.deep.equal([1, 'using Concerto.Models.super;']);
+            param.fileWriter.writeLine.getCall(7).args.should.deep.equal([0, '}']);
             param.fileWriter.closeFile.calledOnce.should.be.ok;
             acceptSpy.withArgs(csharpVisitor, param).calledThrice.should.be.ok;
         });
+
+        it('should write lines for the imports that are not in own namespace (including super types) ignoring primitives using Newtonsoft.Json', () => {
+            let acceptSpy = sinon.spy();
+            let mockEnum = sinon.createStubInstance(EnumDeclaration);
+            mockEnum.isEnum.returns(true);
+            mockEnum.accept = acceptSpy;
+
+            let property1 = {
+                isPrimitive: () => {
+                    return false;
+                },
+                getFullyQualifiedTypeName: () => {
+                    return 'org.org1.Property1';
+                }
+            };
+
+            let property2 = {
+                isPrimitive: () => {
+                    return false;
+                },
+                getFullyQualifiedTypeName: () => {
+                    return 'org.acme.Property2';
+                }
+            };
+
+            let property3 = {
+                isPrimitive: () => {
+                    return true;
+                },
+                getFullyQualifiedTypeName: () => {
+                    return 'super.Property3';
+                }
+            };
+
+            let mockClassDeclaration = sinon.createStubInstance(ClassDeclaration);
+            mockClassDeclaration.isEnum.returns(false);
+            mockClassDeclaration.getSuperType.returns('super.Parent');
+            mockClassDeclaration.getProperties.returns([property1, property2, property3]);
+            mockClassDeclaration.accept = acceptSpy;
+
+            let mockClassDeclaration2 = sinon.createStubInstance(ClassDeclaration);
+            mockClassDeclaration.isEnum.returns(false);
+            mockClassDeclaration2.getSuperType.returns('super.Parent');
+            mockClassDeclaration2.getProperties.returns([]);
+            mockClassDeclaration2.accept = acceptSpy;
+
+            let mockModelFile = sinon.createStubInstance(ModelFile);
+            mockModelFile.getNamespace.returns('org.acme');
+            mockModelFile.getAllDeclarations.returns([
+                mockEnum,
+                mockClassDeclaration,
+                mockClassDeclaration2
+            ]);
+            mockModelFile.getImports.returns([
+                'org.org1.Import1',
+                'org.org1.Import2',
+                'org.org2.Import1',
+                'super.Property3',
+                'super.Parent'
+            ]);
+
+            const newtonsoftParams = { ...param, useNewtonsoftJson: true };
+            csharpVisitor.visitModelFile(mockModelFile, newtonsoftParams);
+
+            param.fileWriter.openFile.withArgs('org.acme.cs').calledOnce.should.be.ok;
+            param.fileWriter.writeLine.callCount.should.equal(8);
+            param.fileWriter.writeLine.getCall(0).args.should.deep.equal([0, 'using System;']);
+            param.fileWriter.writeLine.getCall(1).args.should.deep.equal([0, 'using NewtonsoftJson = Newtonsoft.Json;']);
+            param.fileWriter.writeLine.getCall(2).args.should.deep.equal([0, 'using NewtonsoftConcerto = Concerto.Serialization.Newtonsoft;']);
+            param.fileWriter.writeLine.getCall(3).args.should.deep.equal([0, 'namespace Concerto.Models.org.acme {']);
+            param.fileWriter.writeLine.getCall(4).args.should.deep.equal([1, 'using Concerto.Models.org.org1;']);
+            param.fileWriter.writeLine.getCall(5).args.should.deep.equal([1, 'using Concerto.Models.org.org2;']);
+            param.fileWriter.writeLine.getCall(6).args.should.deep.equal([1, 'using Concerto.Models.super;']);
+            param.fileWriter.writeLine.getCall(7).args.should.deep.equal([0, '}']);
+            param.fileWriter.closeFile.calledOnce.should.be.ok;
+            acceptSpy.withArgs(csharpVisitor, newtonsoftParams).calledThrice.should.be.ok;
+        });
+
 
         it('should write lines for the imports that are not in own namespace ignoring primitives and write lines for importing system type', () => {
             let acceptSpy = sinon.spy();
@@ -293,13 +372,14 @@ describe('CSharpVisitor', function () {
             csharpVisitor.visitModelFile(mockModelFile, param);
 
             param.fileWriter.openFile.withArgs('org.acme.cs').calledOnce.should.be.ok;
-            param.fileWriter.writeLine.callCount.should.equal(6);
+            param.fileWriter.writeLine.callCount.should.equal(7);
             param.fileWriter.writeLine.getCall(0).args.should.deep.equal([0, 'using System;']);
             param.fileWriter.writeLine.getCall(1).args.should.deep.equal([0, 'using System.Text.Json.Serialization;']);
-            param.fileWriter.writeLine.getCall(2).args.should.deep.equal([0, 'namespace org.acme {']);
-            param.fileWriter.writeLine.getCall(3).args.should.deep.equal([1, 'using org.org1;']);
-            param.fileWriter.writeLine.getCall(4).args.should.deep.equal([1, 'using org.org2;']);
-            param.fileWriter.writeLine.getCall(5).args.should.deep.equal([0, '}']);
+            param.fileWriter.writeLine.getCall(2).args.should.deep.equal([0, 'using Concerto.Serialization;']);
+            param.fileWriter.writeLine.getCall(3).args.should.deep.equal([0, 'namespace Concerto.Models.org.acme {']);
+            param.fileWriter.writeLine.getCall(4).args.should.deep.equal([1, 'using Concerto.Models.org.org1;']);
+            param.fileWriter.writeLine.getCall(5).args.should.deep.equal([1, 'using Concerto.Models.org.org2;']);
+            param.fileWriter.writeLine.getCall(6).args.should.deep.equal([0, '}']);
             param.fileWriter.closeFile.calledOnce.should.be.ok;
             acceptSpy.withArgs(csharpVisitor, param).calledTwice.should.be.ok;
         });
@@ -326,7 +406,7 @@ describe('CSharpVisitor', function () {
             csharpVisitor.visitEnumDeclaration(mockEnumDeclaration, param);
 
             param.fileWriter.writeLine.callCount.should.deep.equal(2);
-            param.fileWriter.writeLine.withArgs(1, 'enum Bob {').calledOnce.should.be.ok;
+            param.fileWriter.writeLine.withArgs(1, 'public enum Bob {').calledOnce.should.be.ok;
             param.fileWriter.writeLine.withArgs(1, '}\n').calledOnce.should.be.ok;
 
             acceptSpy.withArgs(csharpVisitor, param).calledTwice.should.be.ok;
@@ -356,9 +436,31 @@ describe('CSharpVisitor', function () {
             csharpVisitor.visitClassDeclaration(mockClassDeclaration, param);
 
             param.fileWriter.writeLine.callCount.should.deep.equal(3);
-            param.fileWriter.writeLine.getCall(0).args.should.deep.equal([1, 'class Bob {']);
-            param.fileWriter.writeLine.getCall(1).args.should.deep.equal([2, '[JsonPropertyName("$class")]\n      public new string _class { get;} = "undefined";']);
+            param.fileWriter.writeLine.getCall(0).args.should.deep.equal([1, 'public class Bob {']);
+            param.fileWriter.writeLine.getCall(1).args.should.deep.equal([2, '[JsonPropertyName("$class")]\n\tpublic override string _class { get;} = "undefined";']);
             param.fileWriter.writeLine.getCall(2).args.should.deep.equal([1, '}']);
+        });
+        it('should write the class opening and close with Newtonsoft.Json', () => {
+            let acceptSpy = sinon.spy();
+
+            let mockClassDeclaration = sinon.createStubInstance(ClassDeclaration);
+            let mockClassDeclaration2 = sinon.createStubInstance(ClassDeclaration);
+            mockClassDeclaration.isClassDeclaration.returns(true);
+            mockClassDeclaration.getOwnProperties.returns([{
+                accept: acceptSpy
+            },
+            {
+                accept: acceptSpy
+            }]);
+            mockClassDeclaration.getName.returns('Bob');
+            mockClassDeclaration.getAssignableClassDeclarations.returns([mockClassDeclaration, mockClassDeclaration2]);
+            csharpVisitor.visitClassDeclaration(mockClassDeclaration, { ...param, useNewtonsoftJson: true});
+
+            param.fileWriter.writeLine.callCount.should.deep.equal(4);
+            param.fileWriter.writeLine.getCall(0).args.should.deep.equal([1, '[NewtonsoftJson.JsonConverter(typeof(NewtonsoftConcerto.ConcertoConverter))]']);
+            param.fileWriter.writeLine.getCall(1).args.should.deep.equal([1, 'public class Bob {']);
+            param.fileWriter.writeLine.getCall(2).args.should.deep.equal([2, '[NewtonsoftJson.JsonProperty("$class")]\n\tpublic override string _class { get;} = "undefined";']);
+            param.fileWriter.writeLine.getCall(3).args.should.deep.equal([1, '}']);
         });
         it('should write the class opening and close with abstract and super type', () => {
             let acceptSpy = sinon.spy();
@@ -378,8 +480,74 @@ describe('CSharpVisitor', function () {
             csharpVisitor.visitClassDeclaration(mockClassDeclaration, param);
 
             param.fileWriter.writeLine.callCount.should.deep.equal(3);
-            param.fileWriter.writeLine.getCall(0).args.should.deep.equal([1, 'abstract class Bob : Person {']);
-            param.fileWriter.writeLine.getCall(1).args.should.deep.equal([2, '[JsonPropertyName("$class")]\n      public new string _class { get;} = "undefined";']);
+            param.fileWriter.writeLine.getCall(0).args.should.deep.equal([1, 'public abstract class Bob : Person {']);
+            param.fileWriter.writeLine.getCall(1).args.should.deep.equal([2, '[JsonPropertyName("$class")]\n\tpublic override string _class { get;} = "undefined";']);
+            param.fileWriter.writeLine.getCall(2).args.should.deep.equal([1, '}']);
+        });
+        it('should write the class opening and close with abstract and super type, with explicit System.Text.Json flag', () => {
+            let acceptSpy = sinon.spy();
+
+            let mockClassDeclaration = sinon.createStubInstance(ClassDeclaration);
+            mockClassDeclaration.isClassDeclaration.returns(true);
+            mockClassDeclaration.getOwnProperties.returns([{
+                accept: acceptSpy
+            },
+            {
+                accept: acceptSpy
+            }]);
+            mockClassDeclaration.getName.returns('Bob');
+            mockClassDeclaration.isAbstract.returns(true);
+            mockClassDeclaration.getSuperType.returns('org.acme.Person');
+
+            csharpVisitor.visitClassDeclaration(mockClassDeclaration, { ...param, useSystemTextJson: true });
+
+            param.fileWriter.writeLine.callCount.should.deep.equal(3);
+            param.fileWriter.writeLine.getCall(0).args.should.deep.equal([1, 'public abstract class Bob : Person {']);
+            param.fileWriter.writeLine.getCall(1).args.should.deep.equal([2, '[JsonPropertyName("$class")]\n\tpublic override string _class { get;} = "undefined";']);
+            param.fileWriter.writeLine.getCall(2).args.should.deep.equal([1, '}']);
+        });
+        it('should write the class opening and close with abstract and super type, with both serializer flags', () => {
+            let acceptSpy = sinon.spy();
+
+            let mockClassDeclaration = sinon.createStubInstance(ClassDeclaration);
+            mockClassDeclaration.isClassDeclaration.returns(true);
+            mockClassDeclaration.getOwnProperties.returns([{
+                accept: acceptSpy
+            },
+            {
+                accept: acceptSpy
+            }]);
+            mockClassDeclaration.getName.returns('Bob');
+            mockClassDeclaration.isAbstract.returns(true);
+            mockClassDeclaration.getSuperType.returns('org.acme.Person');
+
+            csharpVisitor.visitClassDeclaration(mockClassDeclaration, { ...param, useSystemTextJson: true, useNewtonsoftJson: true });
+
+            param.fileWriter.writeLine.callCount.should.deep.equal(3);
+            param.fileWriter.writeLine.getCall(0).args.should.deep.equal([1, 'public abstract class Bob : Person {']);
+            param.fileWriter.writeLine.getCall(1).args.should.deep.equal([2, '[JsonPropertyName("$class")]\n\t[NewtonsoftJson.JsonProperty("$class")]\n\tpublic override string _class { get;} = "undefined";']);
+            param.fileWriter.writeLine.getCall(2).args.should.deep.equal([1, '}']);
+        });
+        it('should write the class opening and close with virtual modifier for base class', () => {
+            let acceptSpy = sinon.spy();
+
+            let mockClassDeclaration = sinon.createStubInstance(ClassDeclaration);
+            mockClassDeclaration.isClassDeclaration.returns(true);
+            mockClassDeclaration.getOwnProperties.returns([{
+                accept: acceptSpy
+            },
+            {
+                accept: acceptSpy
+            }]);
+            mockClassDeclaration.getName.returns('Concept');
+            mockClassDeclaration.getFullyQualifiedName.returns('concerto.Concept');
+            mockClassDeclaration.isAbstract.returns(true);
+
+            csharpVisitor.visitClassDeclaration(mockClassDeclaration, param);
+
+            param.fileWriter.writeLine.callCount.should.deep.equal(3);
+            param.fileWriter.writeLine.getCall(0).args.should.deep.equal([1, 'public abstract class Concept {']);
+            param.fileWriter.writeLine.getCall(1).args.should.deep.equal([2, '[JsonPropertyName("$class")]\n\tpublic virtual string _class { get;} = "concerto.Concept";']);
             param.fileWriter.writeLine.getCall(2).args.should.deep.equal([1, '}']);
         });
     });
@@ -399,6 +567,27 @@ describe('CSharpVisitor', function () {
             mockField.isPrimitive.returns(true);
             csharpVisitor.visitField(mockField, param);
             param.fileWriter.writeLine.withArgs(2, 'public string name { get; set; }').calledOnce.should.be.ok;
+        });
+
+        it('should write a line for primitive field name and type, where the field name is reserved in C#', () => {
+            const mockField = sinon.createStubInstance(Field);
+            mockField.isPrimitive.returns(false);
+            mockField.getName.returns('bool');
+            mockField.getType.returns('String');
+            mockField.isPrimitive.returns(true);
+            csharpVisitor.visitField(mockField, param);
+            param.fileWriter.writeLine.withArgs(2, '[JsonPropertyName("bool")]\n\tpublic string _bool { get; set; }').calledOnce.should.be.ok;
+        });
+
+        it('should write a line for an optional enum field name and type', () => {
+            const mockField = sinon.createStubInstance(Field);
+            mockField.isPrimitive.returns(false);
+            mockField.getName.returns('myEnum');
+            mockField.getType.returns('Enum');
+            mockField.isOptional.returns(true);
+            mockField.isTypeEnum.returns(true);
+            csharpVisitor.visitField(mockField, param);
+            param.fileWriter.writeLine.withArgs(2, 'public Enum? myEnum { get; set; }').calledOnce.should.be.ok;
         });
 
         it('should write a line for field name and type thats an array', () => {

--- a/packages/concerto-tools/test/codegen/fromcto/csharp/csharpvisitor.js
+++ b/packages/concerto-tools/test/codegen/fromcto/csharp/csharpvisitor.js
@@ -220,7 +220,11 @@ describe('CSharpVisitor', function () {
                 'super.Parent'
             ]);
 
-            csharpVisitor.visitModelFile(mockModelFile, param);
+            const myParams = {
+                ...param,
+                namespacePrefix: 'Concerto.Models.'
+            };
+            csharpVisitor.visitModelFile(mockModelFile, myParams);
 
             param.fileWriter.openFile.withArgs('org.acme.cs').calledOnce.should.be.ok;
             param.fileWriter.writeLine.callCount.should.equal(8);
@@ -233,7 +237,7 @@ describe('CSharpVisitor', function () {
             param.fileWriter.writeLine.getCall(6).args.should.deep.equal([1, 'using Concerto.Models.super;']);
             param.fileWriter.writeLine.getCall(7).args.should.deep.equal([0, '}']);
             param.fileWriter.closeFile.calledOnce.should.be.ok;
-            acceptSpy.withArgs(csharpVisitor, param).calledThrice.should.be.ok;
+            acceptSpy.withArgs(csharpVisitor, myParams).calledThrice.should.be.ok;
         });
 
         it('should write lines for the imports that are not in own namespace (including super types) ignoring primitives using Newtonsoft.Json', () => {
@@ -296,7 +300,11 @@ describe('CSharpVisitor', function () {
                 'super.Parent'
             ]);
 
-            const newtonsoftParams = { ...param, useNewtonsoftJson: true };
+            const newtonsoftParams = {
+                ...param,
+                useNewtonsoftJson: true,
+                namespacePrefix: 'Concerto.Models'
+            };
             csharpVisitor.visitModelFile(mockModelFile, newtonsoftParams);
 
             param.fileWriter.openFile.withArgs('org.acme.cs').calledOnce.should.be.ok;
@@ -369,7 +377,11 @@ describe('CSharpVisitor', function () {
             ]);
             mockModelFile.getModelManager.returns(mockModelManager);
 
-            csharpVisitor.visitModelFile(mockModelFile, param);
+            const myParams = {
+                ...param,
+                namespacePrefix: 'Concerto.Models.'
+            };
+            csharpVisitor.visitModelFile(mockModelFile, myParams);
 
             param.fileWriter.openFile.withArgs('org.acme.cs').calledOnce.should.be.ok;
             param.fileWriter.writeLine.callCount.should.equal(7);
@@ -381,7 +393,7 @@ describe('CSharpVisitor', function () {
             param.fileWriter.writeLine.getCall(5).args.should.deep.equal([1, 'using Concerto.Models.org.org2;']);
             param.fileWriter.writeLine.getCall(6).args.should.deep.equal([0, '}']);
             param.fileWriter.closeFile.calledOnce.should.be.ok;
-            acceptSpy.withArgs(csharpVisitor, param).calledTwice.should.be.ok;
+            acceptSpy.withArgs(csharpVisitor, myParams).calledTwice.should.be.ok;
         });
     });
 
@@ -437,7 +449,7 @@ describe('CSharpVisitor', function () {
 
             param.fileWriter.writeLine.callCount.should.deep.equal(3);
             param.fileWriter.writeLine.getCall(0).args.should.deep.equal([1, 'public class Bob {']);
-            param.fileWriter.writeLine.getCall(1).args.should.deep.equal([2, '[JsonPropertyName("$class")]\n\tpublic override string _class { get;} = "undefined";']);
+            param.fileWriter.writeLine.getCall(1).args.should.deep.equal([2, '[JsonPropertyName("$class")]\n\t\tpublic override string _class { get;} = "undefined";']);
             param.fileWriter.writeLine.getCall(2).args.should.deep.equal([1, '}']);
         });
         it('should write the class opening and close with Newtonsoft.Json', () => {
@@ -459,7 +471,7 @@ describe('CSharpVisitor', function () {
             param.fileWriter.writeLine.callCount.should.deep.equal(4);
             param.fileWriter.writeLine.getCall(0).args.should.deep.equal([1, '[NewtonsoftJson.JsonConverter(typeof(NewtonsoftConcerto.ConcertoConverter))]']);
             param.fileWriter.writeLine.getCall(1).args.should.deep.equal([1, 'public class Bob {']);
-            param.fileWriter.writeLine.getCall(2).args.should.deep.equal([2, '[NewtonsoftJson.JsonProperty("$class")]\n\tpublic override string _class { get;} = "undefined";']);
+            param.fileWriter.writeLine.getCall(2).args.should.deep.equal([2, '[NewtonsoftJson.JsonProperty("$class")]\n\t\tpublic override string _class { get;} = "undefined";']);
             param.fileWriter.writeLine.getCall(3).args.should.deep.equal([1, '}']);
         });
         it('should write the class opening and close with abstract and super type', () => {
@@ -481,7 +493,7 @@ describe('CSharpVisitor', function () {
 
             param.fileWriter.writeLine.callCount.should.deep.equal(3);
             param.fileWriter.writeLine.getCall(0).args.should.deep.equal([1, 'public abstract class Bob : Person {']);
-            param.fileWriter.writeLine.getCall(1).args.should.deep.equal([2, '[JsonPropertyName("$class")]\n\tpublic override string _class { get;} = "undefined";']);
+            param.fileWriter.writeLine.getCall(1).args.should.deep.equal([2, '[JsonPropertyName("$class")]\n\t\tpublic override string _class { get;} = "undefined";']);
             param.fileWriter.writeLine.getCall(2).args.should.deep.equal([1, '}']);
         });
         it('should write the class opening and close with abstract and super type, with explicit System.Text.Json flag', () => {
@@ -503,7 +515,7 @@ describe('CSharpVisitor', function () {
 
             param.fileWriter.writeLine.callCount.should.deep.equal(3);
             param.fileWriter.writeLine.getCall(0).args.should.deep.equal([1, 'public abstract class Bob : Person {']);
-            param.fileWriter.writeLine.getCall(1).args.should.deep.equal([2, '[JsonPropertyName("$class")]\n\tpublic override string _class { get;} = "undefined";']);
+            param.fileWriter.writeLine.getCall(1).args.should.deep.equal([2, '[JsonPropertyName("$class")]\n\t\tpublic override string _class { get;} = "undefined";']);
             param.fileWriter.writeLine.getCall(2).args.should.deep.equal([1, '}']);
         });
         it('should write the class opening and close with abstract and super type, with both serializer flags', () => {
@@ -525,7 +537,7 @@ describe('CSharpVisitor', function () {
 
             param.fileWriter.writeLine.callCount.should.deep.equal(3);
             param.fileWriter.writeLine.getCall(0).args.should.deep.equal([1, 'public abstract class Bob : Person {']);
-            param.fileWriter.writeLine.getCall(1).args.should.deep.equal([2, '[JsonPropertyName("$class")]\n\t[NewtonsoftJson.JsonProperty("$class")]\n\tpublic override string _class { get;} = "undefined";']);
+            param.fileWriter.writeLine.getCall(1).args.should.deep.equal([2, '[JsonPropertyName("$class")]\n\t\t[NewtonsoftJson.JsonProperty("$class")]\n\t\tpublic override string _class { get;} = "undefined";']);
             param.fileWriter.writeLine.getCall(2).args.should.deep.equal([1, '}']);
         });
         it('should write the class opening and close with virtual modifier for base class', () => {
@@ -547,7 +559,7 @@ describe('CSharpVisitor', function () {
 
             param.fileWriter.writeLine.callCount.should.deep.equal(3);
             param.fileWriter.writeLine.getCall(0).args.should.deep.equal([1, 'public abstract class Concept {']);
-            param.fileWriter.writeLine.getCall(1).args.should.deep.equal([2, '[JsonPropertyName("$class")]\n\tpublic virtual string _class { get;} = "concerto.Concept";']);
+            param.fileWriter.writeLine.getCall(1).args.should.deep.equal([2, '[JsonPropertyName("$class")]\n\t\tpublic virtual string _class { get;} = "concerto.Concept";']);
             param.fileWriter.writeLine.getCall(2).args.should.deep.equal([1, '}']);
         });
     });
@@ -576,7 +588,7 @@ describe('CSharpVisitor', function () {
             mockField.getType.returns('String');
             mockField.isPrimitive.returns(true);
             csharpVisitor.visitField(mockField, param);
-            param.fileWriter.writeLine.withArgs(2, '[JsonPropertyName("bool")]\n\tpublic string _bool { get; set; }').calledOnce.should.be.ok;
+            param.fileWriter.writeLine.withArgs(2, '[JsonPropertyName("bool")]\n\t\tpublic string _bool { get; set; }').calledOnce.should.be.ok;
         });
 
         it('should write a line for an optional enum field name and type', () => {

--- a/packages/concerto-tools/types/lib/codegen/fromcto/csharp/csharpvisitor.d.ts
+++ b/packages/concerto-tools/types/lib/codegen/fromcto/csharp/csharpvisitor.d.ts
@@ -79,9 +79,10 @@ declare class CSharpVisitor {
      * @param {string} propertyType the Concerto property type
      * @param {string} array the array declaration
      * @param {string} getset the getter and setter declaration
-    * @returns {string} the property declaration
+     * @param {Object} [parameters]  - the parameter
+     * @returns {string} the property declaration
      */
-    toCSharpProperty(access: string, propertyName: string, propertyType: string, array: string, getset: string): string;
+    toCSharpProperty(access: string, propertyName: string, propertyType: string, array: string, getset: string, parameters?: any): string;
     /**
      * Converts a Concerto type to a CSharp type. Primitive types are converted
      * everything else is passed through unchanged.


### PR DESCRIPTION
<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
Extends the C# code generation to:
1. optionally support NewtonsoftJson as a serialization / deserialization library
2. add `useNewtonsoftJson` and `useSystemTextJson` as flags to the `concerto compile` CLI.
3. prefix C# namespaces with `Concerto.Models` to avoid clashes with other packages.
4. make `enum` declarations public
5. switch from `new` modifier to use `virtual`/`override` modifiers for classes. See https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/classes-and-structs/knowing-when-to-use-override-and-new-keywords
6. make Enum fields nullable to prevent C# from making an assumption about a default value
7. escape field names that are reserved keywords in C#

### Related Issues
- This change is used by the new `concerto-dotnet` library, https://github.com/accordproject/concerto-dotnet

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [x] Extend the documentation, if necessary
- [x] Merging to `master` from `fork:branchname`
