### PR TITLE
feat(cli): add generate command for cli

### DIFF
--- a/packages/concerto-cli/index.js
+++ b/packages/concerto-cli/index.js
@@ -72,7 +72,7 @@ require('yargs')
                 .then((result) => {
                     Logger.info('Input is valid');
                     if (!options.functional) {
-                        Logger.info(result);
+                        console.log(result);
                     }
                 })
                 .catch((err) => {
@@ -215,7 +215,7 @@ require('yargs')
         return Commands.parse(argv.model, argv.resolve, argv.all, argv.output, options)
             .then((result) => {
                 if (result) {
-                    Logger.info(result);
+                    console.log(result);
                 }
             })
             .catch((err) => {
@@ -296,6 +296,54 @@ require('yargs')
         });
     }, argv => {
         return Commands.compare(argv.old, argv.new)
+            .catch((err) => {
+                Logger.error(err.message);
+            });
+    })
+    .command('generate <mode>', 'generate a sample JSON object for a concept', yargs => {
+        yargs.demandOption(['model'], 'Please provide a model');
+        yargs.demandOption(['concept'], 'Please provide the concept name');
+        yargs.option('model', {
+            describe: 'The file location of the source models',
+            type: 'string',
+            array: true,
+        });
+        yargs.option('concept', {
+            describe: 'The fully qualified name of the Concept type to generate',
+            type: 'string',
+        });
+        yargs.positional('mode', {
+            describe: 'Generation mode. `empty` will generate a minimal example, `sample` will generate defaul',
+            type: 'string',
+            choices: [
+                'sample',
+                'empty',
+            ]
+        });
+        yargs.option('includeOptionalFields', {
+            describe: 'Include optional fields will be included in the output',
+            type: 'boolean',
+            default: false
+        });
+        yargs.option('metamodel', {
+            describe: 'Include the Concerto Metamodel in the output',
+            type: 'boolean',
+            default: false,
+        });
+        yargs.option('strict', {
+            describe: 'Require versioned namespaces and imports',
+            type: 'boolean',
+            default: false,
+        });
+    }, argv => {
+        return Commands.generate(argv.model, argv.concept, argv.mode, {
+            optionalFields: argv.includeOptionalFields,
+            metamodel: argv.metamodel,
+            strict: argv.strict,
+        })
+            .then(obj => {
+                console.log(JSON.stringify(obj, null, 2));
+            })
             .catch((err) => {
                 Logger.error(err.message);
             });

--- a/packages/concerto-cli/index.js
+++ b/packages/concerto-cli/index.js
@@ -313,7 +313,7 @@ require('yargs')
             type: 'string',
         });
         yargs.positional('mode', {
-            describe: 'Generation mode. `empty` will generate a minimal example, `sample` will generate defaul',
+            describe: 'Generation mode. `empty` will generate a minimal example, `sample` will generate random values',
             type: 'string',
             choices: [
                 'sample',

--- a/packages/concerto-cli/test/cli.js
+++ b/packages/concerto-cli/test/cli.js
@@ -528,4 +528,30 @@ describe('concerto-cli', () => {
             processExitStub.should.have.been.calledWith(1);
         });
     });
+
+    describe('#generate', async () => {
+        it('should generate an object, including metamodel', async () => {
+            const obj = await Commands.generate(
+                offlineModels,
+                'org.accordproject.money.MonetaryAmount',
+                'sample',
+                { offline: true, optionalFields: true, metamodel: true }
+            );
+            obj.$class.should.equal('org.accordproject.money.MonetaryAmount');
+            (typeof obj.currencyCode).should.equal('string');
+            (typeof obj.doubleValue).should.equal('number');
+        });
+
+        it('should generate an object', async () => {
+            const obj = await Commands.generate(
+                offlineModels,
+                'org.accordproject.money.MonetaryAmount',
+                'sample',
+                { offline: true, optionalFields: true }
+            );
+            obj.$class.should.equal('org.accordproject.money.MonetaryAmount');
+            (typeof obj.currencyCode).should.equal('string');
+            (typeof obj.doubleValue).should.equal('number');
+        });
+    });
 });

--- a/packages/concerto-cli/test/cli.js
+++ b/packages/concerto-cli/test/cli.js
@@ -553,5 +553,16 @@ describe('concerto-cli', () => {
             (typeof obj.currencyCode).should.equal('string');
             (typeof obj.doubleValue).should.equal('number');
         });
+
+        it('should generate an identified object', async () => {
+            const obj = await Commands.generate(
+                offlineModels,
+                'org.accordproject.cicero.dom.ContractTemplate',
+                'sample',
+                { offline: true, optionalFields: true }
+            );
+            obj.$class.should.equal('org.accordproject.cicero.dom.ContractTemplate');
+            Object.keys(obj).should.eql(['$class', 'metadata', 'content', 'id', '$identifier']);
+        });
     });
 });


### PR DESCRIPTION
<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
<!--- Provide an overall summary of the pull request -->
Adds a new command to the Concerto command line tool to generate a sample JSON instance of a type.

```console
$ concerto generate sample --model person.cto --concept org.accordproject.person.Person --includeOptionalFields
{
  "$class": "org.accordproject.person.Person",
  "identifier": "resource1",
  "additionalName": "Duis in ut ad elit.",
  "address": {
    "$class": "org.accordproject.address.PostalAddress",
    "streetAddress": "Officia.",
    "postalCode": "Reprehenderit aliqua pariatur.",
    [...]
}
```

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [x] Merging to `master` from `fork:branchname`
