### PR TITLE
feat(*): add keep and set prerelease option to version command

### DIFF
--- a/packages/concerto-cli/index.js
+++ b/packages/concerto-cli/index.js
@@ -226,11 +226,29 @@ require('yargs')
     })
     .command('version <release>', 'modify the version of one or more model files', yargs => {
         yargs.demandOption(['model'], 'Please provide Concerto model(s)');
+        yargs.positional('release', {
+            describe: 'the new version, or a release to use when incrementing the existing version',
+            type: 'string',
+            choices: [
+                'keep',
+                'major',
+                'minor',
+                'patch',
+                'premajor',
+                'preminor',
+                'prepatch',
+                'prerelease'
+            ]
+        });
         yargs.option('model', {
             alias: 'models',
             describe: 'array of concerto model files',
             type: 'string',
             array: true
+        });
+        yargs.option('prerelease', {
+            describe: 'set the specified pre-release version',
+            type: 'string'
         });
     }, argv => {
         const modelFiles = argv.model.flatMap(model => {
@@ -239,7 +257,7 @@ require('yargs')
             }
             return model;
         });
-        return Commands.version(argv.release, modelFiles)
+        return Commands.version(argv.release, modelFiles, argv.prerelease)
             .then((result) => {
                 if (result) {
                     Logger.info(result);

--- a/packages/concerto-cli/test/cli.js
+++ b/packages/concerto-cli/test/cli.js
@@ -297,20 +297,21 @@ describe('concerto-cli', () => {
             { name: 'minor', release: 'minor', expectedNamespace: 'org.accordproject.concerto.test@1.3.0' },
             { name: 'major', release: 'major', expectedNamespace: 'org.accordproject.concerto.test@2.0.0' },
             { name: 'explicit', release: '4.5.6', expectedNamespace: 'org.accordproject.concerto.test@4.5.6' },
-            { name: 'prerelease', release: '5.6.7-pr.3472381', expectedNamespace: 'org.accordproject.concerto.test@5.6.7-pr.3472381' }
+            { name: 'prerelease', release: '5.6.7-pr.3472381', expectedNamespace: 'org.accordproject.concerto.test@5.6.7-pr.3472381' },
+            { name: 'keep-and-set-prerelease', release: 'keep', prerelease: 'pr.1234567', expectedNamespace: 'org.accordproject.concerto.test@1.2.3-pr.1234567' }
         ];
 
-        tests.forEach(({ name, release, expectedNamespace }) => {
+        tests.forEach(({ name, release, prerelease, expectedNamespace }) => {
 
             it(`should patch bump a cto file [${name}]`, async () => {
-                await Commands.version(release, [ctoPath]);
+                await Commands.version(release, [ctoPath], prerelease);
                 const cto = fs.readFileSync(ctoPath, 'utf-8');
                 const metamodel = Parser.parse(cto);
                 metamodel.namespace.should.equal(expectedNamespace);
             });
 
             it(`should patch bump a metamodel file [${name}]`, async () => {
-                await Commands.version(release, [metamodelPath]);
+                await Commands.version(release, [metamodelPath], prerelease);
                 const metamodel = JSON.parse(fs.readFileSync(metamodelPath, 'utf-8'));
                 metamodel.namespace.should.equal(expectedNamespace);
             });


### PR DESCRIPTION
In CI/CD pipelines, it may be desirable to set just the prerelease identifier for a model file before publishing. For example, in a pull request, I may want to set the prerelease identifier for a model published as part of a pull request with version `1.2.3` to `1.2.3-pr.1234567`. This is easy to do if you know the version of the model, but harder where you want to set the same prerelease identifier for a set of models with different versions.

This change updates the `concerto version` command to allow `concerto version keep --prerelease pr.1234567` to only set the prerelease identifier for all specified models, and preserve the existing version.

Signed-off-by: Simon Stone <Simon.Stone@docusign.com>