### PR TITLE
chore(*): bump version to v3.0.0

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,6 +2,6 @@
   "packages": [
     "packages/*"
   ],
-  "version": "2.3.0",
+  "version": "3.0.0",
   "hoist": true
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "concerto",
-	"version": "2.3.0",
+	"version": "3.0.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "concerto",
-			"version": "2.3.0",
+			"version": "3.0.0",
 			"dependencies": {
 				"@babel/preset-env": "7.16.11",
 				"@supercharge/promise-pool": "1.7.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "name": "concerto",
   "description": "You must install [Lerna](https://lernajs.io) to build this multi-package repository.",
-  "version": "2.3.0",
+  "version": "3.0.0",
   "private": true,
   "scripts": {
     "coverage": "node ./scripts/coverage.js \"packages/concerto-*\" && nyc report -t coverage --cwd . --report-dir coverage --reporter=lcov && cat ./coverage/lcov.info",

--- a/packages/concerto-cli/package.json
+++ b/packages/concerto-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@accordproject/concerto-cli",
-  "version": "2.3.0",
+  "version": "3.0.0",
   "description": "Command-line utility for working with Concerto model files",
   "homepage": "https://github.com/accordproject/concerto",
   "license": "Apache-2.0",
@@ -43,11 +43,11 @@
     "tmp-promise": "3.0.2"
   },
   "dependencies": {
-    "@accordproject/concerto-core": "2.3.0",
-    "@accordproject/concerto-cto": "2.3.0",
-    "@accordproject/concerto-metamodel": "2.3.0",
-    "@accordproject/concerto-tools": "2.3.0",
-    "@accordproject/concerto-util": "2.3.0",
+    "@accordproject/concerto-core": "3.0.0",
+    "@accordproject/concerto-cto": "3.0.0",
+    "@accordproject/concerto-metamodel": "3.0.0",
+    "@accordproject/concerto-tools": "3.0.0",
+    "@accordproject/concerto-util": "3.0.0",
     "glob": "7.2.0",
     "mkdirp": "1.0.4",
     "semver": "7.3.5",

--- a/packages/concerto-core/package.json
+++ b/packages/concerto-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@accordproject/concerto-core",
-  "version": "2.3.0",
+  "version": "3.0.0",
   "description": "Core Implementation for the Concerto Modeling Language",
   "homepage": "https://github.com/accordproject/concerto",
   "engines": {
@@ -65,9 +65,9 @@
     "yargs": "17.3.1"
   },
   "dependencies": {
-    "@accordproject/concerto-cto": "2.3.0",
-    "@accordproject/concerto-metamodel": "2.3.0",
-    "@accordproject/concerto-util": "2.3.0",
+    "@accordproject/concerto-cto": "3.0.0",
+    "@accordproject/concerto-metamodel": "3.0.0",
+    "@accordproject/concerto-util": "3.0.0",
     "dayjs": "1.10.8",
     "debug": "4.3.1",
     "lorem-ipsum": "2.0.3",

--- a/packages/concerto-cto/package.json
+++ b/packages/concerto-cto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@accordproject/concerto-cto",
-  "version": "2.3.0",
+  "version": "3.0.0",
   "description": "Parser for Concerto CTO files",
   "homepage": "https://github.com/accordproject/concerto",
   "engines": {
@@ -53,8 +53,8 @@
     "typescript": "4.6.3"
   },
   "dependencies": {
-    "@accordproject/concerto-metamodel": "2.3.0",
-    "@accordproject/concerto-util": "2.3.0"
+    "@accordproject/concerto-metamodel": "3.0.0",
+    "@accordproject/concerto-util": "3.0.0"
   },
   "browserslist": "> 0.25%, not dead",
   "license-check-and-add-config": {

--- a/packages/concerto-metamodel/package.json
+++ b/packages/concerto-metamodel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@accordproject/concerto-metamodel",
-  "version": "2.3.0",
+  "version": "3.0.0",
   "description": "Concerto metamodel utilities",
   "homepage": "https://github.com/accordproject/concerto",
   "engines": {
@@ -50,7 +50,7 @@
     "typescript": "4.6.3"
   },
   "dependencies": {
-    "@accordproject/concerto-util": "2.3.0"
+    "@accordproject/concerto-util": "3.0.0"
   },
   "browserslist": "> 0.25%, not dead",
   "license-check-and-add-config": {

--- a/packages/concerto-tools/package.json
+++ b/packages/concerto-tools/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@accordproject/concerto-tools",
-    "version": "2.3.0",
+    "version": "3.0.0",
     "description": "Tools for the Concerto Modeling Language",
     "homepage": "https://github.com/accordproject/concerto",
     "engines": {
@@ -58,8 +58,8 @@
         "webpack-cli": "4.9.1"
     },
     "dependencies": {
-        "@accordproject/concerto-core": "2.3.0",
-        "@accordproject/concerto-util": "2.3.0",
+        "@accordproject/concerto-core": "3.0.0",
+        "@accordproject/concerto-util": "3.0.0",
         "ajv": "8.10.0",
         "ajv-formats": "2.1.1",
         "debug": "4.3.1",

--- a/packages/concerto-types/package.json
+++ b/packages/concerto-types/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@accordproject/concerto-types",
-    "version": "2.3.0",
+    "version": "3.0.0",
     "description": "Types for the Concerto Modeling Language",
     "homepage": "https://github.com/accordproject/concerto",
     "engines": {
@@ -32,10 +32,10 @@
     "author": "accordproject.org",
     "license": "Apache-2.0",
     "devDependencies": {
-        "@accordproject/concerto-core": "2.3.0",
-        "@accordproject/concerto-metamodel": "2.3.0",
-        "@accordproject/concerto-tools": "2.3.0",
-        "@accordproject/concerto-util": "2.3.0",
+        "@accordproject/concerto-core": "3.0.0",
+        "@accordproject/concerto-metamodel": "3.0.0",
+        "@accordproject/concerto-tools": "3.0.0",
+        "@accordproject/concerto-util": "3.0.0",
         "eslint": "8.2.0",
         "license-check-and-add": "2.3.6",
         "npm-run-all": "4.1.5",

--- a/packages/concerto-util/package-lock.json
+++ b/packages/concerto-util/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@accordproject/concerto-util",
-  "version": "2.3.0",
+  "version": "3.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/packages/concerto-util/package.json
+++ b/packages/concerto-util/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@accordproject/concerto-util",
-  "version": "2.3.0",
+  "version": "3.0.0",
   "description": "Utilities for Concerto Modeling Language",
   "homepage": "https://github.com/accordproject/concerto",
   "engines": {

--- a/packages/concerto-vocabulary/package-lock.json
+++ b/packages/concerto-vocabulary/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@accordproject/concerto-vocabulary",
-  "version": "2.3.0",
+  "version": "3.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/packages/concerto-vocabulary/package.json
+++ b/packages/concerto-vocabulary/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@accordproject/concerto-vocabulary",
-  "version": "2.3.0",
+  "version": "3.0.0",
   "description": "Associate human-readable text to model declarations",
   "homepage": "https://github.com/accordproject/concerto",
   "engines": {
@@ -49,8 +49,8 @@
     "typescript": "4.6.3"
   },
   "dependencies": {
-    "yaml": "2.0.0-9",
-    "@accordproject/concerto-metamodel": "2.3.0"
+    "@accordproject/concerto-metamodel": "3.0.0",
+    "yaml": "2.0.0-9"
   },
   "browserslist": "> 0.25%, not dead",
   "license-check-and-add-config": {


### PR DESCRIPTION
As discussed on the Technical Working Group call today, we should bump the development version to v3.0.0 to kickstart the v3.x release process and allow breaking changes to go in. 