### PR TITLE
fix(*): expose model util methods, remove redundant type lookup

### DIFF
--- a/packages/concerto-core/lib/introspect/modelfile.js
+++ b/packages/concerto-core/lib/introspect/modelfile.js
@@ -393,13 +393,7 @@ class ModelFile {
                 }
             }
             else {
-                // check whether type is defined in another file
-                const fqn = this.resolveImport(type);
-                const modelFile = this.getModelManager().getModelFile(ModelUtil.getNamespace(fqn));
-                if (!modelFile) {
-                    return null;
-                }
-                return modelFile.getLocalType(fqn).getFullyQualifiedName();
+                return this.resolveImport(type);
             }
         }
         else {

--- a/packages/concerto-core/lib/modelutil.js
+++ b/packages/concerto-core/lib/modelutil.js
@@ -30,7 +30,6 @@ class ModelUtil {
      * Returns everything after the last dot, if present, of the source string
      * @param {string} fqn - the source string
      * @return {string} - the string after the last dot
-     * @private
      */
     static getShortName(fqn) {
         //console.log('toShortName ' + name );
@@ -49,7 +48,6 @@ class ModelUtil {
      * @param {string} fqn - the fully qualified identifier of a type
      * @return {string} - namespace of the type (everything before the last dot)
      * or the empty string if there is no dot
-     * @private
      */
     static getNamespace(fqn) {
         if (!fqn) {
@@ -66,12 +64,19 @@ class ModelUtil {
     }
 
     /**
+     * @typedef ParseNamespaceResult
+     * @property {string} name the name of the namespace
+     * @property {string} escapedNamespace the escaped namespace
+     * @property {string} version the version of the namespace
+     * @property {object} versionParsed the parsed semantic version of the namespace
+     */
+
+    /**
      * Parses a potentially versioned namespace into
      * its name and version parts. The version of the namespace
      * (if present) is parsed using semver.parse.
      * @param {string} ns the namespace to parse
-     * @returns {object} the result of parsing: an object with properties: name,
-     * escapedNamespace, version and versionParsed
+     * @returns {ParseNamespaceResult} the result of parsing
      */
     static parseNamespace(ns) {
         if(!ns) {

--- a/packages/concerto-core/types/lib/introspect/modelfile.d.ts
+++ b/packages/concerto-core/types/lib/introspect/modelfile.d.ts
@@ -28,7 +28,7 @@ declare class ModelFile {
     importUriMap: {};
     fileName: string;
     concertoVersion: any;
-    version: any;
+    version: string;
     ast: any;
     definitions: string;
     /**

--- a/packages/concerto-core/types/lib/modelutil.d.ts
+++ b/packages/concerto-core/types/lib/modelutil.d.ts
@@ -11,26 +11,47 @@ declare class ModelUtil {
      * Returns everything after the last dot, if present, of the source string
      * @param {string} fqn - the source string
      * @return {string} - the string after the last dot
-     * @private
      */
-    private static getShortName;
+    static getShortName(fqn: string): string;
     /**
      * Returns the namespace for a the fully qualified name of a type
      * @param {string} fqn - the fully qualified identifier of a type
      * @return {string} - namespace of the type (everything before the last dot)
      * or the empty string if there is no dot
-     * @private
      */
-    private static getNamespace;
+    static getNamespace(fqn: string): string;
+    /**
+     * @typedef ParseNamespaceResult
+     * @property {string} name the name of the namespace
+     * @property {string} escapedNamespace the escaped namespace
+     * @property {string} version the version of the namespace
+     * @property {object} versionParsed the parsed semantic version of the namespace
+     */
     /**
      * Parses a potentially versioned namespace into
      * its name and version parts. The version of the namespace
      * (if present) is parsed using semver.parse.
      * @param {string} ns the namespace to parse
-     * @returns {object} the result of parsing: an object with properties: name,
-     * escapedNamespace, version and versionParsed
+     * @returns {ParseNamespaceResult} the result of parsing
      */
-    static parseNamespace(ns: string): object;
+    static parseNamespace(ns: string): {
+        /**
+         * the name of the namespace
+         */
+        name: string;
+        /**
+         * the escaped namespace
+         */
+        escapedNamespace: string;
+        /**
+         * the version of the namespace
+         */
+        version: string;
+        /**
+         * the parsed semantic version of the namespace
+         */
+        versionParsed: object;
+    };
     /**
      * Return the fully qualified name for an import
      * @param {object} imp - the import


### PR DESCRIPTION
<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
<!--- Provide an overall summary of the pull request -->

### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
- Expose certain `ModelUtil` methods and correct the TypeScript types for `parseNamespace`
- Remove a seemingly redundant codepath from `ModelFile.getFullyQualifiedTypeName`

### Author Checklist
- [ ] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [ ] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ ] Merging to `master` from `fork:branchname`
