### PR TITLE
fix(*): handle version when namespace in comments

### DIFF
--- a/packages/concerto-cli/test/cli.js
+++ b/packages/concerto-cli/test/cli.js
@@ -352,6 +352,32 @@ describe('concerto-cli', () => {
             const sourceCtoPath = path.resolve(__dirname, 'models', 'badversion.cto');
             await Commands.version('patch', [sourceCtoPath]).should.be.rejectedWith(/invalid current version "undefined"/);
         });
+
+        it('should ignore namespaces in comments if possible #1', async () => {
+            const release = 'keep';
+            const prerelease = 'pr.1234567';
+            const sourceCtoPath = path.resolve(__dirname, 'models', 'version-in-comment.cto');
+            const sourceCto = fs.readFileSync(sourceCtoPath, 'utf-8');
+            const ctoPath = (await tmp.file({ unsafeCleanup: true })).path;
+            fs.writeFileSync(ctoPath, sourceCto, 'utf-8');
+            await Commands.version(release, [ctoPath], prerelease);
+            const cto = fs.readFileSync(ctoPath, 'utf-8');
+            const metamodel = Parser.parse(cto);
+            metamodel.namespace.should.equal('org.accordproject.concerto.test@1.2.3-pr.1234567');
+        });
+
+        it('should ignore namespaces in comments if possible #2', async () => {
+            const release = 'keep';
+            const prerelease = 'pr.1234567';
+            const sourceCtoPath = path.resolve(__dirname, 'models', 'version-in-comment2.cto');
+            const sourceCto = fs.readFileSync(sourceCtoPath, 'utf-8');
+            const ctoPath = (await tmp.file({ unsafeCleanup: true })).path;
+            fs.writeFileSync(ctoPath, sourceCto, 'utf-8');
+            await Commands.version(release, [ctoPath], prerelease);
+            const cto = fs.readFileSync(ctoPath, 'utf-8');
+            const metamodel = Parser.parse(cto);
+            metamodel.namespace.should.equal('org.accordproject.concerto.test@1.2.3-pr.1234567');
+        });
     });
 
     describe('#version (imports)', async () => {

--- a/packages/concerto-cli/test/models/version-in-comment.cto
+++ b/packages/concerto-cli/test/models/version-in-comment.cto
@@ -1,0 +1,21 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * This is namespace org.accordproject.concerto.test@1.2.3 for testing purposes.
+ */
+
+namespace org.accordproject.concerto.test@1.2.3
+
+concept Foo {
+    o String bar
+}

--- a/packages/concerto-cli/test/models/version-in-comment2.cto
+++ b/packages/concerto-cli/test/models/version-in-comment2.cto
@@ -1,0 +1,23 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * This is:
+namespace org.accordproject.concerto.test@1.2.3
+ * It is for testing purposes.
+ */
+
+namespace org.accordproject.concerto.test@1.2.3
+
+concept Foo {
+    o String bar
+}


### PR DESCRIPTION
If you attempt to version the following CTO file:

```
/*
 * something something namespace something something concerto
 */

namespace org.example@1.2.3
```

It silently updates the comment and ignores the actual namespace.

This change fixes that problem by improving the regex to only match `namespace <currentNamespace>`, and introduces a sanity test that will ensure that the updated CTO file parses to a metamodel with the new namespace.

Signed-off-by: Simon Stone <Simon.Stone@docusign.com>