### PR TITLE
chore(main) : update workflows and docs to use main branch

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -27,4 +27,4 @@
 - [ ] Vital features and changes captured in unit and/or integration tests
 - [ ] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
 - [ ] Extend the documentation, if necessary
-- [ ] Merging to `master` from `fork:branchname`
+- [ ] Merging to `main` from `fork:branchname`

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Create PR to increment version
         uses: peter-evans/create-pull-request@v3
         with:
-          base: master
+          base: main
           commit-message: 'chore(actions): publish ${{ github.event.release.tag_name }} to npm'
           committer: GitHub <noreply@github.com>
           author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>

--- a/contrib-notes/coding-guidelines.md
+++ b/contrib-notes/coding-guidelines.md
@@ -30,13 +30,13 @@ $ git clone git@github.com:MyGitName/concerto.git
 ```
 $ git remote add upstream git@github.com:accordproject/concerto.git
 ```
-- As this is just forked it will be up-to-date. But if you did this previously and now starting on something new, the next step is to update your master branch.
+- As this is just forked it will be up-to-date. But if you did this previously and now starting on something new, the next step is to update your main branch.
 
   *This is the point you would come to generally when starting anything new, a new clone/fork every time is not necessary*
 
 ```
-$ git checkout master       # puts you into master branch if not there already
-$ git pull upstream master  # gets all the changes from the upstream master
+$ git checkout main       # puts you into main branch if not there already
+$ git pull upstream main  # gets all the changes from the upstream main
 ```
 
 - The piece of work you are starting on could be a defect, new feature, or something experimental.  The approach is the same for any these and requires working in a new branch.
@@ -48,7 +48,7 @@ $ git checkout -b defect-1234    # Including reference to the git issue is usefu
 
 - Time passes, and you now have a change that you are happy with. Next step is to push this to your local repository. First step is to ensure that your branch is updated.
 ```
-$ git pull upstream master
+$ git pull upstream main
 ```
 You might at this point need to do manual merges.
 - **Retest to ensure everything is Good**
@@ -56,7 +56,7 @@ You might at this point need to do manual merges.
 ```
 $ git push origin defect-1234   # note the branch you have been working on
 ```
-- The next step is to go to the Github web-ui and create a pull request to the master repository for this fork.
+- The next step is to go to the Github web-ui and create a pull request to the main repository for this fork.
 - ...screen shots needed here - wip...
 - All Pull Requests should be linked to the issue they are addressing
 - All Pull Requests should have a review by another committer on the Concerto project
@@ -64,9 +64,9 @@ $ git push origin defect-1234   # note the branch you have been working on
 
 ### Important Reminders
 - NEVER work in your master branch
-- Should this occur, then the master branch will need to be reset using this command
+- Should this occur, then the main branch will need to be reset using this command
 ```
-$ git reset --hard upstream/master && curl -O site://hursley-house/topfloor/penguin.penance
+$ git reset --hard upstream/main
 ```
 
 ## Development approach

--- a/contrib-notes/submitting-pull-request.md
+++ b/contrib-notes/submitting-pull-request.md
@@ -8,7 +8,7 @@
 
 *Before* submitting a pull request, please search carefully for any open or closed pull requests that relate to the issue you are targeting.
 
-- Fork the repo and create your branch from `master`.
+- Fork the repo and create your branch from `main`.
 - Follow our [coding guidelines](./coding-guidelines.md) when making your coding changes.
 - Ensure that all test suites pass locally (`npm test`).
 - Commit any changes using a descriptive commit message.


### PR DESCRIPTION
Signed-off-by: Dan Selman <danscode@selman.org>

### Changes
- Updates GitHub workflows to use main branch instead of master
- Updates docs to use main branch instead of master

### Flags
<!--- Provide context or concerns a reviewer should be aware of -->
- <ONE>
- <TWO>

### Screenshots or Video
<!--- Provide an easily accessible demonstration of the changes, if applicable -->

### Related Issues
- Issue #<NUMBER>
- Pull Request #<NUMBER>

### Author Checklist
- [ ] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [ ] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ ] Merging to `master` from `fork:branchname`
