### PR TITLE
(chore) remove mkdirp dep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,6 @@
 				"json-colorizer": "2.2.2",
 				"klaw": "3.0.0",
 				"lorem-ipsum": "2.0.3",
-				"mkdirp": "1.0.4",
 				"mocha": "8.3.2",
 				"mockery": "2.1.0",
 				"moxios": "0.4.0",
@@ -9637,6 +9636,7 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
 			"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+			"dev": true,
 			"bin": {
 				"mkdirp": "bin/cmd.js"
 			},
@@ -21448,7 +21448,8 @@
 		"mkdirp": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-			"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
+			"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+			"dev": true
 		},
 		"mkdirp-infer-owner": {
 			"version": "2.0.0",

--- a/packages/concerto-cli/lib/commands.js
+++ b/packages/concerto-cli/lib/commands.js
@@ -16,7 +16,6 @@
 
 const fs = require('fs');
 const path = require('path');
-const mkdirp = require('mkdirp');
 const semver = require('semver');
 
 const Logger = require('@accordproject/concerto-util').Logger;
@@ -204,7 +203,7 @@ class Commands {
      */
     static async get(ctoFiles, output) {
         const modelManager = await ModelLoader.loadModelManager(ctoFiles);
-        mkdirp.sync(output);
+        fs.mkdirSync(path.dirname(output), {recursive:true});
         modelManager.writeModelsToFileSystem(output);
         return `Loaded external models in '${output}'.`;
     }

--- a/packages/concerto-cli/package.json
+++ b/packages/concerto-cli/package.json
@@ -49,7 +49,6 @@
     "@accordproject/concerto-tools": "3.0.0-alpha.1",
     "@accordproject/concerto-util": "3.0.0-alpha.1",
     "glob": "7.2.0",
-    "mkdirp": "1.0.4",
     "semver": "7.3.5",
     "yargs": "17.3.1"
   },

--- a/packages/concerto-tools/package.json
+++ b/packages/concerto-tools/package.json
@@ -62,8 +62,7 @@
         "@accordproject/concerto-util": "3.0.0-alpha.1",
         "ajv": "8.10.0",
         "ajv-formats": "2.1.1",
-        "debug": "4.3.1",
-        "mkdirp": "1.0.4"
+        "debug": "4.3.1"
     },
     "license-check-and-add-config": {
         "folder": "./lib",

--- a/packages/concerto-util/lib/filewriter.js
+++ b/packages/concerto-util/lib/filewriter.js
@@ -15,7 +15,6 @@
 'use strict';
 
 const fs = require('fs');
-const mkdirp = require('mkdirp');
 const path = require('path');
 
 const Writer = require('./writer');
@@ -44,7 +43,7 @@ class FileWriter extends Writer {
         this.outputDirectory = outputDirectory;
         this.relativeDir = null;
         this.fileName = null;
-        mkdirp.sync(outputDirectory);
+        fs.mkdirSync(outputDirectory, {recursive:true});
     }
 
     /**
@@ -111,7 +110,7 @@ class FileWriter extends Writer {
         filePath = path.resolve(filePath, this.fileName);
 
         //console.log('Writing to ' + filePath );
-        mkdirp.sync(path.dirname(filePath));
+        fs.mkdirSync(path.dirname(filePath), {recursive:true});
         fs.writeFileSync(filePath, this.getBuffer());
 
         this.fileName = null;

--- a/packages/concerto-util/package.json
+++ b/packages/concerto-util/package.json
@@ -53,8 +53,7 @@
     "axios": "0.23.0",
     "colors": "1.4.0",
     "debug": "4.3.1",
-    "json-colorizer": "2.2.2",
-    "mkdirp": "1.0.4"
+    "json-colorizer": "2.2.2"
   },
   "browserslist": "> 0.25%, not dead",
   "license-check-and-add-config": {
@@ -65,7 +64,6 @@
       "api.txt",
       "composer-logs",
       "coverage",
-      "./parser.js",
       "LICENSE",
       "node_modules",
       ".nyc-output",
@@ -109,9 +107,6 @@
     ],
     "include": [
       "lib/**/*.js"
-    ],
-    "exclude": [
-      "lib/parser.js"
     ],
     "all": true,
     "check-coverage": true,

--- a/packages/concerto-util/test/filewriter.js
+++ b/packages/concerto-util/test/filewriter.js
@@ -21,7 +21,6 @@ chai.use(require('chai-things'));
 const sinon = require('sinon');
 
 const fs = require('fs');
-const mkdirp = require('mkdirp');
 const path = require('path');
 
 const Writer = require('../lib/writer');
@@ -41,7 +40,7 @@ describe('FileWriter', function () {
 
     describe('#constructor', function () {
         it('main code path', function () {
-            let syncStub = sandbox.stub(mkdirp, 'sync');
+            let syncStub = sandbox.stub(fs, 'mkdirSync');
             syncStub.returns();
 
             let fileWriter = new FileWriter('dir');
@@ -142,7 +141,7 @@ describe('FileWriter', function () {
             let fsWriteFileSyncStub = sandbox.stub(fs, 'writeFileSync');
             fsWriteFileSyncStub.returns();
 
-            let syncStub = sandbox.stub(mkdirp, 'sync');
+            let syncStub = sandbox.stub(fs, 'mkdirSync');
             syncStub.returns();
 
             let superClearBuffer = sandbox.stub(Writer.prototype, 'clearBuffer');
@@ -180,7 +179,7 @@ describe('FileWriter', function () {
             let fsWriteFileSyncStub = sandbox.stub(fs, 'writeFileSync');
             fsWriteFileSyncStub.returns();
 
-            let syncStub = sandbox.stub(mkdirp, 'sync');
+            let syncStub = sandbox.stub(fs, 'mkdirSync');
             syncStub.returns();
 
             let superClearBuffer = sandbox.stub(Writer.prototype, 'clearBuffer');


### PR DESCRIPTION
Signed-off-by: Dan Selman <danscode@selman.org>

Removes the usage of the `mkdirp` module to recursively create directories, replacing it with `fs.mkdirSync(path, {recursive:true})`

### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
- <ONE>
- <TWO>

### Flags
<!--- Provide context or concerns a reviewer should be aware of -->
- <ONE>
- <TWO>

### Screenshots or Video
<!--- Provide an easily accessible demonstration of the changes, if applicable -->

### Related Issues
- Issue #<NUMBER>
- Pull Request #<NUMBER>

### Author Checklist
- [ ] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [ ] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ ] Merging to `master` from `fork:branchname`
