### PR TITLE
feat(*): add identifier attribute to generated c# fields

### DIFF
--- a/packages/concerto-tools/lib/codegen/fromcto/csharp/csharpvisitor.js
+++ b/packages/concerto-tools/lib/codegen/fromcto/csharp/csharpvisitor.js
@@ -249,6 +249,11 @@ class CSharpVisitor {
             nullableType = '?';
         }
 
+        let isIdentifier = field.getName() === field.getParent()?.getIdentifierFieldName();
+        if (isIdentifier) {
+            parameters.fileWriter.writeLine(1, '[AccordProject.Concerto.Identifier()]');
+        }
+
         const lines = this.toCSharpProperty(
             'public',
             field.getParent()?.getName(),

--- a/packages/concerto-tools/test/codegen/fromcto/csharp/csharpvisitor.js
+++ b/packages/concerto-tools/test/codegen/fromcto/csharp/csharpvisitor.js
@@ -212,6 +212,41 @@ describe('CSharpVisitor', function () {
             file1.should.match(/class Model/);
             file1.should.match(/public string _Model/);
         });
+
+        it('should add identifier attributes for concepts with identified', () => {
+            const modelManager = new ModelManager({ strict: true });
+            modelManager.addCTOModel(`
+            namespace org.acme@1.2.3
+
+            concept Thing identified {
+                o String value
+            }
+            `);
+            csharpVisitor.visit(modelManager, { fileWriter, pascalCase: true });
+            const files = fileWriter.getFilesInMemory();
+            const file1 = files.get('org.acme@1.2.3.cs');
+            file1.should.match(/class Thing/);
+            file1.should.match(/AccordProject.Concerto.Identifier\(\)/);
+            file1.should.match(/public string _Identifier/);
+        });
+
+        it('should add identifier attributes for concepts with identified by', () => {
+            const modelManager = new ModelManager({ strict: true });
+            modelManager.addCTOModel(`
+            namespace org.acme@1.2.3
+
+            concept Thing identified by thingId {
+                o String thingId
+                o String value
+            }
+            `);
+            csharpVisitor.visit(modelManager, { fileWriter, pascalCase: true });
+            const files = fileWriter.getFilesInMemory();
+            const file1 = files.get('org.acme@1.2.3.cs');
+            file1.should.match(/class Thing/);
+            file1.should.match(/AccordProject.Concerto.Identifier\(\)/);
+            file1.should.match(/public string ThingId/);
+        });
     });
 
     describe('visit', () => {


### PR DESCRIPTION
Update the C# code generator to add the new attribute `[AccordProject.Concerto.Identifier()]` to any identifying fields.

Signed-off-by: Simon Stone <Simon.Stone@docusign.com>