### PR TITLE
feat(*): add compile option for including metamodel

### DIFF
--- a/packages/concerto-cli/index.js
+++ b/packages/concerto-cli/index.js
@@ -85,11 +85,11 @@ require('yargs')
         }
     })
     .command('compile', 'generate code for a target platform', (yargs) => {
-        yargs.demandOption(['model'], 'Please provide models');
         yargs.option('model', {
             describe: 'array of concerto model files',
             type: 'string',
-            array: true
+            array: true,
+            default: [],
         });
         yargs.option('offline', {
             describe: 'do not resolve external models',
@@ -106,6 +106,11 @@ require('yargs')
             type: 'string',
             default: './output/'
         });
+        yargs.option('metamodel', {
+            describe: 'Include the Concerto Metamodel in the output',
+            type: 'boolean',
+            default: false,
+        });
         yargs.option('useSystemTextJson', {
             describe: 'Compile for System.Text.Json library (`csharp` target only)',
             type: 'boolean',
@@ -120,6 +125,13 @@ require('yargs')
             describe: 'A prefix to add to all namespaces (`csharp` target only)',
             type: 'string',
         });
+        yargs.check(({ model, metamodel }) => {
+            if (model.length > 0 || metamodel) {
+                return true;
+            } else {
+                throw new Error('Please provide models, or specify metamodel');
+            }
+        });
     }, (argv) => {
         if (argv.verbose) {
             Logger.info(`generate code for target ${argv.target} from models ${argv.model} into directory: ${argv.output}`);
@@ -127,6 +139,7 @@ require('yargs')
 
         const options = {};
         options.offline = argv.offline;
+        options.metamodel = argv.metamodel;
         options.useSystemTextJson = argv.useSystemTextJson;
         options.useNewtonsoftJson = argv.useNewtonsoftJson;
         options.namespacePrefix = argv.namespacePrefix;

--- a/packages/concerto-cli/lib/commands.js
+++ b/packages/concerto-cli/lib/commands.js
@@ -143,6 +143,7 @@ class Commands {
      * @param {string} output the output directory
      * @param {object} options - optional parameters
      * @param {boolean} [options.offline] - do not resolve external models
+     * @param {boolean} [options.metamodel] - include the Concerto Metamodel
      * @param {boolean} [options.useSystemTextJson] - compile for System.Text.Json library
      * @param {boolean} [options.useNewtonsoftJson] - compile for Newtonsoft.Json library
      */
@@ -155,6 +156,9 @@ class Commands {
         };
 
         const modelManager = await ModelLoader.loadModelManager(ctoFiles, modelManagerOptions);
+        if (options && options.metamodel) {
+            modelManager.addCTOModel(MetaModelUtil.metaModelCto);
+        }
 
         let visitor = null;
 

--- a/packages/concerto-cli/test/cli.js
+++ b/packages/concerto-cli/test/cli.js
@@ -190,6 +190,18 @@ describe('concerto-cli', () => {
             fs.readdirSync(dir.path).length.should.be.equal(0);
             dir.cleanup();
         });
+        it('should compile to a TypeScript model with the metamodel', async () => {
+            const dir = await tmp.dir({ unsafeCleanup: true });
+            await Commands.compile('Typescript', models, dir.path, {metamodel: true, offline:false});
+            fs.readdirSync(dir.path).should.contain('concerto.metamodel@1.0.0.ts');
+            dir.cleanup();
+        });
+        it('should compile to a CSharp model with the metamodel', async () => {
+            const dir = await tmp.dir({ unsafeCleanup: true });
+            await Commands.compile('CSharp', models, dir.path, {metamodel: true, offline:false});
+            fs.readdirSync(dir.path).should.contain('concerto.metamodel@1.0.0.cs');
+            dir.cleanup();
+        });
     });
 
     describe('#get', () => {


### PR DESCRIPTION
Extend the `concerto compile` command with an additional `--metamodel` option that users can specify to include the metamodel in the compiled output. This option can be specified with other models, or without (if you just want the metamodel).

Signed-off-by: Simon Stone <Simon.Stone@docusign.com>
