### PR TITLE
fix(*): use webpack version for browsers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
 				"@babel/preset-env": "7.16.11",
 				"@supercharge/promise-pool": "1.7.0",
 				"@types/jest": "28.1.1",
+				"@types/semver": "7.3.10",
 				"@typescript-eslint/eslint-plugin": "5.27.1",
 				"@typescript-eslint/parser": "5.27.1",
 				"acorn": "8.5.0",
@@ -4865,6 +4866,11 @@
 			"version": "2.7.0",
 			"resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.0.tgz",
 			"integrity": "sha512-RI1L7N4JnW5gQw2spvL7Sllfuf1SaHdrZpCHiBlCXjIlufi1SMNnbu2teze3/QE67Fg2tBlH7W+mi4hVNk4p0A=="
+		},
+		"node_modules/@types/semver": {
+			"version": "7.3.10",
+			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.10.tgz",
+			"integrity": "sha512-zsv3fsC7S84NN6nPK06u79oWgrPVd0NvOyqgghV1haPaFcVxIrP4DLomRwGAXk0ui4HZA7mOcSFL98sMVW9viw=="
 		},
 		"node_modules/@types/stack-utils": {
 			"version": "2.0.1",
@@ -22215,6 +22221,11 @@
 			"version": "2.7.0",
 			"resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.0.tgz",
 			"integrity": "sha512-RI1L7N4JnW5gQw2spvL7Sllfuf1SaHdrZpCHiBlCXjIlufi1SMNnbu2teze3/QE67Fg2tBlH7W+mi4hVNk4p0A=="
+		},
+		"@types/semver": {
+			"version": "7.3.10",
+			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.10.tgz",
+			"integrity": "sha512-zsv3fsC7S84NN6nPK06u79oWgrPVd0NvOyqgghV1haPaFcVxIrP4DLomRwGAXk0ui4HZA7mOcSFL98sMVW9viw=="
 		},
 		"@types/stack-utils": {
 			"version": "2.0.1",

--- a/packages/concerto-core/package.json
+++ b/packages/concerto-core/package.json
@@ -7,7 +7,8 @@
     "node": ">=14",
     "npm": ">=6"
   },
-  "main": "dist/concerto-core.js",
+  "main": "index.js",
+  "browser": "dist/concerto-core.js",
   "typings": "types/index.d.ts",
   "scripts": {
     "prepublishOnly": "webpack --config webpack.config.js --mode production",

--- a/packages/concerto-cto/package.json
+++ b/packages/concerto-cto/package.json
@@ -7,7 +7,8 @@
     "node": ">=14",
     "npm": ">=6"
   },
-  "main": "dist/concerto-cto.js",
+  "main": "index.js",
+  "browser": "dist/concerto-cto.js",
   "typings": "types/index.d.ts",
   "scripts": {
     "prepublishOnly": "webpack --config webpack.config.js --mode production",

--- a/packages/concerto-tools/package.json
+++ b/packages/concerto-tools/package.json
@@ -8,6 +8,7 @@
         "npm": ">=6"
     },
     "main": "index.js",
+    "browser": "dist/concerto-tools.js",
     "typings": "types/index.d.ts",
     "scripts": {
         "prepublishOnly": "webpack --config webpack.config.js --mode production",

--- a/packages/concerto-util/package.json
+++ b/packages/concerto-util/package.json
@@ -7,7 +7,8 @@
     "node": ">=14",
     "npm": ">=6"
   },
-  "main": "dist/concerto-util.js",
+  "main": "index.js",
+  "browser": "dist/concerto-util.js",
   "typings": "types/index.d.ts",
   "scripts": {
     "prepublishOnly": "webpack --config webpack.config.js --mode production",


### PR DESCRIPTION
The Concerto modules cannot currently be used in a Node.js application:

```
{"$class":"concerto.metamodel@1.0.0.TypeIdentifier","name":"Model"},"isArray":true,"isOptional":false}]}]}')}},t={},function r(n){var o=t[n];if(void 0!==o)return o.exports;var u=t[n]={exports:{}};return e[n](u,u.exports,r),u.exports}(10);var e,t}));
                                                                                                                                                                                                                   ^

ReferenceError: self is not defined
    at Object.<anonymous> (/home/jenkins/workspace/models-registry_PR-111/node_modules/@accordproject/concerto-cto/dist/concerto-cto.js:2:212)
    at Module._compile (node:internal/modules/cjs/loader:1105:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1159:10)
    at Module.load (node:internal/modules/cjs/loader:981:32)
    at Function.Module._load (node:internal/modules/cjs/loader:822:12)
    at Module.require (node:internal/modules/cjs/loader:1005:19)
    at require (node:internal/modules/cjs/helpers:102:18)
    at Object.<anonymous> (/home/jenkins/workspace/models-registry_PR-111/fixtures.js:1:20)
    at Module._compile (node:internal/modules/cjs/loader:1105:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1159:10)
```

This change updates our `package.json` files to use the Webpack'ed versions of the code for browsers only, and restores the original value of the `main` property for Node.js and other runtimes.