### PR TITLE
feat(*): use pascal case by default for generated c# code

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "concerto",
-			"version": "3.0.0-alpha.4",
+			"version": "3.0.0-beta.1",
 			"dependencies": {
 				"@babel/preset-env": "7.16.11",
 				"@supercharge/promise-pool": "1.7.0",
@@ -21,6 +21,7 @@
 				"ansi-colors": "4.1.3",
 				"axios": "0.23.0",
 				"babel-loader": "8.2.3",
+				"camelcase": "6.3.0",
 				"chai": "4.3.6",
 				"chai-as-promised": "7.1.1",
 				"chai-things": "0.2.0",
@@ -86,9 +87,9 @@
 			}
 		},
 		"node_modules/@babel/compat-data": {
-			"version": "7.18.8",
-			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.18.8.tgz",
-			"integrity": "sha512-HSmX4WZPPK3FUxYp7g2T6EyO8j96HlZJlxmKPSh6KAcqwyDrfx7hKjXpAW/0FhFfTJsR0Yt4lAjLI2coMptIHQ==",
+			"version": "7.19.0",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.19.0.tgz",
+			"integrity": "sha512-y5rqgTTPTmaF5e2nVhOxw+Ur9HDJLsWb6U/KpgUzRZEdPfE6VOubXBKLdbcUTijzRptednSBDQbYZBOSqJxpJw==",
 			"engines": {
 				"node": ">=6.9.0"
 			}
@@ -139,11 +140,11 @@
 			}
 		},
 		"node_modules/@babel/generator": {
-			"version": "7.18.10",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.18.10.tgz",
-			"integrity": "sha512-0+sW7e3HjQbiHbj1NeU/vN8ornohYlacAfZIaXhdoGweQqgcNy69COVciYYqEXJ/v+9OBA7Frxm4CVAuNqKeNA==",
+			"version": "7.19.0",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.19.0.tgz",
+			"integrity": "sha512-S1ahxf1gZ2dpoiFgA+ohK9DIpz50bJ0CWs7Zlzb54Z4sG8qmdIrGrVqmy1sAtTVRb+9CU6U8VqT9L0Zj7hxHVg==",
 			"dependencies": {
-				"@babel/types": "^7.18.10",
+				"@babel/types": "^7.19.0",
 				"@jridgewell/gen-mapping": "^0.3.2",
 				"jsesc": "^2.5.1"
 			},
@@ -186,11 +187,11 @@
 			}
 		},
 		"node_modules/@babel/helper-compilation-targets": {
-			"version": "7.18.9",
-			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.18.9.tgz",
-			"integrity": "sha512-tzLCyVmqUiFlcFoAPLA/gL9TeYrF61VLNtb+hvkuVaB5SUjW7jcfrglBIX1vUIoT7CLP3bBlIMeyEsIl2eFQNg==",
+			"version": "7.19.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.19.0.tgz",
+			"integrity": "sha512-Ai5bNWXIvwDvWM7njqsG3feMlL9hCVQsPYXodsZyLwshYkZVJt59Gftau4VrE8S9IT9asd2uSP1hG6wCNw+sXA==",
 			"dependencies": {
-				"@babel/compat-data": "^7.18.8",
+				"@babel/compat-data": "^7.19.0",
 				"@babel/helper-validator-option": "^7.18.6",
 				"browserslist": "^4.20.2",
 				"semver": "^6.3.0"
@@ -211,13 +212,13 @@
 			}
 		},
 		"node_modules/@babel/helper-create-class-features-plugin": {
-			"version": "7.18.13",
-			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.18.13.tgz",
-			"integrity": "sha512-hDvXp+QYxSRL+23mpAlSGxHMDyIGChm0/AwTfTAAK5Ufe40nCsyNdaYCGuK91phn/fVu9kqayImRDkvNAgdrsA==",
+			"version": "7.19.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.19.0.tgz",
+			"integrity": "sha512-NRz8DwF4jT3UfrmUoZjd0Uph9HQnP30t7Ash+weACcyNkiYTywpIjDBgReJMKgr+n86sn2nPVVmJ28Dm053Kqw==",
 			"dependencies": {
 				"@babel/helper-annotate-as-pure": "^7.18.6",
 				"@babel/helper-environment-visitor": "^7.18.9",
-				"@babel/helper-function-name": "^7.18.9",
+				"@babel/helper-function-name": "^7.19.0",
 				"@babel/helper-member-expression-to-functions": "^7.18.9",
 				"@babel/helper-optimise-call-expression": "^7.18.6",
 				"@babel/helper-replace-supers": "^7.18.9",
@@ -231,9 +232,9 @@
 			}
 		},
 		"node_modules/@babel/helper-create-regexp-features-plugin": {
-			"version": "7.18.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.18.6.tgz",
-			"integrity": "sha512-7LcpH1wnQLGrI+4v+nPp+zUvIkF9x0ddv1Hkdue10tg3gmRnLy97DXh4STiOf1qeIInyD69Qv5kKSZzKD8B/7A==",
+			"version": "7.19.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.19.0.tgz",
+			"integrity": "sha512-htnV+mHX32DF81amCDrwIDr8nrp1PTm+3wfBN9/v8QJOLEioOCOG7qNyq0nHeFiWbT3Eb7gsPwEmV64UCQ1jzw==",
 			"dependencies": {
 				"@babel/helper-annotate-as-pure": "^7.18.6",
 				"regexpu-core": "^5.1.0"
@@ -246,9 +247,9 @@
 			}
 		},
 		"node_modules/@babel/helper-define-polyfill-provider": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.3.2.tgz",
-			"integrity": "sha512-r9QJJ+uDWrd+94BSPcP6/de67ygLtvVy6cK4luE6MOuDsZIdoaPBnfSpbO/+LTifjPckbKXRuI9BB/Z2/y3iTg==",
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.3.3.tgz",
+			"integrity": "sha512-z5aQKU4IzbqCC1XH0nAqfsFLMVSo22SBKUc0BxGrLkolTdPTructy0ToNnlO2zA4j9Q/7pjMZf0DSY+DSTYzww==",
 			"dependencies": {
 				"@babel/helper-compilation-targets": "^7.17.7",
 				"@babel/helper-plugin-utils": "^7.16.7",
@@ -289,12 +290,12 @@
 			}
 		},
 		"node_modules/@babel/helper-function-name": {
-			"version": "7.18.9",
-			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.18.9.tgz",
-			"integrity": "sha512-fJgWlZt7nxGksJS9a0XdSaI4XvpExnNIgRP+rVefWh5U7BL8pPuir6SJUmFKRfjWQ51OtWSzwOxhaH/EBWWc0A==",
+			"version": "7.19.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.19.0.tgz",
+			"integrity": "sha512-WAwHBINyrpqywkUH0nTnNgI5ina5TFn85HKS0pbPDfxFfhyR/aNQEn4hGi1P1JyT//I0t4OgXUlofzWILRvS5w==",
 			"dependencies": {
-				"@babel/template": "^7.18.6",
-				"@babel/types": "^7.18.9"
+				"@babel/template": "^7.18.10",
+				"@babel/types": "^7.19.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -334,18 +335,18 @@
 			}
 		},
 		"node_modules/@babel/helper-module-transforms": {
-			"version": "7.18.9",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.18.9.tgz",
-			"integrity": "sha512-KYNqY0ICwfv19b31XzvmI/mfcylOzbLtowkw+mfvGPAQ3kfCnMLYbED3YecL5tPd8nAYFQFAd6JHp2LxZk/J1g==",
+			"version": "7.19.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.19.0.tgz",
+			"integrity": "sha512-3HBZ377Fe14RbLIA+ac3sY4PTgpxHVkFrESaWhoI5PuyXPBBX8+C34qblV9G89ZtycGJCmCI/Ut+VUDK4bltNQ==",
 			"dependencies": {
 				"@babel/helper-environment-visitor": "^7.18.9",
 				"@babel/helper-module-imports": "^7.18.6",
 				"@babel/helper-simple-access": "^7.18.6",
 				"@babel/helper-split-export-declaration": "^7.18.6",
 				"@babel/helper-validator-identifier": "^7.18.6",
-				"@babel/template": "^7.18.6",
-				"@babel/traverse": "^7.18.9",
-				"@babel/types": "^7.18.9"
+				"@babel/template": "^7.18.10",
+				"@babel/traverse": "^7.19.0",
+				"@babel/types": "^7.19.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -363,9 +364,9 @@
 			}
 		},
 		"node_modules/@babel/helper-plugin-utils": {
-			"version": "7.18.9",
-			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.18.9.tgz",
-			"integrity": "sha512-aBXPT3bmtLryXaoJLyYPXPlSD4p1ld9aYeR+sJNOZjJJGiOpb+fKfh3NkcCu7J54nUJwCERPBExCCpyCOHnu/w==",
+			"version": "7.19.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.19.0.tgz",
+			"integrity": "sha512-40Ryx7I8mT+0gaNxm8JGTZFUITNqdLAgdg0hXzeVZxVD6nFsdhQvip6v8dqkRHzsz1VFpFAaOCHNn0vKBL7Czw==",
 			"engines": {
 				"node": ">=6.9.0"
 			}
@@ -460,14 +461,14 @@
 			}
 		},
 		"node_modules/@babel/helper-wrap-function": {
-			"version": "7.18.11",
-			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.18.11.tgz",
-			"integrity": "sha512-oBUlbv+rjZLh2Ks9SKi4aL7eKaAXBWleHzU89mP0G6BMUlRxSckk9tSIkgDGydhgFxHuGSlBQZfnaD47oBEB7w==",
+			"version": "7.19.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.19.0.tgz",
+			"integrity": "sha512-txX8aN8CZyYGTwcLhlk87KRqncAzhh5TpQamZUa0/u3an36NtDpUP6bQgBCBcLeBs09R/OwQu3OjK0k/HwfNDg==",
 			"dependencies": {
-				"@babel/helper-function-name": "^7.18.9",
+				"@babel/helper-function-name": "^7.19.0",
 				"@babel/template": "^7.18.10",
-				"@babel/traverse": "^7.18.11",
-				"@babel/types": "^7.18.10"
+				"@babel/traverse": "^7.19.0",
+				"@babel/types": "^7.19.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -500,9 +501,9 @@
 			}
 		},
 		"node_modules/@babel/parser": {
-			"version": "7.18.11",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.18.11.tgz",
-			"integrity": "sha512-9JKn5vN+hDt0Hdqn1PiJ2guflwP+B6Ga8qbDuoF0PzzVhrzsKIJo8yGqVk6CmMHiMei9w1C1Bp9IMJSIK+HPIQ==",
+			"version": "7.19.0",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.19.0.tgz",
+			"integrity": "sha512-74bEXKX2h+8rrfQUfsBfuZZHzsEs6Eql4pqy/T4Nn6Y9wNPggQOqD6z6pn5Bl8ZfysKouFZT/UXEH94ummEeQw==",
 			"bin": {
 				"parser": "bin/babel-parser.js"
 			},
@@ -541,12 +542,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-proposal-async-generator-functions": {
-			"version": "7.18.10",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.18.10.tgz",
-			"integrity": "sha512-1mFuY2TOsR1hxbjCo4QL+qlIjV07p4H4EUYw2J/WCqsvFV6V9X9z9YhXbWndc/4fw+hYGlDT7egYxliMp5O6Ew==",
+			"version": "7.19.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.19.0.tgz",
+			"integrity": "sha512-nhEByMUTx3uZueJ/QkJuSlCfN4FGg+xy+vRsfGQGzSauq5ks2Deid2+05Q3KhfaUjvec1IGhw/Zm3cFm8JigTQ==",
 			"dependencies": {
 				"@babel/helper-environment-visitor": "^7.18.9",
-				"@babel/helper-plugin-utils": "^7.18.9",
+				"@babel/helper-plugin-utils": "^7.19.0",
 				"@babel/helper-remap-async-to-generator": "^7.18.9",
 				"@babel/plugin-syntax-async-generators": "^7.8.4"
 			},
@@ -1032,15 +1033,16 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-classes": {
-			"version": "7.18.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.18.9.tgz",
-			"integrity": "sha512-EkRQxsxoytpTlKJmSPYrsOMjCILacAjtSVkd4gChEe2kXjFCun3yohhW5I7plXJhCemM0gKsaGMcO8tinvCA5g==",
+			"version": "7.19.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.19.0.tgz",
+			"integrity": "sha512-YfeEE9kCjqTS9IitkgfJuxjcEtLUHMqa8yUJ6zdz8vR7hKuo6mOy2C05P0F1tdMmDCeuyidKnlrw/iTppHcr2A==",
 			"dependencies": {
 				"@babel/helper-annotate-as-pure": "^7.18.6",
+				"@babel/helper-compilation-targets": "^7.19.0",
 				"@babel/helper-environment-visitor": "^7.18.9",
-				"@babel/helper-function-name": "^7.18.9",
+				"@babel/helper-function-name": "^7.19.0",
 				"@babel/helper-optimise-call-expression": "^7.18.6",
-				"@babel/helper-plugin-utils": "^7.18.9",
+				"@babel/helper-plugin-utils": "^7.19.0",
 				"@babel/helper-replace-supers": "^7.18.9",
 				"@babel/helper-split-export-declaration": "^7.18.6",
 				"globals": "^11.1.0"
@@ -1216,13 +1218,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-modules-systemjs": {
-			"version": "7.18.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.18.9.tgz",
-			"integrity": "sha512-zY/VSIbbqtoRoJKo2cDTewL364jSlZGvn0LKOf9ntbfxOvjfmyrdtEEOAdswOswhZEb8UH3jDkCKHd1sPgsS0A==",
+			"version": "7.19.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.19.0.tgz",
+			"integrity": "sha512-x9aiR0WXAWmOWsqcsnrzGR+ieaTMVyGyffPVA7F8cXAGt/UxefYv6uSHZLkAFChN5M5Iy1+wjE+xJuPt22H39A==",
 			"dependencies": {
 				"@babel/helper-hoist-variables": "^7.18.6",
-				"@babel/helper-module-transforms": "^7.18.9",
-				"@babel/helper-plugin-utils": "^7.18.9",
+				"@babel/helper-module-transforms": "^7.19.0",
+				"@babel/helper-plugin-utils": "^7.19.0",
 				"@babel/helper-validator-identifier": "^7.18.6",
 				"babel-plugin-dynamic-import-node": "^2.3.3"
 			},
@@ -1249,12 +1251,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-named-capturing-groups-regex": {
-			"version": "7.18.6",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.18.6.tgz",
-			"integrity": "sha512-UmEOGF8XgaIqD74bC8g7iV3RYj8lMf0Bw7NJzvnS9qQhM4mg+1WHKotUIdjxgD2RGrgFLZZPCFPFj3P/kVDYhg==",
+			"version": "7.19.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.19.0.tgz",
+			"integrity": "sha512-HDSuqOQzkU//kfGdiHBt71/hkDTApw4U/cMVgKgX7PqfB3LOaK+2GtCEsBu1dL9CkswDm0Gwehht1dCr421ULQ==",
 			"dependencies": {
-				"@babel/helper-create-regexp-features-plugin": "^7.18.6",
-				"@babel/helper-plugin-utils": "^7.18.6"
+				"@babel/helper-create-regexp-features-plugin": "^7.19.0",
+				"@babel/helper-plugin-utils": "^7.19.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1364,11 +1366,11 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-spread": {
-			"version": "7.18.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.18.9.tgz",
-			"integrity": "sha512-39Q814wyoOPtIB/qGopNIL9xDChOE1pNU0ZY5dO0owhiVt/5kFm4li+/bBtwc7QotG0u5EPzqhZdjMtmqBqyQA==",
+			"version": "7.19.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.19.0.tgz",
+			"integrity": "sha512-RsuMk7j6n+r752EtzyScnWkQyuJdli6LdO5Klv8Yx0OfPVTcQkIUfS8clx5e9yHXzlnhOZF3CbQ8C2uP5j074w==",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.18.9",
+				"@babel/helper-plugin-utils": "^7.19.0",
 				"@babel/helper-skip-transparent-expression-wrappers": "^7.18.9"
 			},
 			"engines": {
@@ -1560,9 +1562,9 @@
 			}
 		},
 		"node_modules/@babel/runtime": {
-			"version": "7.18.9",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.18.9.tgz",
-			"integrity": "sha512-lkqXDcvlFT5rvEjiu6+QYO+1GXrEHRo2LOtS7E4GtX5ESIZOgepqsZBVIj6Pv+a6zqsya9VCgiK1KAK4BvJDAw==",
+			"version": "7.19.0",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.19.0.tgz",
+			"integrity": "sha512-eR8Lo9hnDS7tqkO7NsV+mKvCmv5boaXFSZ70DnfhcgiEne8hv9oCEd36Klw74EtizEqLsy4YnW8UWwpBVolHZA==",
 			"dependencies": {
 				"regenerator-runtime": "^0.13.4"
 			},
@@ -1571,9 +1573,9 @@
 			}
 		},
 		"node_modules/@babel/runtime-corejs3": {
-			"version": "7.18.9",
-			"resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.18.9.tgz",
-			"integrity": "sha512-qZEWeccZCrHA2Au4/X05QW5CMdm4VjUDCrGq5gf1ZDcM4hRqreKrtwAn7yci9zfgAS9apvnsFXiGBHBAxZdK9A==",
+			"version": "7.19.0",
+			"resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.19.0.tgz",
+			"integrity": "sha512-JyXXoCu1N8GLuKc2ii8y5RGma5FMpFeO2nAQIe0Yzrbq+rQnN+sFj47auLblR5ka6aHNGPDgv8G/iI2Grb0ldQ==",
 			"dependencies": {
 				"core-js-pure": "^3.20.2",
 				"regenerator-runtime": "^0.13.4"
@@ -1596,18 +1598,18 @@
 			}
 		},
 		"node_modules/@babel/traverse": {
-			"version": "7.18.11",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.18.11.tgz",
-			"integrity": "sha512-TG9PiM2R/cWCAy6BPJKeHzNbu4lPzOSZpeMfeNErskGpTJx6trEvFaVCbDvpcxwy49BKWmEPwiW8mrysNiDvIQ==",
+			"version": "7.19.0",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.19.0.tgz",
+			"integrity": "sha512-4pKpFRDh+utd2mbRC8JLnlsMUii3PMHjpL6a0SZ4NMZy7YFP9aXORxEhdMVOc9CpWtDF09IkciQLEhK7Ml7gRA==",
 			"dependencies": {
 				"@babel/code-frame": "^7.18.6",
-				"@babel/generator": "^7.18.10",
+				"@babel/generator": "^7.19.0",
 				"@babel/helper-environment-visitor": "^7.18.9",
-				"@babel/helper-function-name": "^7.18.9",
+				"@babel/helper-function-name": "^7.19.0",
 				"@babel/helper-hoist-variables": "^7.18.6",
 				"@babel/helper-split-export-declaration": "^7.18.6",
-				"@babel/parser": "^7.18.11",
-				"@babel/types": "^7.18.10",
+				"@babel/parser": "^7.19.0",
+				"@babel/types": "^7.19.0",
 				"debug": "^4.1.0",
 				"globals": "^11.1.0"
 			},
@@ -1616,9 +1618,9 @@
 			}
 		},
 		"node_modules/@babel/types": {
-			"version": "7.18.10",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.18.10.tgz",
-			"integrity": "sha512-MJvnbEiiNkpjo+LknnmRrqbY1GPUUggjv+wQVjetM/AONoupqRALB7I6jGqNUAZsKcRIEu2J6FRFvsczljjsaQ==",
+			"version": "7.19.0",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.19.0.tgz",
+			"integrity": "sha512-YuGopBq3ke25BVSiS6fgF49Ul9gH1x70Bcr6bqRLjWCkcX8Hre1/5+z+IiWOIerRMSSEfGZVB9z9kyq7wVs9YA==",
 			"dependencies": {
 				"@babel/helper-string-parser": "^7.18.10",
 				"@babel/helper-validator-identifier": "^7.18.6",
@@ -2021,9 +2023,9 @@
 			}
 		},
 		"node_modules/@jest/core/node_modules/ci-info": {
-			"version": "3.3.2",
-			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.3.2.tgz",
-			"integrity": "sha512-xmDt/QIAdeZ9+nfdPsaBCpMvHNLFiLdjj59qjqn+6iPe6YmHGQ35sBnQ8uslRBXFmXkiZQOJRjvQeoGppoTjjg=="
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.4.0.tgz",
+			"integrity": "sha512-t5QdPT5jq3o262DOQ8zA6E1tlH2upmUc4Hlvrbx1pGYJuiiHl7O7rvVNI+l8HTVhd/q3Qc9vqimkNk5yiXsAug=="
 		},
 		"node_modules/@jest/core/node_modules/color-convert": {
 			"version": "2.0.1",
@@ -4670,9 +4672,9 @@
 			}
 		},
 		"node_modules/@sinclair/typebox": {
-			"version": "0.24.31",
-			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.31.tgz",
-			"integrity": "sha512-uWZaAsh9WFhcY1rWLLcMU/omiIIAQ/PmgqplaF6UWY6ULPH0ZO8hupJRAydzlTQZJIK3Voz8o8dYlEx+Cm6BAA=="
+			"version": "0.24.41",
+			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.41.tgz",
+			"integrity": "sha512-TJCgQurls4FipFvHeC+gfAzb+GGstL0TDwYJKQVtTeSvJIznWzP7g3bAd5gEBlr8+bIxqnWS9VGVWREDhmE8jA=="
 		},
 		"node_modules/@sinonjs/commons": {
 			"version": "1.8.3",
@@ -4860,9 +4862,9 @@
 			"dev": true
 		},
 		"node_modules/@types/node": {
-			"version": "18.7.14",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.14.tgz",
-			"integrity": "sha512-6bbDaETVi8oyIARulOE9qF1/Qdi/23z6emrUh0fNJRUmjznqrixD4MpGDdgOFk5Xb0m2H6Xu42JGdvAxaJR/wA=="
+			"version": "18.7.17",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.17.tgz",
+			"integrity": "sha512-0UyfUnt02zIuqp7yC8RYtDkp/vo8bFaQ13KkSEvUAohPOAlnVNbj5Fi3fgPSuwzakS+EvvnnZ4x9y7i6ASaSPQ=="
 		},
 		"node_modules/@types/normalize-package-data": {
 			"version": "2.4.1",
@@ -5940,12 +5942,12 @@
 			}
 		},
 		"node_modules/babel-plugin-polyfill-corejs2": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.3.2.tgz",
-			"integrity": "sha512-LPnodUl3lS0/4wN3Rb+m+UK8s7lj2jcLRrjho4gLw+OJs+I4bvGXshINesY5xx/apM+biTnQ9reDI8yj+0M5+Q==",
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.3.3.tgz",
+			"integrity": "sha512-8hOdmFYFSZhqg2C/JgLUQ+t52o5nirNwaWM2B9LWteozwIvM14VSwdsCAUET10qT+kmySAlseadmfeeSWFCy+Q==",
 			"dependencies": {
 				"@babel/compat-data": "^7.17.7",
-				"@babel/helper-define-polyfill-provider": "^0.3.2",
+				"@babel/helper-define-polyfill-provider": "^0.3.3",
 				"semver": "^6.1.1"
 			},
 			"peerDependencies": {
@@ -7100,30 +7102,21 @@
 			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
 		},
 		"node_modules/core-js-compat": {
-			"version": "3.25.0",
-			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.25.0.tgz",
-			"integrity": "sha512-extKQM0g8/3GjFx9US12FAgx8KJawB7RCQ5y8ipYLbmfzEzmFRWdDjIlxDx82g7ygcNG85qMVUSRyABouELdow==",
+			"version": "3.25.1",
+			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.25.1.tgz",
+			"integrity": "sha512-pOHS7O0i8Qt4zlPW/eIFjwp+NrTPx+wTL0ctgI2fHn31sZOq89rDsmtc/A2vAX7r6shl+bmVI+678He46jgBlw==",
 			"dependencies": {
-				"browserslist": "^4.21.3",
-				"semver": "7.0.0"
+				"browserslist": "^4.21.3"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/core-js"
 			}
 		},
-		"node_modules/core-js-compat/node_modules/semver": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
-			"integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==",
-			"bin": {
-				"semver": "bin/semver.js"
-			}
-		},
 		"node_modules/core-js-pure": {
-			"version": "3.25.0",
-			"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.25.0.tgz",
-			"integrity": "sha512-IeHpLwk3uoci37yoI2Laty59+YqH9x5uR65/yiA0ARAJrTrN4YU0rmauLWfvqOuk77SlNJXj2rM6oT/dBD87+A==",
+			"version": "3.25.1",
+			"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.25.1.tgz",
+			"integrity": "sha512-7Fr74bliUDdeJCBMxkkIuQ4xfxn/SwrVg+HkJUAoNEXVqYLv55l6Af0dJ5Lq2YBUW9yKqSkLXaS5SYPK6MGa/A==",
 			"hasInstallScript": true,
 			"funding": {
 				"type": "opencollective",
@@ -8649,9 +8642,9 @@
 			"integrity": "sha512-8/sOawo8tJ4QOBX8YlQBMxL8+RLZfxMQOif9o0KUKTNTjMYElWPE0r/m5VNFxTRd0NSw8qSy8dajrwX4RYI1Hw=="
 		},
 		"node_modules/follow-redirects": {
-			"version": "1.15.1",
-			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.1.tgz",
-			"integrity": "sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==",
+			"version": "1.15.2",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+			"integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
 			"funding": [
 				{
 					"type": "individual",
@@ -10827,9 +10820,9 @@
 			}
 		},
 		"node_modules/jest-config/node_modules/ci-info": {
-			"version": "3.3.2",
-			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.3.2.tgz",
-			"integrity": "sha512-xmDt/QIAdeZ9+nfdPsaBCpMvHNLFiLdjj59qjqn+6iPe6YmHGQ35sBnQ8uslRBXFmXkiZQOJRjvQeoGppoTjjg=="
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.4.0.tgz",
+			"integrity": "sha512-t5QdPT5jq3o262DOQ8zA6E1tlH2upmUc4Hlvrbx1pGYJuiiHl7O7rvVNI+l8HTVhd/q3Qc9vqimkNk5yiXsAug=="
 		},
 		"node_modules/jest-config/node_modules/color-convert": {
 			"version": "2.0.1",
@@ -11954,9 +11947,9 @@
 			}
 		},
 		"node_modules/jest-util/node_modules/ci-info": {
-			"version": "3.3.2",
-			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.3.2.tgz",
-			"integrity": "sha512-xmDt/QIAdeZ9+nfdPsaBCpMvHNLFiLdjj59qjqn+6iPe6YmHGQ35sBnQ8uslRBXFmXkiZQOJRjvQeoGppoTjjg=="
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.4.0.tgz",
+			"integrity": "sha512-t5QdPT5jq3o262DOQ8zA6E1tlH2upmUc4Hlvrbx1pGYJuiiHl7O7rvVNI+l8HTVhd/q3Qc9vqimkNk5yiXsAug=="
 		},
 		"node_modules/jest-util/node_modules/color-convert": {
 			"version": "2.0.1",
@@ -17088,9 +17081,9 @@
 			}
 		},
 		"node_modules/supports-hyperlinks": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.2.0.tgz",
-			"integrity": "sha512-6sXEzV5+I5j8Bmq9/vUphGRM/RJNT9SCURJLjwfOg51heRtguGWDzcaBlgAzKhQa0EVNpPEKzQuBwZ8S8WaCeQ==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.3.0.tgz",
+			"integrity": "sha512-RpsAZlpWcDwOPQA22aCH4J0t7L8JmAvsCxfOSEwm7cQs3LshN36QaTkwd70DnBOXDWGssw2eUoc8CaRWT0XunA==",
 			"dependencies": {
 				"has-flag": "^4.0.0",
 				"supports-color": "^7.0.0"
@@ -18615,9 +18608,9 @@
 			}
 		},
 		"@babel/compat-data": {
-			"version": "7.18.8",
-			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.18.8.tgz",
-			"integrity": "sha512-HSmX4WZPPK3FUxYp7g2T6EyO8j96HlZJlxmKPSh6KAcqwyDrfx7hKjXpAW/0FhFfTJsR0Yt4lAjLI2coMptIHQ=="
+			"version": "7.19.0",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.19.0.tgz",
+			"integrity": "sha512-y5rqgTTPTmaF5e2nVhOxw+Ur9HDJLsWb6U/KpgUzRZEdPfE6VOubXBKLdbcUTijzRptednSBDQbYZBOSqJxpJw=="
 		},
 		"@babel/core": {
 			"version": "7.16.0",
@@ -18654,11 +18647,11 @@
 			}
 		},
 		"@babel/generator": {
-			"version": "7.18.10",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.18.10.tgz",
-			"integrity": "sha512-0+sW7e3HjQbiHbj1NeU/vN8ornohYlacAfZIaXhdoGweQqgcNy69COVciYYqEXJ/v+9OBA7Frxm4CVAuNqKeNA==",
+			"version": "7.19.0",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.19.0.tgz",
+			"integrity": "sha512-S1ahxf1gZ2dpoiFgA+ohK9DIpz50bJ0CWs7Zlzb54Z4sG8qmdIrGrVqmy1sAtTVRb+9CU6U8VqT9L0Zj7hxHVg==",
 			"requires": {
-				"@babel/types": "^7.18.10",
+				"@babel/types": "^7.19.0",
 				"@jridgewell/gen-mapping": "^0.3.2",
 				"jsesc": "^2.5.1"
 			},
@@ -18688,11 +18681,11 @@
 			}
 		},
 		"@babel/helper-compilation-targets": {
-			"version": "7.18.9",
-			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.18.9.tgz",
-			"integrity": "sha512-tzLCyVmqUiFlcFoAPLA/gL9TeYrF61VLNtb+hvkuVaB5SUjW7jcfrglBIX1vUIoT7CLP3bBlIMeyEsIl2eFQNg==",
+			"version": "7.19.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.19.0.tgz",
+			"integrity": "sha512-Ai5bNWXIvwDvWM7njqsG3feMlL9hCVQsPYXodsZyLwshYkZVJt59Gftau4VrE8S9IT9asd2uSP1hG6wCNw+sXA==",
 			"requires": {
-				"@babel/compat-data": "^7.18.8",
+				"@babel/compat-data": "^7.19.0",
 				"@babel/helper-validator-option": "^7.18.6",
 				"browserslist": "^4.20.2",
 				"semver": "^6.3.0"
@@ -18706,13 +18699,13 @@
 			}
 		},
 		"@babel/helper-create-class-features-plugin": {
-			"version": "7.18.13",
-			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.18.13.tgz",
-			"integrity": "sha512-hDvXp+QYxSRL+23mpAlSGxHMDyIGChm0/AwTfTAAK5Ufe40nCsyNdaYCGuK91phn/fVu9kqayImRDkvNAgdrsA==",
+			"version": "7.19.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.19.0.tgz",
+			"integrity": "sha512-NRz8DwF4jT3UfrmUoZjd0Uph9HQnP30t7Ash+weACcyNkiYTywpIjDBgReJMKgr+n86sn2nPVVmJ28Dm053Kqw==",
 			"requires": {
 				"@babel/helper-annotate-as-pure": "^7.18.6",
 				"@babel/helper-environment-visitor": "^7.18.9",
-				"@babel/helper-function-name": "^7.18.9",
+				"@babel/helper-function-name": "^7.19.0",
 				"@babel/helper-member-expression-to-functions": "^7.18.9",
 				"@babel/helper-optimise-call-expression": "^7.18.6",
 				"@babel/helper-replace-supers": "^7.18.9",
@@ -18720,18 +18713,18 @@
 			}
 		},
 		"@babel/helper-create-regexp-features-plugin": {
-			"version": "7.18.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.18.6.tgz",
-			"integrity": "sha512-7LcpH1wnQLGrI+4v+nPp+zUvIkF9x0ddv1Hkdue10tg3gmRnLy97DXh4STiOf1qeIInyD69Qv5kKSZzKD8B/7A==",
+			"version": "7.19.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.19.0.tgz",
+			"integrity": "sha512-htnV+mHX32DF81amCDrwIDr8nrp1PTm+3wfBN9/v8QJOLEioOCOG7qNyq0nHeFiWbT3Eb7gsPwEmV64UCQ1jzw==",
 			"requires": {
 				"@babel/helper-annotate-as-pure": "^7.18.6",
 				"regexpu-core": "^5.1.0"
 			}
 		},
 		"@babel/helper-define-polyfill-provider": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.3.2.tgz",
-			"integrity": "sha512-r9QJJ+uDWrd+94BSPcP6/de67ygLtvVy6cK4luE6MOuDsZIdoaPBnfSpbO/+LTifjPckbKXRuI9BB/Z2/y3iTg==",
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.3.3.tgz",
+			"integrity": "sha512-z5aQKU4IzbqCC1XH0nAqfsFLMVSo22SBKUc0BxGrLkolTdPTructy0ToNnlO2zA4j9Q/7pjMZf0DSY+DSTYzww==",
 			"requires": {
 				"@babel/helper-compilation-targets": "^7.17.7",
 				"@babel/helper-plugin-utils": "^7.16.7",
@@ -18762,12 +18755,12 @@
 			}
 		},
 		"@babel/helper-function-name": {
-			"version": "7.18.9",
-			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.18.9.tgz",
-			"integrity": "sha512-fJgWlZt7nxGksJS9a0XdSaI4XvpExnNIgRP+rVefWh5U7BL8pPuir6SJUmFKRfjWQ51OtWSzwOxhaH/EBWWc0A==",
+			"version": "7.19.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.19.0.tgz",
+			"integrity": "sha512-WAwHBINyrpqywkUH0nTnNgI5ina5TFn85HKS0pbPDfxFfhyR/aNQEn4hGi1P1JyT//I0t4OgXUlofzWILRvS5w==",
 			"requires": {
-				"@babel/template": "^7.18.6",
-				"@babel/types": "^7.18.9"
+				"@babel/template": "^7.18.10",
+				"@babel/types": "^7.19.0"
 			}
 		},
 		"@babel/helper-hoist-variables": {
@@ -18795,18 +18788,18 @@
 			}
 		},
 		"@babel/helper-module-transforms": {
-			"version": "7.18.9",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.18.9.tgz",
-			"integrity": "sha512-KYNqY0ICwfv19b31XzvmI/mfcylOzbLtowkw+mfvGPAQ3kfCnMLYbED3YecL5tPd8nAYFQFAd6JHp2LxZk/J1g==",
+			"version": "7.19.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.19.0.tgz",
+			"integrity": "sha512-3HBZ377Fe14RbLIA+ac3sY4PTgpxHVkFrESaWhoI5PuyXPBBX8+C34qblV9G89ZtycGJCmCI/Ut+VUDK4bltNQ==",
 			"requires": {
 				"@babel/helper-environment-visitor": "^7.18.9",
 				"@babel/helper-module-imports": "^7.18.6",
 				"@babel/helper-simple-access": "^7.18.6",
 				"@babel/helper-split-export-declaration": "^7.18.6",
 				"@babel/helper-validator-identifier": "^7.18.6",
-				"@babel/template": "^7.18.6",
-				"@babel/traverse": "^7.18.9",
-				"@babel/types": "^7.18.9"
+				"@babel/template": "^7.18.10",
+				"@babel/traverse": "^7.19.0",
+				"@babel/types": "^7.19.0"
 			}
 		},
 		"@babel/helper-optimise-call-expression": {
@@ -18818,9 +18811,9 @@
 			}
 		},
 		"@babel/helper-plugin-utils": {
-			"version": "7.18.9",
-			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.18.9.tgz",
-			"integrity": "sha512-aBXPT3bmtLryXaoJLyYPXPlSD4p1ld9aYeR+sJNOZjJJGiOpb+fKfh3NkcCu7J54nUJwCERPBExCCpyCOHnu/w=="
+			"version": "7.19.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.19.0.tgz",
+			"integrity": "sha512-40Ryx7I8mT+0gaNxm8JGTZFUITNqdLAgdg0hXzeVZxVD6nFsdhQvip6v8dqkRHzsz1VFpFAaOCHNn0vKBL7Czw=="
 		},
 		"@babel/helper-remap-async-to-generator": {
 			"version": "7.18.9",
@@ -18885,14 +18878,14 @@
 			"integrity": "sha512-XO7gESt5ouv/LRJdrVjkShckw6STTaB7l9BrpBaAHDeF5YZT+01PCwmR0SJHnkW6i8OwW/EVWRShfi4j2x+KQw=="
 		},
 		"@babel/helper-wrap-function": {
-			"version": "7.18.11",
-			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.18.11.tgz",
-			"integrity": "sha512-oBUlbv+rjZLh2Ks9SKi4aL7eKaAXBWleHzU89mP0G6BMUlRxSckk9tSIkgDGydhgFxHuGSlBQZfnaD47oBEB7w==",
+			"version": "7.19.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.19.0.tgz",
+			"integrity": "sha512-txX8aN8CZyYGTwcLhlk87KRqncAzhh5TpQamZUa0/u3an36NtDpUP6bQgBCBcLeBs09R/OwQu3OjK0k/HwfNDg==",
 			"requires": {
-				"@babel/helper-function-name": "^7.18.9",
+				"@babel/helper-function-name": "^7.19.0",
 				"@babel/template": "^7.18.10",
-				"@babel/traverse": "^7.18.11",
-				"@babel/types": "^7.18.10"
+				"@babel/traverse": "^7.19.0",
+				"@babel/types": "^7.19.0"
 			}
 		},
 		"@babel/helpers": {
@@ -18916,9 +18909,9 @@
 			}
 		},
 		"@babel/parser": {
-			"version": "7.18.11",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.18.11.tgz",
-			"integrity": "sha512-9JKn5vN+hDt0Hdqn1PiJ2guflwP+B6Ga8qbDuoF0PzzVhrzsKIJo8yGqVk6CmMHiMei9w1C1Bp9IMJSIK+HPIQ=="
+			"version": "7.19.0",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.19.0.tgz",
+			"integrity": "sha512-74bEXKX2h+8rrfQUfsBfuZZHzsEs6Eql4pqy/T4Nn6Y9wNPggQOqD6z6pn5Bl8ZfysKouFZT/UXEH94ummEeQw=="
 		},
 		"@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
 			"version": "7.18.6",
@@ -18939,12 +18932,12 @@
 			}
 		},
 		"@babel/plugin-proposal-async-generator-functions": {
-			"version": "7.18.10",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.18.10.tgz",
-			"integrity": "sha512-1mFuY2TOsR1hxbjCo4QL+qlIjV07p4H4EUYw2J/WCqsvFV6V9X9z9YhXbWndc/4fw+hYGlDT7egYxliMp5O6Ew==",
+			"version": "7.19.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.19.0.tgz",
+			"integrity": "sha512-nhEByMUTx3uZueJ/QkJuSlCfN4FGg+xy+vRsfGQGzSauq5ks2Deid2+05Q3KhfaUjvec1IGhw/Zm3cFm8JigTQ==",
 			"requires": {
 				"@babel/helper-environment-visitor": "^7.18.9",
-				"@babel/helper-plugin-utils": "^7.18.9",
+				"@babel/helper-plugin-utils": "^7.19.0",
 				"@babel/helper-remap-async-to-generator": "^7.18.9",
 				"@babel/plugin-syntax-async-generators": "^7.8.4"
 			}
@@ -19253,15 +19246,16 @@
 			}
 		},
 		"@babel/plugin-transform-classes": {
-			"version": "7.18.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.18.9.tgz",
-			"integrity": "sha512-EkRQxsxoytpTlKJmSPYrsOMjCILacAjtSVkd4gChEe2kXjFCun3yohhW5I7plXJhCemM0gKsaGMcO8tinvCA5g==",
+			"version": "7.19.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.19.0.tgz",
+			"integrity": "sha512-YfeEE9kCjqTS9IitkgfJuxjcEtLUHMqa8yUJ6zdz8vR7hKuo6mOy2C05P0F1tdMmDCeuyidKnlrw/iTppHcr2A==",
 			"requires": {
 				"@babel/helper-annotate-as-pure": "^7.18.6",
+				"@babel/helper-compilation-targets": "^7.19.0",
 				"@babel/helper-environment-visitor": "^7.18.9",
-				"@babel/helper-function-name": "^7.18.9",
+				"@babel/helper-function-name": "^7.19.0",
 				"@babel/helper-optimise-call-expression": "^7.18.6",
-				"@babel/helper-plugin-utils": "^7.18.9",
+				"@babel/helper-plugin-utils": "^7.19.0",
 				"@babel/helper-replace-supers": "^7.18.9",
 				"@babel/helper-split-export-declaration": "^7.18.6",
 				"globals": "^11.1.0"
@@ -19365,13 +19359,13 @@
 			}
 		},
 		"@babel/plugin-transform-modules-systemjs": {
-			"version": "7.18.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.18.9.tgz",
-			"integrity": "sha512-zY/VSIbbqtoRoJKo2cDTewL364jSlZGvn0LKOf9ntbfxOvjfmyrdtEEOAdswOswhZEb8UH3jDkCKHd1sPgsS0A==",
+			"version": "7.19.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.19.0.tgz",
+			"integrity": "sha512-x9aiR0WXAWmOWsqcsnrzGR+ieaTMVyGyffPVA7F8cXAGt/UxefYv6uSHZLkAFChN5M5Iy1+wjE+xJuPt22H39A==",
 			"requires": {
 				"@babel/helper-hoist-variables": "^7.18.6",
-				"@babel/helper-module-transforms": "^7.18.9",
-				"@babel/helper-plugin-utils": "^7.18.9",
+				"@babel/helper-module-transforms": "^7.19.0",
+				"@babel/helper-plugin-utils": "^7.19.0",
 				"@babel/helper-validator-identifier": "^7.18.6",
 				"babel-plugin-dynamic-import-node": "^2.3.3"
 			}
@@ -19386,12 +19380,12 @@
 			}
 		},
 		"@babel/plugin-transform-named-capturing-groups-regex": {
-			"version": "7.18.6",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.18.6.tgz",
-			"integrity": "sha512-UmEOGF8XgaIqD74bC8g7iV3RYj8lMf0Bw7NJzvnS9qQhM4mg+1WHKotUIdjxgD2RGrgFLZZPCFPFj3P/kVDYhg==",
+			"version": "7.19.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.19.0.tgz",
+			"integrity": "sha512-HDSuqOQzkU//kfGdiHBt71/hkDTApw4U/cMVgKgX7PqfB3LOaK+2GtCEsBu1dL9CkswDm0Gwehht1dCr421ULQ==",
 			"requires": {
-				"@babel/helper-create-regexp-features-plugin": "^7.18.6",
-				"@babel/helper-plugin-utils": "^7.18.6"
+				"@babel/helper-create-regexp-features-plugin": "^7.19.0",
+				"@babel/helper-plugin-utils": "^7.19.0"
 			}
 		},
 		"@babel/plugin-transform-new-target": {
@@ -19453,11 +19447,11 @@
 			}
 		},
 		"@babel/plugin-transform-spread": {
-			"version": "7.18.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.18.9.tgz",
-			"integrity": "sha512-39Q814wyoOPtIB/qGopNIL9xDChOE1pNU0ZY5dO0owhiVt/5kFm4li+/bBtwc7QotG0u5EPzqhZdjMtmqBqyQA==",
+			"version": "7.19.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.19.0.tgz",
+			"integrity": "sha512-RsuMk7j6n+r752EtzyScnWkQyuJdli6LdO5Klv8Yx0OfPVTcQkIUfS8clx5e9yHXzlnhOZF3CbQ8C2uP5j074w==",
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.18.9",
+				"@babel/helper-plugin-utils": "^7.19.0",
 				"@babel/helper-skip-transparent-expression-wrappers": "^7.18.9"
 			}
 		},
@@ -19603,17 +19597,17 @@
 			}
 		},
 		"@babel/runtime": {
-			"version": "7.18.9",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.18.9.tgz",
-			"integrity": "sha512-lkqXDcvlFT5rvEjiu6+QYO+1GXrEHRo2LOtS7E4GtX5ESIZOgepqsZBVIj6Pv+a6zqsya9VCgiK1KAK4BvJDAw==",
+			"version": "7.19.0",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.19.0.tgz",
+			"integrity": "sha512-eR8Lo9hnDS7tqkO7NsV+mKvCmv5boaXFSZ70DnfhcgiEne8hv9oCEd36Klw74EtizEqLsy4YnW8UWwpBVolHZA==",
 			"requires": {
 				"regenerator-runtime": "^0.13.4"
 			}
 		},
 		"@babel/runtime-corejs3": {
-			"version": "7.18.9",
-			"resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.18.9.tgz",
-			"integrity": "sha512-qZEWeccZCrHA2Au4/X05QW5CMdm4VjUDCrGq5gf1ZDcM4hRqreKrtwAn7yci9zfgAS9apvnsFXiGBHBAxZdK9A==",
+			"version": "7.19.0",
+			"resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.19.0.tgz",
+			"integrity": "sha512-JyXXoCu1N8GLuKc2ii8y5RGma5FMpFeO2nAQIe0Yzrbq+rQnN+sFj47auLblR5ka6aHNGPDgv8G/iI2Grb0ldQ==",
 			"requires": {
 				"core-js-pure": "^3.20.2",
 				"regenerator-runtime": "^0.13.4"
@@ -19630,26 +19624,26 @@
 			}
 		},
 		"@babel/traverse": {
-			"version": "7.18.11",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.18.11.tgz",
-			"integrity": "sha512-TG9PiM2R/cWCAy6BPJKeHzNbu4lPzOSZpeMfeNErskGpTJx6trEvFaVCbDvpcxwy49BKWmEPwiW8mrysNiDvIQ==",
+			"version": "7.19.0",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.19.0.tgz",
+			"integrity": "sha512-4pKpFRDh+utd2mbRC8JLnlsMUii3PMHjpL6a0SZ4NMZy7YFP9aXORxEhdMVOc9CpWtDF09IkciQLEhK7Ml7gRA==",
 			"requires": {
 				"@babel/code-frame": "^7.18.6",
-				"@babel/generator": "^7.18.10",
+				"@babel/generator": "^7.19.0",
 				"@babel/helper-environment-visitor": "^7.18.9",
-				"@babel/helper-function-name": "^7.18.9",
+				"@babel/helper-function-name": "^7.19.0",
 				"@babel/helper-hoist-variables": "^7.18.6",
 				"@babel/helper-split-export-declaration": "^7.18.6",
-				"@babel/parser": "^7.18.11",
-				"@babel/types": "^7.18.10",
+				"@babel/parser": "^7.19.0",
+				"@babel/types": "^7.19.0",
 				"debug": "^4.1.0",
 				"globals": "^11.1.0"
 			}
 		},
 		"@babel/types": {
-			"version": "7.18.10",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.18.10.tgz",
-			"integrity": "sha512-MJvnbEiiNkpjo+LknnmRrqbY1GPUUggjv+wQVjetM/AONoupqRALB7I6jGqNUAZsKcRIEu2J6FRFvsczljjsaQ==",
+			"version": "7.19.0",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.19.0.tgz",
+			"integrity": "sha512-YuGopBq3ke25BVSiS6fgF49Ul9gH1x70Bcr6bqRLjWCkcX8Hre1/5+z+IiWOIerRMSSEfGZVB9z9kyq7wVs9YA==",
 			"requires": {
 				"@babel/helper-string-parser": "^7.18.10",
 				"@babel/helper-validator-identifier": "^7.18.6",
@@ -19946,9 +19940,9 @@
 					}
 				},
 				"ci-info": {
-					"version": "3.3.2",
-					"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.3.2.tgz",
-					"integrity": "sha512-xmDt/QIAdeZ9+nfdPsaBCpMvHNLFiLdjj59qjqn+6iPe6YmHGQ35sBnQ8uslRBXFmXkiZQOJRjvQeoGppoTjjg=="
+					"version": "3.4.0",
+					"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.4.0.tgz",
+					"integrity": "sha512-t5QdPT5jq3o262DOQ8zA6E1tlH2upmUc4Hlvrbx1pGYJuiiHl7O7rvVNI+l8HTVhd/q3Qc9vqimkNk5yiXsAug=="
 				},
 				"color-convert": {
 					"version": "2.0.1",
@@ -22062,9 +22056,9 @@
 			}
 		},
 		"@sinclair/typebox": {
-			"version": "0.24.31",
-			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.31.tgz",
-			"integrity": "sha512-uWZaAsh9WFhcY1rWLLcMU/omiIIAQ/PmgqplaF6UWY6ULPH0ZO8hupJRAydzlTQZJIK3Voz8o8dYlEx+Cm6BAA=="
+			"version": "0.24.41",
+			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.41.tgz",
+			"integrity": "sha512-TJCgQurls4FipFvHeC+gfAzb+GGstL0TDwYJKQVtTeSvJIznWzP7g3bAd5gEBlr8+bIxqnWS9VGVWREDhmE8jA=="
 		},
 		"@sinonjs/commons": {
 			"version": "1.8.3",
@@ -22246,9 +22240,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "18.7.14",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.14.tgz",
-			"integrity": "sha512-6bbDaETVi8oyIARulOE9qF1/Qdi/23z6emrUh0fNJRUmjznqrixD4MpGDdgOFk5Xb0m2H6Xu42JGdvAxaJR/wA=="
+			"version": "18.7.17",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.17.tgz",
+			"integrity": "sha512-0UyfUnt02zIuqp7yC8RYtDkp/vo8bFaQ13KkSEvUAohPOAlnVNbj5Fi3fgPSuwzakS+EvvnnZ4x9y7i6ASaSPQ=="
 		},
 		"@types/normalize-package-data": {
 			"version": "2.4.1",
@@ -23048,12 +23042,12 @@
 			}
 		},
 		"babel-plugin-polyfill-corejs2": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.3.2.tgz",
-			"integrity": "sha512-LPnodUl3lS0/4wN3Rb+m+UK8s7lj2jcLRrjho4gLw+OJs+I4bvGXshINesY5xx/apM+biTnQ9reDI8yj+0M5+Q==",
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.3.3.tgz",
+			"integrity": "sha512-8hOdmFYFSZhqg2C/JgLUQ+t52o5nirNwaWM2B9LWteozwIvM14VSwdsCAUET10qT+kmySAlseadmfeeSWFCy+Q==",
 			"requires": {
 				"@babel/compat-data": "^7.17.7",
-				"@babel/helper-define-polyfill-provider": "^0.3.2",
+				"@babel/helper-define-polyfill-provider": "^0.3.3",
 				"semver": "^6.1.1"
 			},
 			"dependencies": {
@@ -23969,25 +23963,17 @@
 			}
 		},
 		"core-js-compat": {
-			"version": "3.25.0",
-			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.25.0.tgz",
-			"integrity": "sha512-extKQM0g8/3GjFx9US12FAgx8KJawB7RCQ5y8ipYLbmfzEzmFRWdDjIlxDx82g7ygcNG85qMVUSRyABouELdow==",
+			"version": "3.25.1",
+			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.25.1.tgz",
+			"integrity": "sha512-pOHS7O0i8Qt4zlPW/eIFjwp+NrTPx+wTL0ctgI2fHn31sZOq89rDsmtc/A2vAX7r6shl+bmVI+678He46jgBlw==",
 			"requires": {
-				"browserslist": "^4.21.3",
-				"semver": "7.0.0"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "7.0.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
-					"integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A=="
-				}
+				"browserslist": "^4.21.3"
 			}
 		},
 		"core-js-pure": {
-			"version": "3.25.0",
-			"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.25.0.tgz",
-			"integrity": "sha512-IeHpLwk3uoci37yoI2Laty59+YqH9x5uR65/yiA0ARAJrTrN4YU0rmauLWfvqOuk77SlNJXj2rM6oT/dBD87+A=="
+			"version": "3.25.1",
+			"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.25.1.tgz",
+			"integrity": "sha512-7Fr74bliUDdeJCBMxkkIuQ4xfxn/SwrVg+HkJUAoNEXVqYLv55l6Af0dJ5Lq2YBUW9yKqSkLXaS5SYPK6MGa/A=="
 		},
 		"core-util-is": {
 			"version": "1.0.2",
@@ -25141,9 +25127,9 @@
 			"integrity": "sha512-8/sOawo8tJ4QOBX8YlQBMxL8+RLZfxMQOif9o0KUKTNTjMYElWPE0r/m5VNFxTRd0NSw8qSy8dajrwX4RYI1Hw=="
 		},
 		"follow-redirects": {
-			"version": "1.15.1",
-			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.1.tgz",
-			"integrity": "sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA=="
+			"version": "1.15.2",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+			"integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA=="
 		},
 		"for-each": {
 			"version": "0.3.3",
@@ -26708,9 +26694,9 @@
 					}
 				},
 				"ci-info": {
-					"version": "3.3.2",
-					"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.3.2.tgz",
-					"integrity": "sha512-xmDt/QIAdeZ9+nfdPsaBCpMvHNLFiLdjj59qjqn+6iPe6YmHGQ35sBnQ8uslRBXFmXkiZQOJRjvQeoGppoTjjg=="
+					"version": "3.4.0",
+					"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.4.0.tgz",
+					"integrity": "sha512-t5QdPT5jq3o262DOQ8zA6E1tlH2upmUc4Hlvrbx1pGYJuiiHl7O7rvVNI+l8HTVhd/q3Qc9vqimkNk5yiXsAug=="
 				},
 				"color-convert": {
 					"version": "2.0.1",
@@ -27539,9 +27525,9 @@
 					}
 				},
 				"ci-info": {
-					"version": "3.3.2",
-					"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.3.2.tgz",
-					"integrity": "sha512-xmDt/QIAdeZ9+nfdPsaBCpMvHNLFiLdjj59qjqn+6iPe6YmHGQ35sBnQ8uslRBXFmXkiZQOJRjvQeoGppoTjjg=="
+					"version": "3.4.0",
+					"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.4.0.tgz",
+					"integrity": "sha512-t5QdPT5jq3o262DOQ8zA6E1tlH2upmUc4Hlvrbx1pGYJuiiHl7O7rvVNI+l8HTVhd/q3Qc9vqimkNk5yiXsAug=="
 				},
 				"color-convert": {
 					"version": "2.0.1",
@@ -31490,9 +31476,9 @@
 			}
 		},
 		"supports-hyperlinks": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.2.0.tgz",
-			"integrity": "sha512-6sXEzV5+I5j8Bmq9/vUphGRM/RJNT9SCURJLjwfOg51heRtguGWDzcaBlgAzKhQa0EVNpPEKzQuBwZ8S8WaCeQ==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.3.0.tgz",
+			"integrity": "sha512-RpsAZlpWcDwOPQA22aCH4J0t7L8JmAvsCxfOSEwm7cQs3LshN36QaTkwd70DnBOXDWGssw2eUoc8CaRWT0XunA==",
 			"requires": {
 				"has-flag": "^4.0.0",
 				"supports-color": "^7.0.0"

--- a/packages/concerto-cli/index.js
+++ b/packages/concerto-cli/index.js
@@ -130,6 +130,11 @@ require('yargs')
             describe: 'A prefix to add to all namespaces (`csharp` target only)',
             type: 'string',
         });
+        yargs.option('pascalCase', {
+            describe: 'Use PascalCase for generated identifier names',
+            type: 'boolean',
+            default: true
+        });
         yargs.check(({ model, metamodel }) => {
             if (model.length > 0 || metamodel) {
                 return true;
@@ -149,6 +154,7 @@ require('yargs')
         options.useSystemTextJson = argv.useSystemTextJson;
         options.useNewtonsoftJson = argv.useNewtonsoftJson;
         options.namespacePrefix = argv.namespacePrefix;
+        options.pascalCase = argv.pascalCase;
         return Commands.compile(argv.target, argv.model, argv.output, options)
             .then((result) => {
                 Logger.info(result);

--- a/packages/concerto-cli/lib/commands.js
+++ b/packages/concerto-cli/lib/commands.js
@@ -147,13 +147,15 @@ class Commands {
      * @param {boolean} [options.metamodel] - include the Concerto Metamodel
      * @param {boolean} [options.useSystemTextJson] - compile for System.Text.Json library
      * @param {boolean} [options.useNewtonsoftJson] - compile for Newtonsoft.Json library
+     * @param {boolean} [options.pascalCase] - use PascalCase in generated names
      */
     static async compile(target, ctoFiles, output, options) {
         const modelManagerOptions = { offline: options && options.offline, strict: options && options.strict };
         const visitorOptions = {
             useSystemTextJson: options && options.useSystemTextJson,
             useNewtonsoftJson: options && options.useNewtonsoftJson,
-            namespacePrefix: options && options.namespacePrefix
+            namespacePrefix: options && options.namespacePrefix,
+            pascalCase: options && options.pascalCase,
         };
 
         const modelManager = await ModelLoader.loadModelManager(ctoFiles, modelManagerOptions);

--- a/packages/concerto-tools/package.json
+++ b/packages/concerto-tools/package.json
@@ -63,6 +63,7 @@
         "@accordproject/concerto-util": "3.0.0-beta.1",
         "ajv": "8.10.0",
         "ajv-formats": "2.1.1",
+        "camelcase": "6.3.0",
         "debug": "4.3.1"
     },
     "license-check-and-add-config": {

--- a/packages/concerto-tools/types/lib/codegen/fromcto/csharp/csharpvisitor.d.ts
+++ b/packages/concerto-tools/types/lib/codegen/fromcto/csharp/csharpvisitor.d.ts
@@ -75,6 +75,7 @@ declare class CSharpVisitor {
     /**
      * Ensures that a concerto property name is valid in CSharp
      * @param {string} access the CSharp field access
+     * @param {string|undefined} parentName the Concerto parent name
      * @param {string} propertyName the Concerto property name
      * @param {string} propertyType the Concerto property type
      * @param {string} array the array declaration
@@ -82,11 +83,37 @@ declare class CSharpVisitor {
      * @param {Object} [parameters]  - the parameter
      * @returns {string} the property declaration
      */
-    toCSharpProperty(access: string, propertyName: string, propertyType: string, array: string, getset: string, parameters?: any): string;
+    toCSharpProperty(access: string, parentName: string | undefined, propertyName: string, propertyType: string, array: string, getset: string, parameters?: any): string;
+    /**
+     * Converts a Concerto namespace to a CSharp namespace. If pascal casing is enabled,
+     * each component of the namespace is pascal cased - for example org.example will
+     * become Org.Example, not OrgExample.
+     * @param {string} ns the Concerto namespace
+     * @param {object} [parameters] true to enable pascal casing
+     * @param {boolean} [parameters.pascalCase] true to enable pascal casing
+     * @return {string} the CSharp identifier
+     * @private
+     */
+    private toCSharpNamespace;
+    /**
+     * Converts a Concerto name to a CSharp identifier. Internal names such
+     * as $class, $identifier are prefixed with "_". Names matching C# keywords
+     * such as class, namespace are prefixed with "_". If pascal casing is enabled,
+     * the name is pascal cased.
+     * @param {string|undefined} parentName the Concerto name of the parent type
+     * @param {string} name the Concerto name
+     * @param {object} [parameters] true to enable pascal casing
+     * @param {boolean} [parameters.pascalCase] true to enable pascal casing
+     * @return {string} the CSharp identifier
+     * @private
+     */
+    private toCSharpIdentifier;
     /**
      * Converts a Concerto type to a CSharp type. Primitive types are converted
      * everything else is passed through unchanged.
      * @param {string} type  - the concerto type
+     * @param {object} [parameters] true to enable pascal casing
+     * @param {boolean} [parameters.pascalCase] true to enable pascal casing
      * @return {string} the corresponding type in CSharp
      * @private
      */
@@ -95,7 +122,9 @@ declare class CSharpVisitor {
      * Get the .NET namespace for a given model file.
      * @private
      * @param {ModelFile} modelFile the model file
-     * @param {string} [namespacePrefix] the optional namespace prefix
+     * @param {object} [parameters] the parameters
+     * @param {string} [parameters.namespacePrefix] the optional namespace prefix
+     * @param {boolean} [parameters.pascalCase] the optional namespace prefix
      * @return {string} the .NET namespace for the model file
      */
     private getDotNetNamespace;


### PR DESCRIPTION
C# naming conventions (https://docs.microsoft.com/en-us/dotnet/csharp/fundamentals/coding-style/coding-conventions#naming-conventions) dictate that you should use PascalCase for namespace, class, enum and public members. 

We currently don't generate C# code that conforms to these conventions, and when using it in a C# application it just feels... odd!

This change uses the `camelcase` library (confusing, but it seems to be the most popular one!) to generate C# code that conforms to these conventions.

Signed-off-by: Simon Stone <Simon.Stone@docusign.com>