### PR TITLE
feat(*): enable strict mode for cli in compile

### DIFF
--- a/packages/concerto-cli/index.js
+++ b/packages/concerto-cli/index.js
@@ -111,6 +111,11 @@ require('yargs')
             type: 'boolean',
             default: false,
         });
+        yargs.option('strict', {
+            describe: 'Require versioned namespaces and imports',
+            type: 'boolean',
+            default: false,
+        });
         yargs.option('useSystemTextJson', {
             describe: 'Compile for System.Text.Json library (`csharp` target only)',
             type: 'boolean',
@@ -139,6 +144,7 @@ require('yargs')
 
         const options = {};
         options.offline = argv.offline;
+        options.strict = argv.strict;
         options.metamodel = argv.metamodel;
         options.useSystemTextJson = argv.useSystemTextJson;
         options.useNewtonsoftJson = argv.useNewtonsoftJson;

--- a/packages/concerto-cli/lib/commands.js
+++ b/packages/concerto-cli/lib/commands.js
@@ -143,12 +143,13 @@ class Commands {
      * @param {string} output the output directory
      * @param {object} options - optional parameters
      * @param {boolean} [options.offline] - do not resolve external models
+     * @param {boolean} [options.strict] - require versioned namespaces and imports
      * @param {boolean} [options.metamodel] - include the Concerto Metamodel
      * @param {boolean} [options.useSystemTextJson] - compile for System.Text.Json library
      * @param {boolean} [options.useNewtonsoftJson] - compile for Newtonsoft.Json library
      */
     static async compile(target, ctoFiles, output, options) {
-        const modelManagerOptions = { offline: options && options.offline };
+        const modelManagerOptions = { offline: options && options.offline, strict: options && options.strict };
         const visitorOptions = {
             useSystemTextJson: options && options.useSystemTextJson,
             useNewtonsoftJson: options && options.useNewtonsoftJson,

--- a/packages/concerto-cli/test/cli.js
+++ b/packages/concerto-cli/test/cli.js
@@ -202,6 +202,20 @@ describe('concerto-cli', () => {
             fs.readdirSync(dir.path).should.contain('concerto.metamodel@1.0.0.cs');
             dir.cleanup();
         });
+        it('should compile to a TypeScript model in strict mode', async () => {
+            const dir = await tmp.dir({ unsafeCleanup: true });
+            await Commands.compile('Typescript', [], dir.path, {metamodel: true, offline:false, strict: true});
+            fs.readdirSync(dir.path).should.not.contain('concerto.ts');
+            fs.readdirSync(dir.path).should.contain('concerto@1.0.0.ts');
+            dir.cleanup();
+        });
+        it('should compile to a CSharp model in strict mode', async () => {
+            const dir = await tmp.dir({ unsafeCleanup: true });
+            await Commands.compile('CSharp', [], dir.path, {metamodel: true, offline:false, strict: true});
+            fs.readdirSync(dir.path).should.not.contain('concerto.cs');
+            fs.readdirSync(dir.path).should.contain('concerto@1.0.0.cs');
+            dir.cleanup();
+        });
     });
 
     describe('#get', () => {


### PR DESCRIPTION
Add a `--strict` option to `concerto compile` which mandates versioned namespaces and imports and stops it producing both `concerto` and `concerto@1.0.0` code.

Signed-off-by: Simon Stone <Simon.Stone@docusign.com>