### PR TITLE
BREAKING CHANGE(core): rename strict option, ban wildcard imports in strict mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "concerto",
-			"version": "3.0.0-alpha.3",
+			"version": "3.0.0-alpha.4",
 			"dependencies": {
 				"@babel/preset-env": "7.16.11",
 				"@supercharge/promise-pool": "1.7.0",

--- a/packages/concerto-analysis/src/compare.ts
+++ b/packages/concerto-analysis/src/compare.ts
@@ -26,9 +26,9 @@ export class Compare {
     }
 
     public compare(a: ModelFile, b: ModelFile): CompareResults {
-        if (!a.getModelManager().isVersionedNamespacesStrict()) {
+        if (!a.getModelManager().isStrict()) {
             throw new Error(`model file "${a.getNamespace()}" does not have strict versioned namespaces`);
-        } else if (!b.getModelManager().isVersionedNamespacesStrict()) {
+        } else if (!b.getModelManager().isStrict()) {
             throw new Error(`model file "${b.getNamespace()}" does not have strict versioned namespaces`);
         }
         const comparerFactories = this.config.comparerFactories;

--- a/packages/concerto-analysis/test/unit/compare.test.ts
+++ b/packages/concerto-analysis/test/unit/compare.test.ts
@@ -15,7 +15,7 @@ async function getModelFiles(
     aFileName: string,
     bFileName: string
 ): Promise<[a: ModelFile, b: ModelFile]> {
-    const modelManager = new ModelManager({ versionedNamespacesStrict: true });
+    const modelManager = new ModelManager({ strict: true });
     const a = await getModelFile(modelManager, aFileName);
     const b = await getModelFile(modelManager, bFileName);
     return [a, b];

--- a/packages/concerto-cli/lib/commands.js
+++ b/packages/concerto-cli/lib/commands.js
@@ -306,7 +306,7 @@ class Commands {
     static async compare(oldPath, newPath) {
         const oldContents = fs.readFileSync(path.resolve(oldPath), 'utf-8');
         const newContents = fs.readFileSync(path.resolve(newPath), 'utf-8');
-        const modelManager = new ModelManager({ versionedNamespacesStrict: true });
+        const modelManager = new ModelManager({ strict: true });
         const oldModelFile = this.getModelFile(modelManager, oldContents);
         const newModelFile = this.getModelFile(modelManager, newContents);
         const results = new Compare().compare(oldModelFile, newModelFile);

--- a/packages/concerto-cli/package-lock.json
+++ b/packages/concerto-cli/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@accordproject/concerto-cli",
-			"version": "3.0.0-alpha.1",
+			"version": "3.0.0-alpha.4",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"glob": "7.2.0"

--- a/packages/concerto-core/api.txt
+++ b/packages/concerto-core/api.txt
@@ -4,7 +4,7 @@ class AstModelManager extends BaseModelManager {
 class BaseModelManager {
    + void constructor(object?,boolean?,Object?,processFile?) 
    + boolean isModelManager() 
-   + boolean isVersionedNamespacesStrict() 
+   + boolean isStrict() 
    + Object accept(Object,Object) 
    + void validateModelFile(string|ModelFile,string?) throws IllegalModelException
    + Object addModelFile(ModelFile,string?,string?,boolean?) throws IllegalModelException

--- a/packages/concerto-core/changelog.txt
+++ b/packages/concerto-core/changelog.txt
@@ -24,10 +24,7 @@
 # Note that the latest public API is documented using JSDocs and is available in api.txt.
 #
 
-Version 3.0.0-alpha.5 {48c93cbd61ea3facc4824480c4dcd1d8} 2022-08-18
-- Rename isVersionedNamespacesStrict to isStrict in ModelManager
-
-Version 3.0.0-alpha.1 {d444400c2ba8cdba79972ae8ef95b478} 2022-08-18
+Version 3.0.0 {48c93cbd61ea3facc4824480c4dcd1d8} 2022-08-28
 - Allow client-provided RegExp engine to ModelManager
 - Allow decorators to be attached to model files/namespaces
 

--- a/packages/concerto-core/changelog.txt
+++ b/packages/concerto-core/changelog.txt
@@ -24,7 +24,10 @@
 # Note that the latest public API is documented using JSDocs and is available in api.txt.
 #
 
-Version 3.0.0 {d444400c2ba8cdba79972ae8ef95b478} 2022-08-18
+Version 3.0.0-alpha.5 {48c93cbd61ea3facc4824480c4dcd1d8} 2022-08-18
+- Rename isVersionedNamespacesStrict to isStrict in ModelManager
+
+Version 3.0.0-alpha.1 {d444400c2ba8cdba79972ae8ef95b478} 2022-08-18
 - Allow client-provided RegExp engine to ModelManager
 - Allow decorators to be attached to model files/namespaces
 

--- a/packages/concerto-core/lib/basemodelmanager.js
+++ b/packages/concerto-core/lib/basemodelmanager.js
@@ -74,7 +74,7 @@ class BaseModelManager {
      * Create the ModelManager.
      * @constructor
      * @param {object} [options] - ModelManager options, also passed to Serializer
-     * @param {boolean} [options.versionedNamespacesStrict] - require versioned namespaces and imports
+     * @param {boolean} [options.strict] - require versioned namespaces and imports
      * @param {Object} [options.regExp] - An alternative regular expression engine.
      * @param {*} [processFile] - how to obtain a concerto AST from an input to the model manager
      */
@@ -84,7 +84,7 @@ class BaseModelManager {
         this.factory = new Factory(this);
         this.serializer = new Serializer(this.factory, this, options);
         this.decoratorFactories = [];
-        this.versionedNamespacesStrict = !!options?.versionedNamespacesStrict;
+        this.strict = !!options?.strict;
         this.options = options;
         this.addRootModel();
     }
@@ -98,11 +98,11 @@ class BaseModelManager {
     }
 
     /**
-     * Returns the value of the versionedNamespacesStrict option
-     * @returns {boolean} true if the versionedNamespacesStrict has been set
+     * Returns the value of the strict option
+     * @returns {boolean} true if the strict has been set
      */
-    isVersionedNamespacesStrict() {
-        return this.versionedNamespacesStrict;
+    isStrict() {
+        return this.strict;
     }
 
     /**
@@ -114,7 +114,7 @@ class BaseModelManager {
         const {rootModelAst, rootModelCto, rootModelFile} = getRootModel(true);
         const m = new ModelFile(this, rootModelAst, rootModelCto, rootModelFile);
 
-        if(this.versionedNamespacesStrict ) {
+        if(this.strict ) {
             // add the versioned concerto namespace
             this.addModelFile(m, rootModelCto, rootModelFile);
         }
@@ -192,8 +192,8 @@ class BaseModelManager {
         const NAME = 'addModelFile';
         debug(NAME, 'addModelFile', modelFile, fileName);
 
-        if(this.isVersionedNamespacesStrict() && !modelFile.getVersion()) {
-            throw new Error('Cannot add an unversioned namespace when \'versionedNamespacesStrict\' is true');
+        if(this.isStrict() && !modelFile.getVersion()) {
+            throw new Error('Cannot add an unversioned namespace when \'strict\' is true');
         }
 
         if (!this.modelFiles[modelFile.getNamespace()]) {

--- a/packages/concerto-core/lib/introspect/modelfile.js
+++ b/packages/concerto-core/lib/introspect/modelfile.js
@@ -618,15 +618,15 @@ class ModelFile extends Decorated {
     }
 
     /**
-     * Verifies that an import is versioned if the versionedNamespacesStrict
+     * Verifies that an import is versioned if the strict
      * option has been set on the Model Manager
      * @param {*} imp - the import to validate
      */
     enforceImportVersioning(imp) {
-        if(this.getModelManager().isVersionedNamespacesStrict()) {
+        if(this.getModelManager().isStrict()) {
             const nsInfo = ModelUtil.parseNamespace(imp.namespace);
             if(!nsInfo.version) {
-                throw new Error(`Cannot use an unversioned import ${imp.namespace} when 'versionedNamespacesStrict' option on Model Manager is set.`);
+                throw new Error(`Cannot use an unversioned import ${imp.namespace} when 'strict' option on Model Manager is set.`);
             }
         }
     }
@@ -659,6 +659,10 @@ class ModelFile extends Decorated {
             this.enforceImportVersioning(imp);
             switch(imp.$class) {
             case `${MetaModelNamespace}.ImportAll`:
+                if (this.getModelManager().isStrict()){
+                    throw new Error('Wilcard Imports are not permitted in strict mode.');
+                }
+                console.warn('DEPRECATED: Wilcard Imports are deprecated in this version of Concerto and will be removed in a future version.');
                 this.importWildcardNamespaces.push(imp.namespace);
                 break;
             case `${MetaModelNamespace}.ImportTypes`:

--- a/packages/concerto-core/lib/modelloader.js
+++ b/packages/concerto-core/lib/modelloader.js
@@ -60,11 +60,11 @@ class ModelLoader {
      * @param {string[]} ctoFiles - the CTO files (can be local file paths or URLs)
      * @param {object} options - optional parameters
      * @param {boolean} [options.offline] - do not resolve external models
-     * @param {boolean} [options.versionedNamespacesStrict] - disallow unversioned namespaces
+     * @param {boolean} [options.strict] - disallow unversioned namespaces
     * @param {number} [options.utcOffset] - UTC Offset for this execution
      * @return {Promise<ModelManager>} the model manager
      */
-    static async loadModelManager(ctoFiles, options = { offline: false, versionedNamespacesStrict: false }) {
+    static async loadModelManager(ctoFiles, options = { offline: false, strict: false }) {
         let modelManager = new ModelManager(options);
         // How to create a modelfile from the external content
         const processFile = (name, data) => {
@@ -95,11 +95,11 @@ class ModelLoader {
      * @param {string[]} [fileNames] - An optional array of file names to associate with the model files
      * @param {object} options - optional parameters
      * @param {boolean} [options.offline] - do not resolve external models
-     * @param {boolean} [options.versionedNamespacesStrict] - disallow unversioned namespaces
+     * @param {boolean} [options.strict] - disallow unversioned namespaces
      * @param {number} [options.utcOffset] - UTC Offset for this execution
      * @return {Promise<ModelManager>} the model manager
      */
-    static async loadModelManagerFromModelFiles(modelFiles, fileNames, options = { offline: false, versionedNamespacesStrict: false }) {
+    static async loadModelManagerFromModelFiles(modelFiles, fileNames, options = { offline: false, strict: false }) {
         let modelManager = new ModelManager(options);
 
         // Load system model

--- a/packages/concerto-core/lib/modelmanager.js
+++ b/packages/concerto-core/lib/modelmanager.js
@@ -57,7 +57,7 @@ class ModelManager extends BaseModelManager {
      * Create the ModelManager.
      * @constructor
      * @param {object} [options] - ModelManager options, also passed to Serializer
-     * @param {boolean} [options.versionedNamespacesStrict] - require versioned namespaces and imports
+     * @param {boolean} [options.strict] - require versioned namespaces and imports
      * @param {Object} [options.regExp] - An alternative regular expression engine.
      */
     constructor(options) {

--- a/packages/concerto-core/package-lock.json
+++ b/packages/concerto-core/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@accordproject/concerto-core",
-			"version": "3.0.0-alpha.3",
+			"version": "3.0.0-alpha.4",
 			"license": "Apache-2.0",
 			"devDependencies": {
 				"mocha": "10.0.0"

--- a/packages/concerto-core/test/introspect/modelfile.js
+++ b/packages/concerto-core/test/introspect/modelfile.js
@@ -128,6 +128,27 @@ describe('ModelFile', () => {
             (mf.getImportURI('org.doge.Foo') === null).should.be.true;
         });
 
+        it('should throw for a wildcard import when strict is true', () => {
+            const strictModelManager = new ModelManager({ strict: true });
+
+            const imports = [{
+                $class: `${MetaModelNamespace}.ImportAll`,
+                namespace: 'org.freddos@1.0.0',
+                uri: 'https://freddos.org/model.cto'
+            }];
+            const ast = {
+                $class: `${MetaModelNamespace}.Model`,
+                namespace: 'org.acme',
+                imports: imports,
+                declarations: [ ]
+            };
+            sandbox.stub(Parser, 'parse').returns(ast);
+
+            (() => {
+                ParserUtil.newModelFile(strictModelManager, 'fake definitions');
+            }).should.throw(/Wilcard Imports are not permitted in strict mode./);
+        });
+
         it('should throw for an unrecognized body element', () => {
             const ast = {
                 $class: `${MetaModelNamespace}.Model`,

--- a/packages/concerto-core/test/semver.js
+++ b/packages/concerto-core/test/semver.js
@@ -42,7 +42,7 @@ describe('Semantic Versioning', () => {
         sandbox.restore();
     });
 
-    describe('#namespace versioning - versionedNamespacesStrict:false', () => {
+    describe('#namespace versioning - strict:false', () => {
         it('should support versioned namespaces', () => {
             modelManager = new ModelManager();
             modelManager.addCTOModel(personCto, 'person.cto');
@@ -94,9 +94,9 @@ import {Event} from concerto@1.0.0`, 'test.cto');
         });
     });
 
-    describe('#namespace versioning - versionedNamespacesStrict:true', () => {
+    describe('#namespace versioning - strict:true', () => {
         it('should support versioned namespaces', () => {
-            modelManager = new ModelManager({ versionedNamespacesStrict: true });
+            modelManager = new ModelManager({ strict: true });
             modelManager.addCTOModel(personCto, 'person.cto');
             modelManager.addCTOModel(employeeCto, 'employee.cto');
             modelManager.getModelFile('person@1.0.0').should.be.not.null;
@@ -106,21 +106,21 @@ import {Event} from concerto@1.0.0`, 'test.cto');
 
         it('should not support unversioned namespaces', () => {
             (() => {
-                modelManager = new ModelManager({ versionedNamespacesStrict: true });
+                modelManager = new ModelManager({ strict: true });
                 modelManager.addCTOModel('namespace test', 'test.cto');
             }).should.throw(/Cannot add an unversioned namespace/);
         });
 
         it('should not support unversioned imports', () => {
             (() => {
-                modelManager = new ModelManager({ versionedNamespacesStrict: true });
+                modelManager = new ModelManager({ strict: true });
                 modelManager.addCTOModel(`namespace test@1.0.0
 import concerto.Event`, 'test.cto');
             }).should.throw(/Cannot use an unversioned import/);
         });
 
         it('should not deserialize unversioned declarations', () => {
-            modelManager = new ModelManager({ versionedNamespacesStrict: true });
+            modelManager = new ModelManager({ strict: true });
             modelManager.addCTOModel(personCto, 'person.cto');
             modelManager.addCTOModel(employeeCto, 'employee.cto');
             const factory = new Factory(modelManager);

--- a/packages/concerto-core/types/lib/basemodelmanager.d.ts
+++ b/packages/concerto-core/types/lib/basemodelmanager.d.ts
@@ -19,12 +19,12 @@ declare class BaseModelManager {
      * Create the ModelManager.
      * @constructor
      * @param {object} [options] - ModelManager options, also passed to Serializer
-     * @param {boolean} [options.versionedNamespacesStrict] - require versioned namespaces and imports
+     * @param {boolean} [options.strict] - require versioned namespaces and imports
      * @param {Object} [options.regExp] - An alternative regular expression engine.
      * @param {*} [processFile] - how to obtain a concerto AST from an input to the model manager
      */
     constructor(options?: {
-        versionedNamespacesStrict?: boolean;
+        strict?: boolean;
         regExp?: any;
     }, processFile?: any);
     processFile: any;
@@ -32,9 +32,9 @@ declare class BaseModelManager {
     factory: any;
     serializer: any;
     decoratorFactories: any[];
-    versionedNamespacesStrict: boolean;
+    strict: boolean;
     options: {
-        versionedNamespacesStrict?: boolean;
+        strict?: boolean;
         regExp?: any;
     };
     /**
@@ -43,10 +43,10 @@ declare class BaseModelManager {
      */
     isModelManager(): boolean;
     /**
-     * Returns the value of the versionedNamespacesStrict option
-     * @returns {boolean} true if the versionedNamespacesStrict has been set
+     * Returns the value of the strict option
+     * @returns {boolean} true if the strict has been set
      */
-    isVersionedNamespacesStrict(): boolean;
+    isStrict(): boolean;
     /**
      * Adds root types
      * @private

--- a/packages/concerto-core/types/lib/introspect/modelfile.d.ts
+++ b/packages/concerto-core/types/lib/introspect/modelfile.d.ts
@@ -242,7 +242,7 @@ declare class ModelFile extends Decorated {
      */
     isCompatibleVersion(): void;
     /**
-     * Verifies that an import is versioned if the versionedNamespacesStrict
+     * Verifies that an import is versioned if the strict
      * option has been set on the Model Manager
      * @param {*} imp - the import to validate
      */

--- a/packages/concerto-core/types/lib/modelloader.d.ts
+++ b/packages/concerto-core/types/lib/modelloader.d.ts
@@ -24,13 +24,13 @@ declare class ModelLoader {
      * @param {string[]} ctoFiles - the CTO files (can be local file paths or URLs)
      * @param {object} options - optional parameters
      * @param {boolean} [options.offline] - do not resolve external models
-     * @param {boolean} [options.versionedNamespacesStrict] - disallow unversioned namespaces
+     * @param {boolean} [options.strict] - disallow unversioned namespaces
     * @param {number} [options.utcOffset] - UTC Offset for this execution
      * @return {Promise<ModelManager>} the model manager
      */
     static loadModelManager(ctoFiles: string[], options?: {
         offline?: boolean;
-        versionedNamespacesStrict?: boolean;
+        strict?: boolean;
         utcOffset?: number;
     }): Promise<ModelManager>;
     /**
@@ -40,13 +40,13 @@ declare class ModelLoader {
      * @param {string[]} [fileNames] - An optional array of file names to associate with the model files
      * @param {object} options - optional parameters
      * @param {boolean} [options.offline] - do not resolve external models
-     * @param {boolean} [options.versionedNamespacesStrict] - disallow unversioned namespaces
+     * @param {boolean} [options.strict] - disallow unversioned namespaces
      * @param {number} [options.utcOffset] - UTC Offset for this execution
      * @return {Promise<ModelManager>} the model manager
      */
     static loadModelManagerFromModelFiles(modelFiles: object[], fileNames?: string[], options?: {
         offline?: boolean;
-        versionedNamespacesStrict?: boolean;
+        strict?: boolean;
         utcOffset?: number;
     }): Promise<ModelManager>;
 }

--- a/packages/concerto-core/types/lib/modelmanager.d.ts
+++ b/packages/concerto-core/types/lib/modelmanager.d.ts
@@ -17,11 +17,11 @@ declare class ModelManager extends BaseModelManager {
      * Create the ModelManager.
      * @constructor
      * @param {object} [options] - ModelManager options, also passed to Serializer
-     * @param {boolean} [options.versionedNamespacesStrict] - require versioned namespaces and imports
+     * @param {boolean} [options.strict] - require versioned namespaces and imports
      * @param {Object} [options.regExp] - An alternative regular expression engine.
      */
     constructor(options?: {
-        versionedNamespacesStrict?: boolean;
+        strict?: boolean;
         regExp?: any;
     });
     /**

--- a/packages/concerto-types/scripts/codegen.js
+++ b/packages/concerto-types/scripts/codegen.js
@@ -10,7 +10,7 @@ const path = require('path');
  * Generate TypeScript files from the metamodel.
  */
 async function main() {
-    const modelManager = await ModelLoader.loadModelManagerFromModelFiles([metaModelCto], {versionedNamespacesStrict: true});
+    const modelManager = await ModelLoader.loadModelManagerFromModelFiles([metaModelCto], {strict: true});
     const visitor = new TypescriptVisitor();
     const fileWriter = new FileWriter(path.resolve(__dirname, '..', 'src', 'generated'));
     const parameters = { fileWriter };


### PR DESCRIPTION
<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Partially Closes #458 
This change is an incremental step towards dropping support for Wildcard Imports. This change prevents their use in "strict" mode, and warns in the default mode.

### Changes
- Renames `isVersionedNamespacesStrict` to `isStrict` in ModelManager
- Adds a warning when a `concerto.metamodel@1.0.0.ImportAll` is encountered in a `ModelFile`.
- Throws an error when a `concerto.metamodel@1.0.0.ImportAll` is encountered in a `ModelFile` when in strict mode.

### Related Issues
- Required for 3.0 release, Issue #420

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [x] Extend the documentation, if necessary
- [x] Merging to `master` from `fork:branchname`
