### PR TITLE
(fix) CSharp code gen with versioned namespaces

### DIFF
--- a/packages/concerto-core/api.txt
+++ b/packages/concerto-core/api.txt
@@ -79,6 +79,7 @@ class ClassDeclaration extends Decorated {
    + string getName() 
    + string getNamespace() 
    + string getFullyQualifiedName() 
+   + string getEscapedFullyQualifiedName() 
    + Boolean isIdentified() 
    + Boolean isSystemIdentified() 
    + Boolean isExplicitlyIdentified() 

--- a/packages/concerto-core/changelog.txt
+++ b/packages/concerto-core/changelog.txt
@@ -23,7 +23,7 @@
 #
 # Note that the latest public API is documented using JSDocs and is available in api.txt.
 #
-Version 2.3.0 {774980a857090905fe276b6e94f1dbb1} 2022-07-21
+Version 2.3.0 {2fcea15dff01ec08b79e6b71115e84e9} 2022-07-26
 - Versioned namespaces
 
 Version 2.3.0 {28dd70fd922b3b8b491216661796b95b} 2022-06-21

--- a/packages/concerto-core/lib/introspect/classdeclaration.js
+++ b/packages/concerto-core/lib/introspect/classdeclaration.js
@@ -327,6 +327,17 @@ class ClassDeclaration extends Decorated {
     }
 
     /**
+     * Returns the fully qualified name of this class.
+     * The name will include the escaped namespace if present.
+     *
+     * @return {string} the fully-qualified and escaped name of this class
+     */
+    getEscapedFullyQualifiedName() {
+        const { escapedNamespace } = ModelUtil.escapeNamespace(this.getNamespace());
+        return `${escapedNamespace}.${this.getName()}`;
+    }
+
+    /**
      * Returns true if this class declaration declares an identifying field
      * (system or explicit)
      * @returns {Boolean} true if the class declaration includes an identifier

--- a/packages/concerto-core/lib/modelutil.js
+++ b/packages/concerto-core/lib/modelutil.js
@@ -66,12 +66,27 @@ class ModelUtil {
     }
 
     /**
+     * Escapes a namespace string for use in typical source code
+     * @param {string} ns the namespace
+     * @returns {*} an object with the properties from parseNamespace as
+     * well as an escapedNamespace property
+     */
+    static escapeNamespace(ns) {
+        const nsInfo = ModelUtil.parseNamespace(ns);
+        const escapedNamespace = nsInfo.version ? `${nsInfo.name}_${nsInfo.version.replace(/\./g, '_')}` : nsInfo.name;
+        return {
+            escapedNamespace,
+            ...nsInfo
+        };
+    }
+
+    /**
      * Parses a potentially versioned namespace into
      * its name and version parts. The version of the namespace
      * (if present) is parsed using semver.parse.
      * @param {string} ns the namespace to parse
      * @returns {object} the result of parsing: an object with properties: name,
-     * escapedNamespace, version and versionParsed
+     * version and versionParsed
      */
     static parseNamespace(ns) {
         if(!ns) {
@@ -91,7 +106,6 @@ class ModelUtil {
 
         return {
             name: parts[0],
-            escapedNamespace: ns.replace('@', '_'),
             version: parts.length > 1 ? parts[1] : null,
             versionParsed: parts.length > 1 ? semver.parse(parts[1]) : null
         };

--- a/packages/concerto-core/test/modelutil.js
+++ b/packages/concerto-core/test/modelutil.js
@@ -151,15 +151,15 @@ describe('ModelUtil', function () {
 
     describe('#parseNamespace', function() {
         it('valid, no version', function() {
-            const nsInfo = ModelUtil.parseNamespace('org.acme');
+            const nsInfo = ModelUtil.escapeNamespace('org.acme');
             nsInfo.name.should.equal('org.acme');
             nsInfo.escapedNamespace.should.equal('org.acme');
         });
 
         it('valid, with version', function() {
-            const nsInfo = ModelUtil.parseNamespace('org.acme@1.0.0');
+            const nsInfo = ModelUtil.escapeNamespace('org.acme@1.0.0');
             nsInfo.name.should.equal('org.acme');
-            nsInfo.escapedNamespace.should.equal('org.acme_1.0.0');
+            nsInfo.escapedNamespace.should.equal('org.acme_1_0_0');
             nsInfo.version.should.equal('1.0.0');
             nsInfo.versionParsed.major.should.equal(1);
         });

--- a/packages/concerto-core/types/lib/introspect/classdeclaration.d.ts
+++ b/packages/concerto-core/types/lib/introspect/classdeclaration.d.ts
@@ -82,6 +82,13 @@ declare class ClassDeclaration extends Decorated {
      */
     getFullyQualifiedName(): string;
     /**
+     * Returns the fully qualified name of this class.
+     * The name will include the escaped namespace if present.
+     *
+     * @return {string} the fully-qualified and escaped name of this class
+     */
+    getEscapedFullyQualifiedName(): string;
+    /**
      * Returns true if this class declaration declares an identifying field
      * (system or explicit)
      * @returns {Boolean} true if the class declaration includes an identifier

--- a/packages/concerto-core/types/lib/modelutil.d.ts
+++ b/packages/concerto-core/types/lib/modelutil.d.ts
@@ -23,12 +23,19 @@ declare class ModelUtil {
      */
     private static getNamespace;
     /**
+     * Escapes a namespace string for use in typical source code
+     * @param {string} ns the namespace
+     * @returns {*} an object with the properties from parseNamespace as
+     * well as an escapedNamespace property
+     */
+    static escapeNamespace(ns: string): any;
+    /**
      * Parses a potentially versioned namespace into
      * its name and version parts. The version of the namespace
      * (if present) is parsed using semver.parse.
      * @param {string} ns the namespace to parse
      * @returns {object} the result of parsing: an object with properties: name,
-     * escapedNamespace, version and versionParsed
+     * version and versionParsed
      */
     static parseNamespace(ns: string): object;
     /**

--- a/packages/concerto-tools/lib/codegen/fromcto/golang/golangvisitor.js
+++ b/packages/concerto-tools/lib/codegen/fromcto/golang/golangvisitor.js
@@ -97,7 +97,7 @@ class GoLangVisitor {
     visitModelFile(modelFile, parameters) {
         // we put all the code into the main package, but we
         // seperate out into multiple files using the namespaces
-        const { escapedNamespace } = ModelUtil.parseNamespace(modelFile.getNamespace());
+        const { escapedNamespace } = ModelUtil.escapeNamespace(modelFile.getNamespace());
         parameters.fileWriter.openFile(this.toGoPackageName(escapedNamespace) + '.go');
         parameters.fileWriter.writeLine(0, 'package main');
 

--- a/packages/concerto-tools/lib/codegen/fromcto/java/javavisitor.js
+++ b/packages/concerto-tools/lib/codegen/fromcto/java/javavisitor.js
@@ -127,7 +127,7 @@ public abstract class Resource
      * @private
      */
     startClassFile(clazz, parameters) {
-        const { escapedNamespace } = ModelUtil.parseNamespace(clazz.getModelFile().getNamespace());
+        const { escapedNamespace } = ModelUtil.escapeNamespace(clazz.getModelFile().getNamespace());
         parameters.fileWriter.openFile( clazz.getModelFile().getNamespace().replace(/\./g, '/') + '/' + clazz.getName() + '.java');
         parameters.fileWriter.writeLine(0, '// this code is generated and should not be modified');
         parameters.fileWriter.writeLine(0, 'package ' + escapedNamespace + ';');

--- a/packages/concerto-tools/test/codegen/fromcto/csharp/csharpvisitor.js
+++ b/packages/concerto-tools/test/codegen/fromcto/csharp/csharpvisitor.js
@@ -437,6 +437,7 @@ describe('CSharpVisitor', function () {
 
             let mockClassDeclaration = sinon.createStubInstance(ClassDeclaration);
             mockClassDeclaration.isClassDeclaration.returns(true);
+            mockClassDeclaration.getNamespace.returns('org.acme');
             mockClassDeclaration.getOwnProperties.returns([{
                 accept: acceptSpy
             },
@@ -458,6 +459,7 @@ describe('CSharpVisitor', function () {
             let mockClassDeclaration = sinon.createStubInstance(ClassDeclaration);
             let mockClassDeclaration2 = sinon.createStubInstance(ClassDeclaration);
             mockClassDeclaration.isClassDeclaration.returns(true);
+            mockClassDeclaration.getNamespace.returns('org.acme');
             mockClassDeclaration.getOwnProperties.returns([{
                 accept: acceptSpy
             },
@@ -479,6 +481,7 @@ describe('CSharpVisitor', function () {
 
             let mockClassDeclaration = sinon.createStubInstance(ClassDeclaration);
             mockClassDeclaration.isClassDeclaration.returns(true);
+            mockClassDeclaration.getNamespace.returns('org.acme');
             mockClassDeclaration.getOwnProperties.returns([{
                 accept: acceptSpy
             },
@@ -501,6 +504,7 @@ describe('CSharpVisitor', function () {
 
             let mockClassDeclaration = sinon.createStubInstance(ClassDeclaration);
             mockClassDeclaration.isClassDeclaration.returns(true);
+            mockClassDeclaration.getNamespace.returns('org.acme');
             mockClassDeclaration.getOwnProperties.returns([{
                 accept: acceptSpy
             },
@@ -523,6 +527,7 @@ describe('CSharpVisitor', function () {
 
             let mockClassDeclaration = sinon.createStubInstance(ClassDeclaration);
             mockClassDeclaration.isClassDeclaration.returns(true);
+            mockClassDeclaration.getNamespace.returns('org.acme');
             mockClassDeclaration.getOwnProperties.returns([{
                 accept: acceptSpy
             },
@@ -545,6 +550,7 @@ describe('CSharpVisitor', function () {
 
             let mockClassDeclaration = sinon.createStubInstance(ClassDeclaration);
             mockClassDeclaration.isClassDeclaration.returns(true);
+            mockClassDeclaration.getNamespace.returns('concerto');
             mockClassDeclaration.getOwnProperties.returns([{
                 accept: acceptSpy
             },
@@ -554,6 +560,7 @@ describe('CSharpVisitor', function () {
             mockClassDeclaration.getName.returns('Concept');
             mockClassDeclaration.getFullyQualifiedName.returns('concerto.Concept');
             mockClassDeclaration.isAbstract.returns(true);
+            mockClassDeclaration.getEscapedFullyQualifiedName.returns('concerto.Concept');
 
             csharpVisitor.visitClassDeclaration(mockClassDeclaration, param);
 


### PR DESCRIPTION
Signed-off-by: Dan Selman <danscode@selman.org>

# Closes #<CORRESPONDING ISSUE NUMBER>

Fixes the escaping of versioned namespaces.

### Changes
- Improve namespace escaping
- Manual test to ensure that the output from CSharp code generation compiles with .NET compiler

### Flags
<!--- Provide context or concerns a reviewer should be aware of -->
- <ONE>
- <TWO>

### Screenshots or Video
<!--- Provide an easily accessible demonstration of the changes, if applicable -->

### Related Issues
- Issue #<NUMBER>
- Pull Request #<NUMBER>

### Author Checklist
- [ ] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [ ] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ ] Merging to `master` from `fork:branchname`
