### PR TITLE
feat(*): allow c# namespace to be specified via decorator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -211,9 +211,9 @@
 			}
 		},
 		"node_modules/@babel/helper-create-class-features-plugin": {
-			"version": "7.18.9",
-			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.18.9.tgz",
-			"integrity": "sha512-WvypNAYaVh23QcjpMR24CwZY2Nz6hqdOcFdPbNpV56hL5H6KiFheO7Xm1aPdlLQ7d5emYZX7VZwPp9x3z+2opw==",
+			"version": "7.18.13",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.18.13.tgz",
+			"integrity": "sha512-hDvXp+QYxSRL+23mpAlSGxHMDyIGChm0/AwTfTAAK5Ufe40nCsyNdaYCGuK91phn/fVu9kqayImRDkvNAgdrsA==",
 			"dependencies": {
 				"@babel/helper-annotate-as-pure": "^7.18.6",
 				"@babel/helper-environment-visitor": "^7.18.9",
@@ -1067,9 +1067,9 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-destructuring": {
-			"version": "7.18.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.18.9.tgz",
-			"integrity": "sha512-p5VCYNddPLkZTq4XymQIaIfZNJwT9YsjkPOhkVEqt6QIpQFZVM9IltqqYpOEkJoN1DPznmxUDyZ5CTZs/ZCuHA==",
+			"version": "7.18.13",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.18.13.tgz",
+			"integrity": "sha512-TodpQ29XekIsex2A+YJPj5ax2plkGa8YYY6mFjCohk/IG9IY42Rtuj1FuDeemfg2ipxIFLzPeA83SIBnlhSIow==",
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.18.9"
 			},
@@ -2458,15 +2458,15 @@
 			}
 		},
 		"node_modules/@jest/transform/node_modules/write-file-atomic": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.1.tgz",
-			"integrity": "sha512-nSKUxgAbyioruk6hU87QzVbY279oYT6uiwgDoujth2ju4mJ+TZau7SQBhtbTmUyuNYTuXnSyRn66FV0+eCgcrQ==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
+			"integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
 			"dependencies": {
 				"imurmurhash": "^0.1.4",
 				"signal-exit": "^3.0.7"
 			},
 			"engines": {
-				"node": "^12.13.0 || ^14.15.0 || >=16"
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/@jest/types": {
@@ -4670,9 +4670,9 @@
 			}
 		},
 		"node_modules/@sinclair/typebox": {
-			"version": "0.24.28",
-			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.28.tgz",
-			"integrity": "sha512-dgJd3HLOkLmz4Bw50eZx/zJwtBq65nms3N9VBYu5LTjJ883oBFkTyXRlCB/ZGGwqYpJJHA5zW2Ibhl5ngITfow=="
+			"version": "0.24.31",
+			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.31.tgz",
+			"integrity": "sha512-uWZaAsh9WFhcY1rWLLcMU/omiIIAQ/PmgqplaF6UWY6ULPH0ZO8hupJRAydzlTQZJIK3Voz8o8dYlEx+Cm6BAA=="
 		},
 		"node_modules/@sinonjs/commons": {
 			"version": "1.8.3",
@@ -4752,17 +4752,17 @@
 			}
 		},
 		"node_modules/@types/babel__traverse": {
-			"version": "7.18.0",
-			"resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.18.0.tgz",
-			"integrity": "sha512-v4Vwdko+pgymgS+A2UIaJru93zQd85vIGWObM5ekZNdXCKtDYqATlEYnWgfo86Q6I1Lh0oXnksDnMU1cwmlPDw==",
+			"version": "7.18.1",
+			"resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.18.1.tgz",
+			"integrity": "sha512-FSdLaZh2UxaMuLp9lixWaHq/golWTRWOnRsAXzDTDSDOQLuZb1nsdCt6pJSPWSEQt2eFZ2YVk3oYhn+1kLMeMA==",
 			"dependencies": {
 				"@babel/types": "^7.3.0"
 			}
 		},
 		"node_modules/@types/eslint": {
-			"version": "8.4.5",
-			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.5.tgz",
-			"integrity": "sha512-dhsC09y1gpJWnK+Ff4SGvCuSnk9DaU0BJZSzOwa6GVSg65XtTugLBITDAAzRU5duGBoXBHpdR/9jHGxJjNflJQ==",
+			"version": "8.4.6",
+			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.6.tgz",
+			"integrity": "sha512-/fqTbjxyFUaYNO7VcW5g+4npmqVACz1bB7RTHYuLj+PRjw9hrCwrUXVQFpChUS0JsyEFvMZ7U/PfmvWgxJhI9g==",
 			"dependencies": {
 				"@types/estree": "*",
 				"@types/json-schema": "*"
@@ -4860,9 +4860,9 @@
 			"dev": true
 		},
 		"node_modules/@types/node": {
-			"version": "18.7.6",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.6.tgz",
-			"integrity": "sha512-EdxgKRXgYsNITy5mjjXjVE/CS8YENSdhiagGrLqjG0pvA2owgJ6i4l7wy/PFZGC0B1/H20lWKN7ONVDNYDZm7A=="
+			"version": "18.7.14",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.14.tgz",
+			"integrity": "sha512-6bbDaETVi8oyIARulOE9qF1/Qdi/23z6emrUh0fNJRUmjznqrixD4MpGDdgOFk5Xb0m2H6Xu42JGdvAxaJR/wA=="
 		},
 		"node_modules/@types/normalize-package-data": {
 			"version": "2.4.1",
@@ -4892,9 +4892,9 @@
 			"integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw=="
 		},
 		"node_modules/@types/yargs": {
-			"version": "17.0.11",
-			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.11.tgz",
-			"integrity": "sha512-aB4y9UDUXTSMxmM4MH+YnuR0g5Cph3FLQBoWoMB21DSvFVAxRVEHEMx3TLh+zUZYMCQtKiqazz0Q4Rre31f/OA==",
+			"version": "17.0.12",
+			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.12.tgz",
+			"integrity": "sha512-Nz4MPhecOFArtm81gFQvQqdV7XYCrWKx5uUt6GNHredFHn1i2mtWqXTON7EPXMtNi1qjtjEM/VCHDhcHsAMLXQ==",
 			"dependencies": {
 				"@types/yargs-parser": "*"
 			}
@@ -7100,9 +7100,9 @@
 			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
 		},
 		"node_modules/core-js-compat": {
-			"version": "3.24.1",
-			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.24.1.tgz",
-			"integrity": "sha512-XhdNAGeRnTpp8xbD+sR/HFDK9CbeeeqXT6TuofXh3urqEevzkWmLRgrVoykodsw8okqo2pu1BOmuCKrHx63zdw==",
+			"version": "3.25.0",
+			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.25.0.tgz",
+			"integrity": "sha512-extKQM0g8/3GjFx9US12FAgx8KJawB7RCQ5y8ipYLbmfzEzmFRWdDjIlxDx82g7ygcNG85qMVUSRyABouELdow==",
 			"dependencies": {
 				"browserslist": "^4.21.3",
 				"semver": "7.0.0"
@@ -7121,9 +7121,9 @@
 			}
 		},
 		"node_modules/core-js-pure": {
-			"version": "3.24.1",
-			"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.24.1.tgz",
-			"integrity": "sha512-r1nJk41QLLPyozHUUPmILCEMtMw24NG4oWK6RbsDdjzQgg9ZvrUsPBj1MnG0wXXp1DCDU6j+wUvEmBSrtRbLXg==",
+			"version": "3.25.0",
+			"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.25.0.tgz",
+			"integrity": "sha512-IeHpLwk3uoci37yoI2Laty59+YqH9x5uR65/yiA0ARAJrTrN4YU0rmauLWfvqOuk77SlNJXj2rM6oT/dBD87+A==",
 			"hasInstallScript": true,
 			"funding": {
 				"type": "opencollective",
@@ -13987,9 +13987,9 @@
 			}
 		},
 		"node_modules/node-polyfill-webpack-plugin/node_modules/type-fest": {
-			"version": "2.18.0",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.18.0.tgz",
-			"integrity": "sha512-pRS+/yrW5TjPPHNOvxhbNZexr2bS63WjrMU8a+VzEBhUi9Tz1pZeD+vQz3ut0svZ46P+SRqMEPnJmk2XnvNzTw==",
+			"version": "2.19.0",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+			"integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
 			"engines": {
 				"node": ">=12.20"
 			},
@@ -17249,9 +17249,9 @@
 			}
 		},
 		"node_modules/terser": {
-			"version": "5.14.2",
-			"resolved": "https://registry.npmjs.org/terser/-/terser-5.14.2.tgz",
-			"integrity": "sha512-oL0rGeM/WFQCUd0y2QrWxYnq7tfSuKBiqTjRPWrRgB46WD/kiwHwF8T23z78H6Q6kGCuuHcPB+KULHRdxvVGQA==",
+			"version": "5.15.0",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-5.15.0.tgz",
+			"integrity": "sha512-L1BJiXVmheAQQy+as0oF3Pwtlo4s3Wi1X2zNZ2NxOB4wx9bdS9Vk67XQENLFdLYGCK/Z2di53mTj/hBafR+dTA==",
 			"dependencies": {
 				"@jridgewell/source-map": "^0.3.2",
 				"acorn": "^8.5.0",
@@ -17266,9 +17266,9 @@
 			}
 		},
 		"node_modules/terser-webpack-plugin": {
-			"version": "5.3.5",
-			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.5.tgz",
-			"integrity": "sha512-AOEDLDxD2zylUGf/wxHxklEkOe2/r+seuyOWujejFrIxHf11brA1/dWQNIgXa1c6/Wkxgu7zvv0JhOWfc2ELEA==",
+			"version": "5.3.6",
+			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.6.tgz",
+			"integrity": "sha512-kfLFk+PoLUQIbLmB1+PZDMRSZS99Mp+/MHqDNmMA6tOItzRt+Npe3E+fsMs5mfcM0wCtrrdU387UnV+vnSffXQ==",
 			"dependencies": {
 				"@jridgewell/trace-mapping": "^0.3.14",
 				"jest-worker": "^27.4.5",
@@ -18706,9 +18706,9 @@
 			}
 		},
 		"@babel/helper-create-class-features-plugin": {
-			"version": "7.18.9",
-			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.18.9.tgz",
-			"integrity": "sha512-WvypNAYaVh23QcjpMR24CwZY2Nz6hqdOcFdPbNpV56hL5H6KiFheO7Xm1aPdlLQ7d5emYZX7VZwPp9x3z+2opw==",
+			"version": "7.18.13",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.18.13.tgz",
+			"integrity": "sha512-hDvXp+QYxSRL+23mpAlSGxHMDyIGChm0/AwTfTAAK5Ufe40nCsyNdaYCGuK91phn/fVu9kqayImRDkvNAgdrsA==",
 			"requires": {
 				"@babel/helper-annotate-as-pure": "^7.18.6",
 				"@babel/helper-environment-visitor": "^7.18.9",
@@ -19276,9 +19276,9 @@
 			}
 		},
 		"@babel/plugin-transform-destructuring": {
-			"version": "7.18.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.18.9.tgz",
-			"integrity": "sha512-p5VCYNddPLkZTq4XymQIaIfZNJwT9YsjkPOhkVEqt6QIpQFZVM9IltqqYpOEkJoN1DPznmxUDyZ5CTZs/ZCuHA==",
+			"version": "7.18.13",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.18.13.tgz",
+			"integrity": "sha512-TodpQ29XekIsex2A+YJPj5ax2plkGa8YYY6mFjCohk/IG9IY42Rtuj1FuDeemfg2ipxIFLzPeA83SIBnlhSIow==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.18.9"
 			}
@@ -20273,9 +20273,9 @@
 					}
 				},
 				"write-file-atomic": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.1.tgz",
-					"integrity": "sha512-nSKUxgAbyioruk6hU87QzVbY279oYT6uiwgDoujth2ju4mJ+TZau7SQBhtbTmUyuNYTuXnSyRn66FV0+eCgcrQ==",
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
+					"integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
 					"requires": {
 						"imurmurhash": "^0.1.4",
 						"signal-exit": "^3.0.7"
@@ -22062,9 +22062,9 @@
 			}
 		},
 		"@sinclair/typebox": {
-			"version": "0.24.28",
-			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.28.tgz",
-			"integrity": "sha512-dgJd3HLOkLmz4Bw50eZx/zJwtBq65nms3N9VBYu5LTjJ883oBFkTyXRlCB/ZGGwqYpJJHA5zW2Ibhl5ngITfow=="
+			"version": "0.24.31",
+			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.31.tgz",
+			"integrity": "sha512-uWZaAsh9WFhcY1rWLLcMU/omiIIAQ/PmgqplaF6UWY6ULPH0ZO8hupJRAydzlTQZJIK3Voz8o8dYlEx+Cm6BAA=="
 		},
 		"@sinonjs/commons": {
 			"version": "1.8.3",
@@ -22138,17 +22138,17 @@
 			}
 		},
 		"@types/babel__traverse": {
-			"version": "7.18.0",
-			"resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.18.0.tgz",
-			"integrity": "sha512-v4Vwdko+pgymgS+A2UIaJru93zQd85vIGWObM5ekZNdXCKtDYqATlEYnWgfo86Q6I1Lh0oXnksDnMU1cwmlPDw==",
+			"version": "7.18.1",
+			"resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.18.1.tgz",
+			"integrity": "sha512-FSdLaZh2UxaMuLp9lixWaHq/golWTRWOnRsAXzDTDSDOQLuZb1nsdCt6pJSPWSEQt2eFZ2YVk3oYhn+1kLMeMA==",
 			"requires": {
 				"@babel/types": "^7.3.0"
 			}
 		},
 		"@types/eslint": {
-			"version": "8.4.5",
-			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.5.tgz",
-			"integrity": "sha512-dhsC09y1gpJWnK+Ff4SGvCuSnk9DaU0BJZSzOwa6GVSg65XtTugLBITDAAzRU5duGBoXBHpdR/9jHGxJjNflJQ==",
+			"version": "8.4.6",
+			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.6.tgz",
+			"integrity": "sha512-/fqTbjxyFUaYNO7VcW5g+4npmqVACz1bB7RTHYuLj+PRjw9hrCwrUXVQFpChUS0JsyEFvMZ7U/PfmvWgxJhI9g==",
 			"requires": {
 				"@types/estree": "*",
 				"@types/json-schema": "*"
@@ -22246,9 +22246,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "18.7.6",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.6.tgz",
-			"integrity": "sha512-EdxgKRXgYsNITy5mjjXjVE/CS8YENSdhiagGrLqjG0pvA2owgJ6i4l7wy/PFZGC0B1/H20lWKN7ONVDNYDZm7A=="
+			"version": "18.7.14",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.14.tgz",
+			"integrity": "sha512-6bbDaETVi8oyIARulOE9qF1/Qdi/23z6emrUh0fNJRUmjznqrixD4MpGDdgOFk5Xb0m2H6Xu42JGdvAxaJR/wA=="
 		},
 		"@types/normalize-package-data": {
 			"version": "2.4.1",
@@ -22278,9 +22278,9 @@
 			"integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw=="
 		},
 		"@types/yargs": {
-			"version": "17.0.11",
-			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.11.tgz",
-			"integrity": "sha512-aB4y9UDUXTSMxmM4MH+YnuR0g5Cph3FLQBoWoMB21DSvFVAxRVEHEMx3TLh+zUZYMCQtKiqazz0Q4Rre31f/OA==",
+			"version": "17.0.12",
+			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.12.tgz",
+			"integrity": "sha512-Nz4MPhecOFArtm81gFQvQqdV7XYCrWKx5uUt6GNHredFHn1i2mtWqXTON7EPXMtNi1qjtjEM/VCHDhcHsAMLXQ==",
 			"requires": {
 				"@types/yargs-parser": "*"
 			}
@@ -23969,9 +23969,9 @@
 			}
 		},
 		"core-js-compat": {
-			"version": "3.24.1",
-			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.24.1.tgz",
-			"integrity": "sha512-XhdNAGeRnTpp8xbD+sR/HFDK9CbeeeqXT6TuofXh3urqEevzkWmLRgrVoykodsw8okqo2pu1BOmuCKrHx63zdw==",
+			"version": "3.25.0",
+			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.25.0.tgz",
+			"integrity": "sha512-extKQM0g8/3GjFx9US12FAgx8KJawB7RCQ5y8ipYLbmfzEzmFRWdDjIlxDx82g7ygcNG85qMVUSRyABouELdow==",
 			"requires": {
 				"browserslist": "^4.21.3",
 				"semver": "7.0.0"
@@ -23985,9 +23985,9 @@
 			}
 		},
 		"core-js-pure": {
-			"version": "3.24.1",
-			"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.24.1.tgz",
-			"integrity": "sha512-r1nJk41QLLPyozHUUPmILCEMtMw24NG4oWK6RbsDdjzQgg9ZvrUsPBj1MnG0wXXp1DCDU6j+wUvEmBSrtRbLXg=="
+			"version": "3.25.0",
+			"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.25.0.tgz",
+			"integrity": "sha512-IeHpLwk3uoci37yoI2Laty59+YqH9x5uR65/yiA0ARAJrTrN4YU0rmauLWfvqOuk77SlNJXj2rM6oT/dBD87+A=="
 		},
 		"core-util-is": {
 			"version": "1.0.2",
@@ -29138,9 +29138,9 @@
 					}
 				},
 				"type-fest": {
-					"version": "2.18.0",
-					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.18.0.tgz",
-					"integrity": "sha512-pRS+/yrW5TjPPHNOvxhbNZexr2bS63WjrMU8a+VzEBhUi9Tz1pZeD+vQz3ut0svZ46P+SRqMEPnJmk2XnvNzTw=="
+					"version": "2.19.0",
+					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+					"integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
 				}
 			}
 		},
@@ -31614,9 +31614,9 @@
 			}
 		},
 		"terser": {
-			"version": "5.14.2",
-			"resolved": "https://registry.npmjs.org/terser/-/terser-5.14.2.tgz",
-			"integrity": "sha512-oL0rGeM/WFQCUd0y2QrWxYnq7tfSuKBiqTjRPWrRgB46WD/kiwHwF8T23z78H6Q6kGCuuHcPB+KULHRdxvVGQA==",
+			"version": "5.15.0",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-5.15.0.tgz",
+			"integrity": "sha512-L1BJiXVmheAQQy+as0oF3Pwtlo4s3Wi1X2zNZ2NxOB4wx9bdS9Vk67XQENLFdLYGCK/Z2di53mTj/hBafR+dTA==",
 			"requires": {
 				"@jridgewell/source-map": "^0.3.2",
 				"acorn": "^8.5.0",
@@ -31636,9 +31636,9 @@
 			}
 		},
 		"terser-webpack-plugin": {
-			"version": "5.3.5",
-			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.5.tgz",
-			"integrity": "sha512-AOEDLDxD2zylUGf/wxHxklEkOe2/r+seuyOWujejFrIxHf11brA1/dWQNIgXa1c6/Wkxgu7zvv0JhOWfc2ELEA==",
+			"version": "5.3.6",
+			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.6.tgz",
+			"integrity": "sha512-kfLFk+PoLUQIbLmB1+PZDMRSZS99Mp+/MHqDNmMA6tOItzRt+Npe3E+fsMs5mfcM0wCtrrdU387UnV+vnSffXQ==",
 			"requires": {
 				"@jridgewell/trace-mapping": "^0.3.14",
 				"jest-worker": "^27.4.5",

--- a/packages/concerto-core/lib/rootmodel.js
+++ b/packages/concerto-core/lib/rootmodel.js
@@ -25,7 +25,8 @@ const rootModelAst = require('./rootmodel.json');
 function getRootModel(versioned) {
     const rootModelFile = versioned ? 'concerto_1.0.0.cto' : 'concerto.cto';
     const ns = versioned ? 'concerto@1.0.0' : 'concerto';
-    const rootModelCto = `namespace ${ns}
+    const rootModelCto = `@DotNetNamespace("AccordProject.Concerto")
+    namespace ${ns}
     abstract concept Concept {}
     abstract concept Asset identified {}
     abstract concept Participant identified {}

--- a/packages/concerto-core/lib/rootmodel.json
+++ b/packages/concerto-core/lib/rootmodel.json
@@ -1,5 +1,17 @@
 {
     "$class": "concerto.metamodel@1.0.0.Model",
+    "decorators": [
+        {
+            "$class": "concerto.metamodel@1.0.0.Decorator",
+            "name": "DotNetNamespace",
+            "arguments": [
+                {
+                    "$class": "concerto.metamodel@1.0.0.DecoratorString",
+                    "value": "AccordProject.Concerto"
+                }
+            ]
+        }
+    ],
     "namespace": "concerto@1.0.0",
     "imports": [],
     "declarations": [

--- a/packages/concerto-metamodel/lib/metamodel.json
+++ b/packages/concerto-metamodel/lib/metamodel.json
@@ -1,6 +1,17 @@
 {
     "$class": "concerto.metamodel@1.0.0.Model",
-    "decorators": [],
+    "decorators": [
+        {
+            "$class": "concerto.metamodel@1.0.0.Decorator",
+            "name": "DotNetNamespace",
+            "arguments": [
+                {
+                    "$class": "concerto.metamodel@1.0.0.DecoratorString",
+                    "value": "AccordProject.Concerto.Metamodel"
+                }
+            ]
+        }
+    ],
     "namespace": "concerto.metamodel@1.0.0",
     "imports": [],
     "declarations": [

--- a/packages/concerto-metamodel/lib/metamodelutil.js
+++ b/packages/concerto-metamodel/lib/metamodelutil.js
@@ -27,7 +27,8 @@ const MetaModelNamespace = 'concerto.metamodel@1.0.0';
 /**
  * The metamodel itself, as a CTO string
  */
-const metaModelCto = `namespace ${MetaModelNamespace}
+const metaModelCto = `@DotNetNamespace("AccordProject.Concerto.Metamodel")
+namespace ${MetaModelNamespace}
 
 concept Position {
   o Integer line


### PR DESCRIPTION
This change allows the .NET namespace for generated C# classes to be specified via a decorator in the model:

```
@DotNetNamespace("Org.Acme.Models")
namespace org.acme
```

This allows the model author to shape the generated output in a way similar to Protocol Buffers: https://github.com/hyperledger/fabric-protos/blob/main/gateway/gateway.proto#L7

I've also updated the metamodel to use this decorator to generate the Concerto types in the `AccordProject.Concerto` namespace to match our package in https://github.com/accordproject/concerto-dotnet

Signed-off-by: Simon Stone <Simon.Stone@docusign.com>