### PR TITLE
feat(*): extend concerto compare to include field validators

### DIFF
--- a/packages/concerto-analysis/src/compare-config.ts
+++ b/packages/concerto-analysis/src/compare-config.ts
@@ -57,5 +57,8 @@ export const defaultCompareConfig: CompareConfig = {
         'enum-value-added': CompareResult.PATCH,
         'enum-value-removed': CompareResult.MAJOR,
         'property-type-changed': CompareResult.MAJOR,
+        'property-validator-added': CompareResult.MAJOR,
+        'property-validator-removed': CompareResult.PATCH,
+        'property-validator-changed': CompareResult.MAJOR,
     }
 };

--- a/packages/concerto-analysis/src/compare-utils.ts
+++ b/packages/concerto-analysis/src/compare-utils.ts
@@ -12,7 +12,7 @@
  * limitations under the License.
  */
 
-import { ClassDeclaration, EnumValueDeclaration, Field, Property, RelationshipDeclaration } from '@accordproject/concerto-core';
+import { ClassDeclaration, EnumValueDeclaration, Field, NumberValidator, Property, RelationshipDeclaration, StringValidator, Validator } from '@accordproject/concerto-core';
 
 export function getClassDeclarationType(classDeclaration: ClassDeclaration) {
     if (classDeclaration.isAsset()) {
@@ -41,5 +41,15 @@ export function getPropertyType(property: Property) {
         return 'enum value';
     } else {
         throw new Error(`unknown property type "${property}"`);
+    }
+}
+
+export function getValidatorType(validator: Validator) {
+    if (validator instanceof NumberValidator) {
+        return 'number';
+    } else if (validator instanceof StringValidator) {
+        return 'string';
+    } else {
+        throw new Error(`unknown validator type "${validator}"`);
     }
 }

--- a/packages/concerto-analysis/test/fixtures/identical.cto
+++ b/packages/concerto-analysis/test/fixtures/identical.cto
@@ -5,5 +5,8 @@ import { OtherThing } from org.accordproject.concerto.test.other@2.3.4
 concept Thing {
     o String value
     o String otherValue optional
+    o String regexValue regex=/foo/
+    o Integer number
+    o Integer rangeNumber range=[0,0]
     o OtherThing otherThing
 }

--- a/packages/concerto-analysis/test/fixtures/number-validator-added.cto
+++ b/packages/concerto-analysis/test/fixtures/number-validator-added.cto
@@ -1,0 +1,6 @@
+namespace org.accordproject.concerto.test@1.2.3
+
+concept Thing {
+    o Integer number range=[-1,1]
+    o String string
+}

--- a/packages/concerto-analysis/test/fixtures/number-validator-changed-lowercompat.cto
+++ b/packages/concerto-analysis/test/fixtures/number-validator-changed-lowercompat.cto
@@ -1,0 +1,6 @@
+namespace org.accordproject.concerto.test@1.2.3
+
+concept Thing {
+    o Integer number range=[-2,1]
+    o String string
+}

--- a/packages/concerto-analysis/test/fixtures/number-validator-changed-lowerincompat.cto
+++ b/packages/concerto-analysis/test/fixtures/number-validator-changed-lowerincompat.cto
@@ -1,0 +1,6 @@
+namespace org.accordproject.concerto.test@1.2.3
+
+concept Thing {
+    o Integer number range=[0,1]
+    o String string
+}

--- a/packages/concerto-analysis/test/fixtures/number-validator-changed-uppercompat.cto
+++ b/packages/concerto-analysis/test/fixtures/number-validator-changed-uppercompat.cto
@@ -1,0 +1,6 @@
+namespace org.accordproject.concerto.test@1.2.3
+
+concept Thing {
+    o Integer number range=[-1,2]
+    o String string
+}

--- a/packages/concerto-analysis/test/fixtures/number-validator-changed-upperincompat.cto
+++ b/packages/concerto-analysis/test/fixtures/number-validator-changed-upperincompat.cto
@@ -1,0 +1,6 @@
+namespace org.accordproject.concerto.test@1.2.3
+
+concept Thing {
+    o Integer number range=[-1,0]
+    o String string
+}

--- a/packages/concerto-analysis/test/fixtures/string-validator-added.cto
+++ b/packages/concerto-analysis/test/fixtures/string-validator-added.cto
@@ -1,0 +1,6 @@
+namespace org.accordproject.concerto.test@1.2.3
+
+concept Thing {
+    o Integer number
+    o String string regex=/foo/
+}

--- a/packages/concerto-analysis/test/fixtures/string-validator-changed.cto
+++ b/packages/concerto-analysis/test/fixtures/string-validator-changed.cto
@@ -1,0 +1,6 @@
+namespace org.accordproject.concerto.test@1.2.3
+
+concept Thing {
+    o Integer number
+    o String string regex=/bar/
+}

--- a/packages/concerto-analysis/test/fixtures/validators.cto
+++ b/packages/concerto-analysis/test/fixtures/validators.cto
@@ -1,0 +1,6 @@
+namespace org.accordproject.concerto.test@1.2.3
+
+concept Thing {
+    o Integer number
+    o String string
+}

--- a/packages/concerto-analysis/test/unit/compare.test.ts
+++ b/packages/concerto-analysis/test/unit/compare.test.ts
@@ -274,3 +274,101 @@ test('should detect a declaration typed field namespace major version change', a
     ]));
     expect(results.result).toBe(CompareResult.MAJOR);
 });
+
+test('should detect a number validator being added to a property', async () => {
+    const [a, b] = await getModelFiles('validators.cto', 'number-validator-added.cto');
+    const results = new Compare().compare(a, b);
+    expect(results.findings).toEqual(expect.arrayContaining([
+        expect.objectContaining({
+            key: 'property-validator-added',
+            message: 'A number validator was added to the field "number" in the concept "Thing"'
+        })
+    ]));
+    expect(results.result).toBe(CompareResult.MAJOR);
+});
+
+test('should detect a number validator being removed from a property', async () => {
+    const [a, b] = await getModelFiles('number-validator-added.cto', 'validators.cto');
+    const results = new Compare().compare(a, b);
+    expect(results.findings).toEqual(expect.arrayContaining([
+        expect.objectContaining({
+            key: 'property-validator-removed',
+            message: 'A number validator was removed from the field "number" in the concept "Thing"'
+        })
+    ]));
+    expect(results.result).toBe(CompareResult.PATCH);
+});
+
+test('should not detect a number validator being changed on a property (compatible lower bound)', async () => {
+    const [a, b] = await getModelFiles('number-validator-added.cto', 'number-validator-changed-lowercompat.cto');
+    const results = new Compare().compare(a, b);
+    expect(results.findings).toEqual([]);
+    expect(results.result).toBe(CompareResult.NONE);
+});
+
+test('should detect a number validator being changed on a property (incompatible lower bound)', async () => {
+    const [a, b] = await getModelFiles('number-validator-added.cto', 'number-validator-changed-lowerincompat.cto');
+    const results = new Compare().compare(a, b);
+    expect(results.findings).toEqual(expect.arrayContaining([
+        expect.objectContaining({
+            key: 'property-validator-changed',
+            message: 'A number validator for the field "number" in the concept "Thing" was changed and is no longer compatible'
+        })
+    ]));
+    expect(results.result).toBe(CompareResult.MAJOR);
+});
+
+test('should not detect a number validator being changed on a property (compatible upper bound)', async () => {
+    const [a, b] = await getModelFiles('number-validator-added.cto', 'number-validator-changed-uppercompat.cto');
+    const results = new Compare().compare(a, b);
+    expect(results.findings).toEqual([]);
+    expect(results.result).toBe(CompareResult.NONE);
+});
+
+test('should detect a number validator being changed on a property (incompatible upper bound)', async () => {
+    const [a, b] = await getModelFiles('number-validator-added.cto', 'number-validator-changed-upperincompat.cto');
+    const results = new Compare().compare(a, b);
+    expect(results.findings).toEqual(expect.arrayContaining([
+        expect.objectContaining({
+            key: 'property-validator-changed',
+            message: 'A number validator for the field "number" in the concept "Thing" was changed and is no longer compatible'
+        })
+    ]));
+    expect(results.result).toBe(CompareResult.MAJOR);
+});
+
+test('should detect a string validator being added to a property', async () => {
+    const [a, b] = await getModelFiles('validators.cto', 'string-validator-added.cto');
+    const results = new Compare().compare(a, b);
+    expect(results.findings).toEqual(expect.arrayContaining([
+        expect.objectContaining({
+            key: 'property-validator-added',
+            message: 'A string validator was added to the field "string" in the concept "Thing"'
+        })
+    ]));
+    expect(results.result).toBe(CompareResult.MAJOR);
+});
+
+test('should detect a string validator being removed from a property', async () => {
+    const [a, b] = await getModelFiles('string-validator-added.cto', 'validators.cto');
+    const results = new Compare().compare(a, b);
+    expect(results.findings).toEqual(expect.arrayContaining([
+        expect.objectContaining({
+            key: 'property-validator-removed',
+            message: 'A string validator was removed from the field "string" in the concept "Thing"'
+        })
+    ]));
+    expect(results.result).toBe(CompareResult.PATCH);
+});
+
+test('should detect a string validator being changed on a property', async () => {
+    const [a, b] = await getModelFiles('string-validator-added.cto', 'string-validator-changed.cto');
+    const results = new Compare().compare(a, b);
+    expect(results.findings).toEqual(expect.arrayContaining([
+        expect.objectContaining({
+            key: 'property-validator-changed',
+            message: 'A string validator for the field "string" in the concept "Thing" was changed and is no longer compatible'
+        })
+    ]));
+    expect(results.result).toBe(CompareResult.MAJOR);
+});

--- a/packages/concerto-core/index.js
+++ b/packages/concerto-core/index.js
@@ -46,6 +46,11 @@ const Field = require('./lib/introspect/field');
 const EnumDeclaration = require('./lib/introspect/enumdeclaration');
 const RelationshipDeclaration = require('./lib/introspect/relationshipdeclaration');
 
+// Validators
+const Validator = require('./lib/introspect/validator');
+const NumberValidator = require('./lib/introspect/numbervalidator');
+const StringValidator = require('./lib/introspect/stringvalidator');
+
 // Typed
 const Typed = require('./lib/model/typed');
 
@@ -113,6 +118,9 @@ module.exports = {
     Field,
     EnumDeclaration,
     RelationshipDeclaration,
+    Validator,
+    NumberValidator,
+    StringValidator,
     Typed,
     Identifiable,
     Relationship,

--- a/packages/concerto-core/lib/introspect/field.js
+++ b/packages/concerto-core/lib/introspect/field.js
@@ -23,6 +23,7 @@ const StringValidator = require('./stringvalidator');
 /* istanbul ignore next */
 if (global === undefined) {
     const ClassDeclaration = require('./classdeclaration');
+    const Validator = require('./validator');
 }
 /* eslint-enable no-unused-vars */
 
@@ -81,7 +82,7 @@ class Field extends Property {
 
     /**
      * Returns the validator string for this field
-     * @return {string} the validator for the field or null
+     * @return {Validator} the validator for the field or null
      */
     getValidator() {
         return this.validator;

--- a/packages/concerto-core/lib/introspect/numbervalidator.js
+++ b/packages/concerto-core/lib/introspect/numbervalidator.js
@@ -14,6 +14,7 @@
 
 'use strict';
 
+const { isNull } = require('../util');
 const Validator = require('./validator');
 
 // Types needed for TypeScript generation.
@@ -106,6 +107,39 @@ class NumberValidator extends Validator{
      */
     toString() {
         return 'NumberValidator lower: ' + this.lowerBound + ' upper: ' + this.upperBound;
+    }
+
+    /**
+     * Determine if the validator is compatible with another validator. For the
+     * validators to be compatible, all values accepted by this validator must
+     * be accepted by the other validator.
+     * @param {Validator} other the other validator.
+     * @returns {boolean} True if this validator is compatible with the other
+     * validator, false otherwise.
+     */
+    compatibleWith(other) {
+        if (!(other instanceof NumberValidator)) {
+            return false;
+        }
+        const thisLowerBound = this.getLowerBound();
+        const otherLowerBound = other.getLowerBound();
+        if (isNull(thisLowerBound) && !isNull(otherLowerBound)) {
+            return false;
+        } else if (!isNull(thisLowerBound) && !isNull(otherLowerBound)) {
+            if (thisLowerBound < otherLowerBound) {
+                return false;
+            }
+        }
+        const thisUpperBound = this.getUpperBound();
+        const otherUpperBound = other.getUpperBound();
+        if (isNull(thisUpperBound) && !isNull(otherUpperBound)) {
+            return false;
+        } else if (!isNull(thisUpperBound) && !isNull(otherUpperBound)) {
+            if (thisUpperBound > otherUpperBound) {
+                return false;
+            }
+        }
+        return true;
     }
 }
 

--- a/packages/concerto-core/lib/introspect/stringvalidator.js
+++ b/packages/concerto-core/lib/introspect/stringvalidator.js
@@ -76,6 +76,26 @@ class StringValidator extends Validator{
     getRegex() {
         return this.regex;
     }
+
+    /**
+     * Determine if the validator is compatible with another validator. For the
+     * validators to be compatible, all values accepted by this validator must
+     * be accepted by the other validator.
+     * @param {Validator} other the other validator.
+     * @returns {boolean} True if this validator is compatible with the other
+     * validator, false otherwise.
+     */
+    compatibleWith(other) {
+        if (!(other instanceof StringValidator)) {
+            return false;
+        } else if (this.validator.pattern !== other.validator.pattern) {
+            return false;
+        } else if (this.validator.flags !== other.validator.flags) {
+            return false;
+        } else {
+            return true;
+        }
+    }
 }
 
 module.exports = StringValidator;

--- a/packages/concerto-core/lib/introspect/validator.js
+++ b/packages/concerto-core/lib/introspect/validator.js
@@ -80,6 +80,18 @@ class Validator {
      */
     validate(identifier, value) {
     }
+
+    /**
+     * Determine if the validator is compatible with another validator. For the
+     * validators to be compatible, all values accepted by this validator must
+     * be accepted by the other validator.
+     * @param {Validator} other the other validator.
+     * @returns {boolean} True if this validator is compatible with the other
+     * validator, false otherwise.
+     */
+    compatibleWith(other) {
+        return false;
+    }
 }
 
 module.exports = Validator;

--- a/packages/concerto-core/test/introspect/numbervalidator.js
+++ b/packages/concerto-core/test/introspect/numbervalidator.js
@@ -21,6 +21,7 @@ require('chai').should();
 const chai = require('chai'), should = chai.should();
 
 const sinon = require('sinon');
+const StringValidator = require('../../lib/introspect/stringvalidator');
 
 describe('NumberValidator', () => {
 
@@ -127,6 +128,49 @@ describe('NumberValidator', () => {
         it('should return the correct string', () => {
             let v = new NumberValidator(mockField, VALID_UPPER_AND_LOWER_BOUND_AST);
             v.toString().should.equal(`NumberValidator lower: ${VALID_UPPER_AND_LOWER_BOUND_AST.lower} upper: ${VALID_UPPER_AND_LOWER_BOUND_AST.upper}`);
+        });
+    });
+
+    describe('#compatibleWith', () => {
+        it('should return false for a string validator', () => {
+            const other = new StringValidator(mockField, { pattern: 'foo' });
+            const v = new NumberValidator(mockField, { lower: -1, upper: 1 });
+            v.compatibleWith(other).should.be.false;
+        });
+        it('should return true when the bounds are the same', () => {
+            const other = new NumberValidator(mockField, { lower: -1, upper: 1 });
+            const v = new NumberValidator(mockField, { lower: -1, upper: 1 });
+            v.compatibleWith(other).should.be.true;
+        });
+        it('should return false when a lower bound is added', () => {
+            const other = new NumberValidator(mockField, { lower: -1, upper: 1 });
+            const v = new NumberValidator(mockField, { upper: 1 });
+            v.compatibleWith(other).should.be.false;
+        });
+        it('should return true when the lower bound is lower', () => {
+            const other = new NumberValidator(mockField, { lower: -2, upper: 1 });
+            const v = new NumberValidator(mockField, { lower: -1, upper: 1 });
+            v.compatibleWith(other).should.be.true;
+        });
+        it('should return false when the lower bound is higher', () => {
+            const other = new NumberValidator(mockField, { lower: 0, upper: 1 });
+            const v = new NumberValidator(mockField, { lower: -1, upper: 1 });
+            v.compatibleWith(other).should.be.false;
+        });
+        it('should return false when an upper bound is added', () => {
+            const other = new NumberValidator(mockField, { lower: -1, upper: 1 });
+            const v = new NumberValidator(mockField, { lower: -1 });
+            v.compatibleWith(other).should.be.false;
+        });
+        it('should return true when the upper bound is higher', () => {
+            const other = new NumberValidator(mockField, { lower: -1, upper: 2 });
+            const v = new NumberValidator(mockField, { lower: -1, upper: 1 });
+            v.compatibleWith(other).should.be.true;
+        });
+        it('should return false when the upper bound is lower', () => {
+            const other = new NumberValidator(mockField, { lower: -1, upper: 0 });
+            const v = new NumberValidator(mockField, { lower: -1, upper: 1 });
+            v.compatibleWith(other).should.be.false;
         });
     });
 });

--- a/packages/concerto-core/test/introspect/numbervalidator.js
+++ b/packages/concerto-core/test/introspect/numbervalidator.js
@@ -147,6 +147,11 @@ describe('NumberValidator', () => {
             const v = new NumberValidator(mockField, { upper: 1 });
             v.compatibleWith(other).should.be.false;
         });
+        it('should return true when a lower bound is removed', () => {
+            const other = new NumberValidator(mockField, { upper: 1 });
+            const v = new NumberValidator(mockField, { lower: -1, upper: 1 });
+            v.compatibleWith(other).should.be.true;
+        });
         it('should return true when the lower bound is lower', () => {
             const other = new NumberValidator(mockField, { lower: -2, upper: 1 });
             const v = new NumberValidator(mockField, { lower: -1, upper: 1 });
@@ -161,6 +166,11 @@ describe('NumberValidator', () => {
             const other = new NumberValidator(mockField, { lower: -1, upper: 1 });
             const v = new NumberValidator(mockField, { lower: -1 });
             v.compatibleWith(other).should.be.false;
+        });
+        it('should return true when an upper bound is removed', () => {
+            const other = new NumberValidator(mockField, { lower: -1 });
+            const v = new NumberValidator(mockField, { lower: -1, upper: 1 });
+            v.compatibleWith(other).should.be.true;
         });
         it('should return true when the upper bound is higher', () => {
             const other = new NumberValidator(mockField, { lower: -1, upper: 2 });

--- a/packages/concerto-core/test/introspect/stringvalidator.js
+++ b/packages/concerto-core/test/introspect/stringvalidator.js
@@ -19,6 +19,7 @@ const StringValidator = require('../../lib/introspect/stringvalidator');
 
 require('chai').should();
 const sinon = require('sinon');
+const NumberValidator = require('../../lib/introspect/numbervalidator');
 
 describe('StringValidator', () => {
 
@@ -84,5 +85,33 @@ describe('StringValidator', () => {
             }).should.throw(/Validator error for field id org.acme.myField/);
         });
 
+    });
+
+    describe('#compatibleWith', () => {
+        it('should return false for a number validator', () => {
+            const other = new NumberValidator(mockField, { lower: -1, upper: 1 });
+            const v = new StringValidator(mockField, { pattern: 'foo' });
+            v.compatibleWith(other).should.be.false;
+        });
+        it('should return true when the patterns are the same', () => {
+            const other = new StringValidator(mockField, { pattern: 'foo' });
+            const v = new StringValidator(mockField, { pattern: 'foo' });
+            v.compatibleWith(other).should.be.true;
+        });
+        it('should return false when the pattern is changed', () => {
+            const other = new StringValidator(mockField, { pattern: 'bar' });
+            const v = new StringValidator(mockField, { pattern: 'foo' });
+            v.compatibleWith(other).should.be.false;
+        });
+        it('should return true when the patterns and flags are the same', () => {
+            const other = new StringValidator(mockField, { pattern: 'foo', flags: 'i' });
+            const v = new StringValidator(mockField, { pattern: 'foo', flags: 'i' });
+            v.compatibleWith(other).should.be.true;
+        });
+        it('should return false when the flags are changed', () => {
+            const other = new StringValidator(mockField, { pattern: 'foo', flags: 'i' });
+            const v = new StringValidator(mockField, { pattern: 'foo', flags: 'g' });
+            v.compatibleWith(other).should.be.false;
+        });
     });
 });

--- a/packages/concerto-core/test/introspect/validator.js
+++ b/packages/concerto-core/test/introspect/validator.js
@@ -59,4 +59,12 @@ describe('Validator', () => {
         });
 
     });
+
+    describe('#compatibleWith', () => {
+        it('should always return false', () => {
+            const v = new Validator(mockField, 'dummy');
+            const other = new Validator(mockField, 'other');
+            v.compatibleWith(other).should.be.false;
+        });
+    });
 });

--- a/packages/concerto-core/types/index.d.ts
+++ b/packages/concerto-core/types/index.d.ts
@@ -16,6 +16,9 @@ import Property = require("./lib/introspect/property");
 import Field = require("./lib/introspect/field");
 import EnumDeclaration = require("./lib/introspect/enumdeclaration");
 import RelationshipDeclaration = require("./lib/introspect/relationshipdeclaration");
+import Validator = require("./lib/introspect/validator");
+import NumberValidator = require("./lib/introspect/numbervalidator");
+import StringValidator = require("./lib/introspect/stringvalidator");
 import Typed = require("./lib/model/typed");
 import Identifiable = require("./lib/model/identifiable");
 import Relationship = require("./lib/model/relationship");
@@ -36,4 +39,4 @@ export const version: {
     name: string;
     version: string;
 };
-export { SecurityException, IllegalModelException, TypeNotFoundException, Decorator, DecoratorFactory, DecoratorManager, ClassDeclaration, IdentifiedDeclaration, AssetDeclaration, ConceptDeclaration, EnumValueDeclaration, EventDeclaration, ParticipantDeclaration, TransactionDeclaration, Property, Field, EnumDeclaration, RelationshipDeclaration, Typed, Identifiable, Relationship, Resource, Factory, Globalize, Introspector, ModelFile, ModelManager, Serializer, ModelUtil, ModelLoader, DateTimeUtil, Concerto, MetaModel };
+export { SecurityException, IllegalModelException, TypeNotFoundException, Decorator, DecoratorFactory, DecoratorManager, ClassDeclaration, IdentifiedDeclaration, AssetDeclaration, ConceptDeclaration, EnumValueDeclaration, EventDeclaration, ParticipantDeclaration, TransactionDeclaration, Property, Field, EnumDeclaration, RelationshipDeclaration, Validator, NumberValidator, StringValidator, Typed, Identifiable, Relationship, Resource, Factory, Globalize, Introspector, ModelFile, ModelManager, Serializer, ModelUtil, ModelLoader, DateTimeUtil, Concerto, MetaModel };

--- a/packages/concerto-core/types/lib/introspect/field.d.ts
+++ b/packages/concerto-core/types/lib/introspect/field.d.ts
@@ -14,9 +14,9 @@ declare class Field extends Property {
     defaultValue: any;
     /**
      * Returns the validator string for this field
-     * @return {string} the validator for the field or null
+     * @return {Validator} the validator for the field or null
      */
-    getValidator(): string;
+    getValidator(): Validator;
     /**
      * Returns the default value for the field or null
      * @return {string} the default value for the field or null
@@ -32,3 +32,4 @@ declare class Field extends Property {
 import Property = require("./property");
 import NumberValidator = require("./numbervalidator");
 import StringValidator = require("./stringvalidator");
+import Validator = require("./validator");

--- a/packages/concerto-core/types/lib/introspect/validator.d.ts
+++ b/packages/concerto-core/types/lib/introspect/validator.d.ts
@@ -44,5 +44,14 @@ declare class Validator {
      * @private
      */
     private validate;
+    /**
+     * Determine if the validator is compatible with another validator. For the
+     * validators to be compatible, all values accepted by this validator must
+     * be accepted by the other validator.
+     * @param {Validator} other the other validator.
+     * @returns {boolean} True if this validator is compatible with the other
+     * validator, false otherwise.
+     */
+    compatibleWith(other: Validator): boolean;
 }
 import Field = require("./field");


### PR DESCRIPTION
Extend `concerto compare` so that it can compare number and string validators attached to a field.

This will catch:
- Number validator added to a field (incompatible change)
- Lower bound of a number validator increased (incompatible change)
- Lower bound of a number validator decreased (compatible change)
- Upper bound of a number validator decreased (incompatible change)
- Upper bound of a number validator increased (compatible change)
- String validator added to a field (incompatible change)
- String validator regex pattern changed (incompatible change)
- String validator regex flags changed (incompatible change)

Note that for regexes, it may be possible to make a regex more lenient than it was before, but there is no way for us to programmatically assert that one regex is more lenient than another regex.