### PR TITLE
feat(tools): improve JSON schema inference 

### DIFF
--- a/packages/concerto-cli/index.js
+++ b/packages/concerto-cli/index.js
@@ -323,7 +323,7 @@ require('yargs')
             type: 'string'
         });
         yargs.option('namespace', {
-            describe: 'The namepspace for the output model',
+            describe: 'The namespace for the output model',
             type: 'string',
         });
         yargs.option('typeName', {

--- a/packages/concerto-cli/test/cli.js
+++ b/packages/concerto-cli/test/cli.js
@@ -563,8 +563,6 @@ describe('concerto-cli', () => {
             );
             obj.should.equal(`namespace concerto.test.jsonSchema
 
-import org.accordproject.time.* from https://models.accordproject.org/time@0.2.0.cto
-
 concept Root {
    o String name optional
    o Root[] children optional
@@ -581,8 +579,6 @@ concept Root {
                 'openapi'
             );
             obj.should.equal(`namespace petstore
-
-import org.accordproject.time.* from https://models.accordproject.org/time@0.2.0.cto
 
 concept Pet {
    o NewPet pet optional

--- a/packages/concerto-tools/test/codegen/fromJsonSchema/cto/data/full.cto
+++ b/packages/concerto-tools/test/codegen/fromJsonSchema/cto/data/full.cto
@@ -1,7 +1,5 @@
 namespace org.acme
 
-import org.accordproject.time.* from https://models.accordproject.org/time@0.2.0.cto
-
 concept Children {
    o String name
    o Integer age
@@ -16,6 +14,8 @@ concept Children {
    o String[] emptyArray
    o Pet[] favoritePets
    o Stuff[] stuff
+   o String json optional
+   o Double alternation optional
 }
 
 enum Color {

--- a/packages/concerto-tools/test/codegen/fromJsonSchema/cto/data/schema.json
+++ b/packages/concerto-tools/test/codegen/fromJsonSchema/cto/data/schema.json
@@ -142,6 +142,16 @@
                         },
                         "required": ["$class", "sku", "price", "product"]
                     }
+                },
+                "json": {
+                    "type": "object"
+                },
+                "alternation": {
+                    "oneOf": [
+                        { "type": "number" },
+                        { "type": "string" }
+                    ]
+
                 }
             },
             "required": [


### PR DESCRIPTION
- Relaxes error handling to quietly warn users of issues. This allows users to manually rectify issues.
- Basic support for `oneOf` alternatives (fallback to first alternative)
- Basic support for plain object types (defaults to `String` type, to allow serialisation. 