### PR TITLE
feat(cli): extend concerto version to update imports (resolves #465)

### DIFF
--- a/packages/concerto-cli/test/models/version-a.cto
+++ b/packages/concerto-cli/test/models/version-a.cto
@@ -1,0 +1,21 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace org.accordproject.concerto.test.a@1.2.3
+
+import { Zoo } from org.accordproject.concerto.test.b@2.3.4
+
+concept Foo {
+    o Zoo zoo
+}

--- a/packages/concerto-cli/test/models/version-b.cto
+++ b/packages/concerto-cli/test/models/version-b.cto
@@ -1,0 +1,21 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace org.accordproject.concerto.test.b@2.3.4
+
+import { Boo } from org.accordproject.concerto.test.c@3.4.5
+
+concept Zoo {
+    o String bar
+}

--- a/packages/concerto-cli/test/models/version-c.cto
+++ b/packages/concerto-cli/test/models/version-c.cto
@@ -1,0 +1,19 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace org.accordproject.concerto.test.c@3.4.5
+
+concept Boo {
+    o String bar
+}


### PR DESCRIPTION
<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #465
<!--- Provide an overall summary of the pull request -->

### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
- Improve `concerto version` command so that it updates the version numbers in any affected `import` statements across the specified set of model files

### Flags
<!--- Provide context or concerns a reviewer should be aware of -->
- CTO model file updating is messy as roundtripping a CTO model through the parser is lossy (whitespace, comments)

### Screenshots or Video
```
% concerto version patch --models ?.cto
09:34:27 - INFO: Updated version of "/Users/Simon.Stone/git/models-registry/features/fixtures/a.cto" from "3.4.5" to "3.4.6"
09:34:27 - INFO: Updated version of "/Users/Simon.Stone/git/models-registry/features/fixtures/b.cto" from "2.3.4" to "2.3.5"
09:34:27 - INFO: Updated version of "/Users/Simon.Stone/git/models-registry/features/fixtures/c.cto" from "1.2.3" to "1.2.4"
```

```
--- a/features/fixtures/a.cto
+++ b/features/fixtures/a.cto
@@ -1,6 +1,6 @@
-namespace com.example.e2e.a@3.4.5
+namespace com.example.e2e.a@3.4.6
 
-import { Ipsum } from com.example.e2e.b@2.3.4
+import { Ipsum } from com.example.e2e.b@2.3.5
```

### Author Checklist
- [ ] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [ ] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ ] Merging to `master` from `fork:branchname`
