### PR TITLE
feat(*): add type attributes to generated c#

### DIFF
--- a/packages/concerto-tools/lib/codegen/fromcto/csharp/csharpvisitor.js
+++ b/packages/concerto-tools/lib/codegen/fromcto/csharp/csharpvisitor.js
@@ -186,15 +186,17 @@ class CSharpVisitor {
             abstract = 'abstract ';
         }
 
+        const { name: namespace, version } = ModelUtil.parseNamespace(classDeclaration.getNamespace());
+        const name = classDeclaration.getName();
+        parameters.fileWriter.writeLine(1, `[AccordProject.Concerto.Type(Namespace = "${namespace}", Version = ${version ? `"${version}"` : 'null'}, Name = "${name}")]`);
+
         // classDeclaration has any other subtypes
         if (classDeclaration.getAssignableClassDeclarations()?.length > 1 && parameters.useNewtonsoftJson){
             parameters.fileWriter.writeLine(1, '[NewtonsoftJson.JsonConverter(typeof(NewtonsoftConcerto.ConcertoConverter))]');
         }
         parameters.fileWriter.writeLine(1, `public ${abstract}class ${classDeclaration.getName()}${superType}{`);
-        const { name: namespace } = ModelUtil.parseNamespace(classDeclaration.getNamespace());
-        const name = classDeclaration.getName();
         const override = namespace === 'concerto' && name === 'Concept' ? 'virtual' : 'override';
-        parameters.fileWriter.writeLine(2, this.toCSharpProperty('public '+ override, '$class', 'String','', `{ get;} = "${classDeclaration.getFullyQualifiedName()}";`, parameters));
+        parameters.fileWriter.writeLine(2, this.toCSharpProperty('public '+ override, '$class', 'String','', `{ get; } = "${classDeclaration.getFullyQualifiedName()}";`, parameters));
         classDeclaration.getOwnProperties().forEach((property) => {
             property.accept(this, parameters);
         });

--- a/packages/concerto-tools/test/codegen/fromcto/csharp/csharpvisitor.js
+++ b/packages/concerto-tools/test/codegen/fromcto/csharp/csharpvisitor.js
@@ -536,10 +536,11 @@ describe('CSharpVisitor', function () {
 
             csharpVisitor.visitClassDeclaration(mockClassDeclaration, param);
 
-            param.fileWriter.writeLine.callCount.should.deep.equal(3);
-            param.fileWriter.writeLine.getCall(0).args.should.deep.equal([1, 'public class Bob {']);
-            param.fileWriter.writeLine.getCall(1).args.should.deep.equal([2, '[JsonPropertyName("$class")]\n\t\tpublic override string _class { get;} = "undefined";']);
-            param.fileWriter.writeLine.getCall(2).args.should.deep.equal([1, '}']);
+            param.fileWriter.writeLine.callCount.should.deep.equal(4);
+            param.fileWriter.writeLine.getCall(0).args.should.deep.equal([1, '[AccordProject.Concerto.Type(Namespace = "org.acme", Version = null, Name = "Bob")]']);
+            param.fileWriter.writeLine.getCall(1).args.should.deep.equal([1, 'public class Bob {']);
+            param.fileWriter.writeLine.getCall(2).args.should.deep.equal([2, '[JsonPropertyName("$class")]\n\t\tpublic override string _class { get; } = "undefined";']);
+            param.fileWriter.writeLine.getCall(3).args.should.deep.equal([1, '}']);
         });
         it('should write the class opening and close with Newtonsoft.Json', () => {
             let acceptSpy = sinon.spy();
@@ -558,11 +559,12 @@ describe('CSharpVisitor', function () {
             mockClassDeclaration.getAssignableClassDeclarations.returns([mockClassDeclaration, mockClassDeclaration2]);
             csharpVisitor.visitClassDeclaration(mockClassDeclaration, { ...param, useNewtonsoftJson: true});
 
-            param.fileWriter.writeLine.callCount.should.deep.equal(4);
-            param.fileWriter.writeLine.getCall(0).args.should.deep.equal([1, '[NewtonsoftJson.JsonConverter(typeof(NewtonsoftConcerto.ConcertoConverter))]']);
-            param.fileWriter.writeLine.getCall(1).args.should.deep.equal([1, 'public class Bob {']);
-            param.fileWriter.writeLine.getCall(2).args.should.deep.equal([2, '[NewtonsoftJson.JsonProperty("$class")]\n\t\tpublic override string _class { get;} = "undefined";']);
-            param.fileWriter.writeLine.getCall(3).args.should.deep.equal([1, '}']);
+            param.fileWriter.writeLine.callCount.should.deep.equal(5);
+            param.fileWriter.writeLine.getCall(0).args.should.deep.equal([1, '[AccordProject.Concerto.Type(Namespace = "org.acme", Version = null, Name = "Bob")]']);
+            param.fileWriter.writeLine.getCall(1).args.should.deep.equal([1, '[NewtonsoftJson.JsonConverter(typeof(NewtonsoftConcerto.ConcertoConverter))]']);
+            param.fileWriter.writeLine.getCall(2).args.should.deep.equal([1, 'public class Bob {']);
+            param.fileWriter.writeLine.getCall(3).args.should.deep.equal([2, '[NewtonsoftJson.JsonProperty("$class")]\n\t\tpublic override string _class { get; } = "undefined";']);
+            param.fileWriter.writeLine.getCall(4).args.should.deep.equal([1, '}']);
         });
         it('should write the class opening and close with abstract and super type', () => {
             let acceptSpy = sinon.spy();
@@ -582,10 +584,11 @@ describe('CSharpVisitor', function () {
 
             csharpVisitor.visitClassDeclaration(mockClassDeclaration, param);
 
-            param.fileWriter.writeLine.callCount.should.deep.equal(3);
-            param.fileWriter.writeLine.getCall(0).args.should.deep.equal([1, 'public abstract class Bob : Person {']);
-            param.fileWriter.writeLine.getCall(1).args.should.deep.equal([2, '[JsonPropertyName("$class")]\n\t\tpublic override string _class { get;} = "undefined";']);
-            param.fileWriter.writeLine.getCall(2).args.should.deep.equal([1, '}']);
+            param.fileWriter.writeLine.callCount.should.deep.equal(4);
+            param.fileWriter.writeLine.getCall(0).args.should.deep.equal([1, '[AccordProject.Concerto.Type(Namespace = "org.acme", Version = null, Name = "Bob")]']);
+            param.fileWriter.writeLine.getCall(1).args.should.deep.equal([1, 'public abstract class Bob : Person {']);
+            param.fileWriter.writeLine.getCall(2).args.should.deep.equal([2, '[JsonPropertyName("$class")]\n\t\tpublic override string _class { get; } = "undefined";']);
+            param.fileWriter.writeLine.getCall(3).args.should.deep.equal([1, '}']);
         });
         it('should write the class opening and close with abstract and super type, with explicit System.Text.Json flag', () => {
             let acceptSpy = sinon.spy();
@@ -605,10 +608,11 @@ describe('CSharpVisitor', function () {
 
             csharpVisitor.visitClassDeclaration(mockClassDeclaration, { ...param, useSystemTextJson: true });
 
-            param.fileWriter.writeLine.callCount.should.deep.equal(3);
-            param.fileWriter.writeLine.getCall(0).args.should.deep.equal([1, 'public abstract class Bob : Person {']);
-            param.fileWriter.writeLine.getCall(1).args.should.deep.equal([2, '[JsonPropertyName("$class")]\n\t\tpublic override string _class { get;} = "undefined";']);
-            param.fileWriter.writeLine.getCall(2).args.should.deep.equal([1, '}']);
+            param.fileWriter.writeLine.callCount.should.deep.equal(4);
+            param.fileWriter.writeLine.getCall(0).args.should.deep.equal([1, '[AccordProject.Concerto.Type(Namespace = "org.acme", Version = null, Name = "Bob")]']);
+            param.fileWriter.writeLine.getCall(1).args.should.deep.equal([1, 'public abstract class Bob : Person {']);
+            param.fileWriter.writeLine.getCall(2).args.should.deep.equal([2, '[JsonPropertyName("$class")]\n\t\tpublic override string _class { get; } = "undefined";']);
+            param.fileWriter.writeLine.getCall(3).args.should.deep.equal([1, '}']);
         });
         it('should write the class opening and close with abstract and super type, with both serializer flags', () => {
             let acceptSpy = sinon.spy();
@@ -628,10 +632,11 @@ describe('CSharpVisitor', function () {
 
             csharpVisitor.visitClassDeclaration(mockClassDeclaration, { ...param, useSystemTextJson: true, useNewtonsoftJson: true });
 
-            param.fileWriter.writeLine.callCount.should.deep.equal(3);
-            param.fileWriter.writeLine.getCall(0).args.should.deep.equal([1, 'public abstract class Bob : Person {']);
-            param.fileWriter.writeLine.getCall(1).args.should.deep.equal([2, '[JsonPropertyName("$class")]\n\t\t[NewtonsoftJson.JsonProperty("$class")]\n\t\tpublic override string _class { get;} = "undefined";']);
-            param.fileWriter.writeLine.getCall(2).args.should.deep.equal([1, '}']);
+            param.fileWriter.writeLine.callCount.should.deep.equal(4);
+            param.fileWriter.writeLine.getCall(0).args.should.deep.equal([1, '[AccordProject.Concerto.Type(Namespace = "org.acme", Version = null, Name = "Bob")]']);
+            param.fileWriter.writeLine.getCall(1).args.should.deep.equal([1, 'public abstract class Bob : Person {']);
+            param.fileWriter.writeLine.getCall(2).args.should.deep.equal([2, '[JsonPropertyName("$class")]\n\t\t[NewtonsoftJson.JsonProperty("$class")]\n\t\tpublic override string _class { get; } = "undefined";']);
+            param.fileWriter.writeLine.getCall(3).args.should.deep.equal([1, '}']);
         });
         it('should write the class opening and close with virtual modifier for base class', () => {
             let acceptSpy = sinon.spy();
@@ -651,10 +656,11 @@ describe('CSharpVisitor', function () {
 
             csharpVisitor.visitClassDeclaration(mockClassDeclaration, param);
 
-            param.fileWriter.writeLine.callCount.should.deep.equal(3);
-            param.fileWriter.writeLine.getCall(0).args.should.deep.equal([1, 'public abstract class Concept {']);
-            param.fileWriter.writeLine.getCall(1).args.should.deep.equal([2, '[JsonPropertyName("$class")]\n\t\tpublic virtual string _class { get;} = "concerto.Concept";']);
-            param.fileWriter.writeLine.getCall(2).args.should.deep.equal([1, '}']);
+            param.fileWriter.writeLine.callCount.should.deep.equal(4);
+            param.fileWriter.writeLine.getCall(0).args.should.deep.equal([1, '[AccordProject.Concerto.Type(Namespace = "concerto", Version = null, Name = "Concept")]']);
+            param.fileWriter.writeLine.getCall(1).args.should.deep.equal([1, 'public abstract class Concept {']);
+            param.fileWriter.writeLine.getCall(2).args.should.deep.equal([2, '[JsonPropertyName("$class")]\n\t\tpublic virtual string _class { get; } = "concerto.Concept";']);
+            param.fileWriter.writeLine.getCall(3).args.should.deep.equal([1, '}']);
         });
         it('should write the class opening and close with virtual modifier for base versioned class', () => {
             let acceptSpy = sinon.spy();
@@ -674,10 +680,11 @@ describe('CSharpVisitor', function () {
 
             csharpVisitor.visitClassDeclaration(mockClassDeclaration, param);
 
-            param.fileWriter.writeLine.callCount.should.deep.equal(3);
-            param.fileWriter.writeLine.getCall(0).args.should.deep.equal([1, 'public abstract class Concept {']);
-            param.fileWriter.writeLine.getCall(1).args.should.deep.equal([2, '[JsonPropertyName("$class")]\n\t\tpublic virtual string _class { get;} = "concerto@1.0.0.Concept";']);
-            param.fileWriter.writeLine.getCall(2).args.should.deep.equal([1, '}']);
+            param.fileWriter.writeLine.callCount.should.deep.equal(4);
+            param.fileWriter.writeLine.getCall(0).args.should.deep.equal([1, '[AccordProject.Concerto.Type(Namespace = "concerto", Version = "1.0.0", Name = "Concept")]']);
+            param.fileWriter.writeLine.getCall(1).args.should.deep.equal([1, 'public abstract class Concept {']);
+            param.fileWriter.writeLine.getCall(2).args.should.deep.equal([2, '[JsonPropertyName("$class")]\n\t\tpublic virtual string _class { get; } = "concerto@1.0.0.Concept";']);
+            param.fileWriter.writeLine.getCall(3).args.should.deep.equal([1, '}']);
         });
     });
 


### PR DESCRIPTION
The .NET package for Concerto now has a `Type` attribute that can be used to associate model information with a .NET class, and make it possible to find all of the available .NET classes generated by Concerto (find all classes in all assemblies with the attribute).

This change adds this attribute to the generated C# code as follows:

```
   [AccordProject.Concerto.Type(Namespace = "concerto", Version = "1.0.0", Name = "Concept")]
   public abstract class Concept {
      [JsonPropertyName("$class")]
      public virtual string _class { get; } = "concerto@1.0.0.Concept";
   }
```