### PR TITLE
fix(core): deal with unqualified date times in local offsets

### DIFF
--- a/packages/concerto-cli/lib/commands.js
+++ b/packages/concerto-cli/lib/commands.js
@@ -122,7 +122,7 @@ class Commands {
             const factory = new Factory(modelManager);
             const serializer = new Serializer(factory, modelManager);
 
-            const object = serializer.fromJSON(json);
+            const object = serializer.fromJSON(json, options);
             return JSON.stringify(serializer.toJSON(object, options));
         }
     }

--- a/packages/concerto-core/lib/serializer.js
+++ b/packages/concerto-core/lib/serializer.js
@@ -15,18 +15,15 @@
 'use strict';
 
 const { TypedStack } = require('@accordproject/concerto-util');
-const DateTimeUtil = require('./datetimeutil');
 const Globalize = require('./globalize');
 const JSONGenerator = require('./serializer/jsongenerator');
 const JSONPopulator = require('./serializer/jsonpopulator');
 const Typed = require('./model/typed');
 const ResourceValidator = require('./serializer/resourcevalidator');
 
-const { utcOffset: defaultUtcOffset } = DateTimeUtil.setCurrentTime();
 const baseDefaultOptions = {
     validate: true,
     ergo: false,
-    utcOffset: defaultUtcOffset,
 };
 
 // Types needed for TypeScript generation.

--- a/packages/concerto-core/lib/serializer.js
+++ b/packages/concerto-core/lib/serializer.js
@@ -15,6 +15,9 @@
 'use strict';
 
 const { TypedStack } = require('@accordproject/concerto-util');
+const dayjs = require('dayjs');
+const utc = require('dayjs/plugin/utc');
+dayjs.extend(utc);
 const Globalize = require('./globalize');
 const JSONGenerator = require('./serializer/jsongenerator');
 const JSONPopulator = require('./serializer/jsonpopulator');
@@ -59,7 +62,7 @@ class Serializer {
 
         this.factory = factory;
         this.modelManager = modelManager;
-        this.defaultOptions = Object.assign({}, baseDefaultOptions, options || {});
+        this.defaultOptions = { ...baseDefaultOptions, ...options };
     }
 
     /**
@@ -68,7 +71,7 @@ class Serializer {
      */
     setDefaultOptions(newDefaultOptions) {
         // Combine the specified default options with the base default
-        this.defaultOptions = Object.assign({}, baseDefaultOptions, newDefaultOptions);
+        this.defaultOptions = { ...baseDefaultOptions, ...newDefaultOptions };
     }
 
     /**
@@ -107,8 +110,15 @@ class Serializer {
         parameters.dedupeResources = new Set();
         const classDeclaration = this.modelManager.getType( resource.getFullyQualifiedType() );
 
+        options = {
+            ...this.defaultOptions,
+            ...options,
+            // if there is no explicit offset, we use Z
+            // i.e. the default offset is only used for parsing ambiguous dates
+            utcOffset: options?.utcOffset
+        };
+
         // validate the resource against the model
-        options = options ? Object.assign({}, this.defaultOptions, options) : this.defaultOptions;
         if(options.validate) {
             const validator = new ResourceValidator(options);
             classDeclaration.accept(validator, parameters);
@@ -149,7 +159,7 @@ class Serializer {
      */
     fromJSON(jsonObject, options) {
         // set default options
-        options = options ? Object.assign({}, this.defaultOptions, options) : this.defaultOptions;
+        options = { ...this.defaultOptions, ...options };
 
         if (options && options.ergo === true) {
             const theClass = jsonObject.$class.$coll[0];
@@ -191,7 +201,12 @@ class Serializer {
         parameters.resourceStack = new TypedStack(resource);
         parameters.modelManager = this.modelManager;
         parameters.factory = this.factory;
-        const populator = new JSONPopulator(options.acceptResourcesForRelationships === true, options.ergo === true, options.utcOffset);
+
+        const utcOffset = options.utcOffset;
+        const acceptResourcesForRelationships = options.acceptResourcesForRelationships === true;
+        const ergo = options.ergo === true;
+
+        const populator = new JSONPopulator(acceptResourcesForRelationships, ergo, utcOffset);
         classDeclaration.accept(populator, parameters);
 
         // validate the resource against the model

--- a/packages/concerto-core/lib/serializer/jsongenerator.js
+++ b/packages/concerto-core/lib/serializer/jsongenerator.js
@@ -14,10 +14,6 @@
 
 'use strict';
 
-const dayjs = require('dayjs');
-const utc = require('dayjs/plugin/utc');
-dayjs.extend(utc);
-
 const Resource = require('../model/resource');
 const Typed = require('../model/typed');
 const ModelUtil = require('../modelutil');
@@ -55,12 +51,7 @@ class JSONGenerator {
         this.deduplicateResources = deduplicateResources;
         this.convertResourcesToId = convertResourcesToId;
         this.ergo = ergo;
-
-        // 0 is a valid offset, but is falsy in JS
-        if (utcOffset !== undefined){
-            const normalizedUtcOffset = dayjs.utc().utcOffset(utcOffset).utcOffset();
-            this.utcOffset =  normalizedUtcOffset;
-        }
+        this.utcOffset = utcOffset || 0;
     }
 
     /**
@@ -223,16 +214,12 @@ class JSONGenerator {
         switch (field.getType()) {
         case 'DateTime':
         {
+            const objWithOffset = obj.utc().utcOffset(this.utcOffset);
             if (this.ergo) {
-                return obj;
+                return objWithOffset;
             } else {
-                // Render the date using the explicitly provided offset
-                if (this.utcOffset !== undefined && this.utcOffset !== obj.utcOffset()) {
-                    const inZ = this.utcOffset === 0;
-                    return obj.utcOffset(this.utcOffset).format(`YYYY-MM-DDTHH:mm:ss.SSS${inZ ? '[Z]': 'Z'}`);
-                }
-                const inZ = obj.utcOffset() === 0;
-                return obj.format(`YYYY-MM-DDTHH:mm:ss.SSS${inZ ? '[Z]': 'Z'}`);
+                const inZ = objWithOffset.utcOffset() === 0;
+                return objWithOffset.format(`YYYY-MM-DDTHH:mm:ss.SSS${inZ ? '[Z]': 'Z'}`);
             }
         }
         case 'Integer':

--- a/packages/concerto-core/lib/serializer/jsongenerator.js
+++ b/packages/concerto-core/lib/serializer/jsongenerator.js
@@ -60,9 +60,6 @@ class JSONGenerator {
         if (utcOffset !== undefined){
             const normalizedUtcOffset = dayjs.utc().utcOffset(utcOffset).utcOffset();
             this.utcOffset =  normalizedUtcOffset;
-        } else {
-            const localMachineUtcOffset = dayjs().utcOffset();
-            this.utcOffset = localMachineUtcOffset;
         }
     }
 
@@ -229,10 +226,12 @@ class JSONGenerator {
             if (this.ergo) {
                 return obj;
             } else {
-                const inZ = this.utcOffset === 0;
-                if (this.utcOffset !== obj.utcOffset()) {
+                // Render the date using the explicitly provided offset
+                if (this.utcOffset !== undefined && this.utcOffset !== obj.utcOffset()) {
+                    const inZ = this.utcOffset === 0;
                     return obj.utcOffset(this.utcOffset).format(`YYYY-MM-DDTHH:mm:ss.SSS${inZ ? '[Z]': 'Z'}`);
                 }
+                const inZ = obj.utcOffset() === 0;
                 return obj.format(`YYYY-MM-DDTHH:mm:ss.SSS${inZ ? '[Z]': 'Z'}`);
             }
         }

--- a/packages/concerto-core/lib/serializer/jsonpopulator.js
+++ b/packages/concerto-core/lib/serializer/jsonpopulator.js
@@ -96,9 +96,6 @@ class JSONPopulator {
         if (utcOffset !== undefined){
             const normalizedUtcOffset = dayjs.utc().utcOffset(utcOffset).utcOffset();
             this.utcOffset =  normalizedUtcOffset;
-        } else {
-            const localMachineUtcOffset = dayjs().utcOffset();
-            this.utcOffset = localMachineUtcOffset;
         }
     }
 
@@ -269,16 +266,16 @@ class JSONPopulator {
             // offsets. Specifically, parsing does not respect the local offset.
             } else if (json.match(/^(--)?\d{2}-\d{2}$/)) {
                 throw new ValidationException(`Expected value at path \`${path}\` to be of type \`${field.getType()}\``);
-            // The date is an unqualified "local-time" so use the
-            // local UTC Offset if an offset wasn't specified as a parameter
-            // https://en.wikipedia.org/wiki/ISO_8601#Local_time_(unqualified)
-            } else if (!json.match(/(Z|(\+|-)\d{2}:\d{2}?)$/i)) {
-                // setting true keeps the time the same when changing the offset
-                result = dayjs.utc(json).utcOffset(this.utcOffset, true);
-            // Otherwise, all of the offset information is in the string.
+            // Unqualified Local Time, i.e. no zone designation in string
+            } else if (!json.match(/(Z|(\+|-)\d{2}:\d{2}?)$/i)){
+                // Default to UTC
+                const offset = this.utcOffset !== undefined ? this.utcOffset : 0;
+                result = dayjs.utc(json).utcOffset(offset, true);
+            // Otherwise, all of the offset information is in the string
             } else {
                 result = dayjs.utc(json);
             }
+
             if (!result.isValid()) {
                 throw new ValidationException(`Expected value at path \`${path}\` to be of type \`${field.getType()}\``);
             }

--- a/packages/concerto-core/lib/serializer/jsonpopulator.js
+++ b/packages/concerto-core/lib/serializer/jsonpopulator.js
@@ -268,8 +268,8 @@ class JSONPopulator {
                 throw new ValidationException(`Expected value at path \`${path}\` to be of type \`${field.getType()}\``);
             // Unqualified Local Time, i.e. no zone designation in string
             } else if (!json.match(/(Z|(\+|-)\d{2}:\d{2}?)$/i)){
-                // Default to UTC
-                const offset = this.utcOffset !== undefined ? this.utcOffset : 0;
+                // Default to local offset
+                const offset = this.utcOffset !== undefined ? this.utcOffset : dayjs().utcOffset();
                 result = dayjs.utc(json).utcOffset(offset, true);
             // Otherwise, all of the offset information is in the string
             } else {

--- a/packages/concerto-core/lib/serializer/jsonpopulator.js
+++ b/packages/concerto-core/lib/serializer/jsonpopulator.js
@@ -87,16 +87,13 @@ class JSONPopulator {
      * place of relationships, false by default.
      * @param {boolean} [ergo] target ergo.
      * @param {number} [utcOffset] - UTC Offset for DateTime values.
+     * @param {number} [strictQualifiedDateTimes] - Only allow fully-qualified date-times with offsets.
      */
-    constructor(acceptResourcesForRelationships, ergo, utcOffset) {
+    constructor(acceptResourcesForRelationships, ergo, utcOffset, strictQualifiedDateTimes) {
         this.acceptResourcesForRelationships = acceptResourcesForRelationships;
         this.ergo = ergo;
-
-        // 0 is a valid offset, but is falsy in JS
-        if (utcOffset !== undefined){
-            const normalizedUtcOffset = dayjs.utc().utcOffset(utcOffset).utcOffset();
-            this.utcOffset =  normalizedUtcOffset;
-        }
+        this.utcOffset = utcOffset || 0; // Defaults to UTC
+        this.strictQualifiedDateTimes = strictQualifiedDateTimes;
     }
 
     /**
@@ -261,22 +258,16 @@ class JSONPopulator {
                 result = json;
             } else if (typeof json !== 'string') {
                 throw new ValidationException(`Expected value at path \`${path}\` to be of type \`${field.getType()}\``);
-            // Yearless dates from the HTML Living Standard are supported by DayJS and JS Date
-            // however, their behaviour is not stable in a distributed system with different
-            // offsets. Specifically, parsing does not respect the local offset.
-            } else if (json.match(/^(--)?\d{2}-\d{2}$/)) {
-                throw new ValidationException(`Expected value at path \`${path}\` to be of type \`${field.getType()}\``);
-            // Unqualified Local Time, i.e. no zone designation in string
-            } else if (!json.match(/(Z|(\+|-)\d{2}:\d{2}?)$/i)){
-                // Default to local offset
-                const offset = this.utcOffset !== undefined ? this.utcOffset : dayjs().utcOffset();
-                result = dayjs.utc(json).utcOffset(offset, true);
-            // Otherwise, all of the offset information is in the string
-            } else {
-                result = dayjs.utc(json);
+            } else if (!this.strictQualifiedDateTimes){
+                result = dayjs.utc(json).utcOffset(this.utcOffset);
+            } else if (this.strictQualifiedDateTimes){
+                if (json.match(/^((?:(\d{4}-\d{2}-\d{2})T(\d{2}:\d{2}:\d{2}(?:\.\d+)?))(Z|[+-]\d{2}:\d{2}))$/)){
+                    result = dayjs.utc(json);
+                } else {
+                    throw new ValidationException(`Expected value at path \`${path}\` to be of type \`${field.getType()}\` with format YYYY-MM-DDTHH:mm:ss[Z]`);
+                }
             }
-
-            if (!result.isValid()) {
+            if (!result || !result.isValid()) {
                 throw new ValidationException(`Expected value at path \`${path}\` to be of type \`${field.getType()}\``);
             }
         }

--- a/packages/concerto-core/test/concerto.js
+++ b/packages/concerto-core/test/concerto.js
@@ -387,6 +387,5 @@ describe('concerto', () => {
                 concerto.validate(obj);
             }).should.throw(/The class "org.accordproject.test.Person" is abstract and should not contain an instance./);
         });
-
     });
 });

--- a/packages/concerto-core/test/serializer.js
+++ b/packages/concerto-core/test/serializer.js
@@ -40,6 +40,8 @@ describe('Serializer', () => {
         modelManager.addCTOModel(`
         namespace org.acme.sample
 
+        scalar PostalCode extends String
+
         asset SampleAsset identified by assetId {
         o String assetId
         --> SampleParticipant owner
@@ -63,6 +65,7 @@ describe('Serializer', () => {
             o String city
             o String country
             o Double elevation
+            o PostalCode postcode optional
         }
 
         concept DateTimeTest {
@@ -218,12 +221,14 @@ describe('Serializer', () => {
             address.city = 'Winchester';
             address.country = 'UK';
             address.elevation = 3.14;
+            address.postcode = 'SO21 2JN';
             const json = serializer.toJSON(address);
             json.should.deep.equal({
                 $class: 'org.acme.sample.Address',
                 country: 'UK',
                 elevation: 3.14,
-                city: 'Winchester'
+                city: 'Winchester',
+                postcode: 'SO21 2JN',
             });
         });
 
@@ -316,13 +321,15 @@ describe('Serializer', () => {
                 $class: 'org.acme.sample.Address',
                 city: 'Winchester',
                 country: 'UK',
-                elevation: 3.14
+                elevation: 3.14,
+                postcode: 'SO21 2JN',
             };
             let resource = serializer.fromJSON(json);
             resource.should.be.an.instanceOf(Resource);
             resource.city.should.equal('Winchester');
             resource.country.should.equal('UK');
             resource.elevation.should.equal(3.14);
+            resource.postcode.should.equal('SO21 2JN');
         });
 
         it('should throw validation errors if the validate flag is not specified', () => {

--- a/packages/concerto-core/test/serializer.js
+++ b/packages/concerto-core/test/serializer.js
@@ -427,29 +427,11 @@ describe('Serializer', () => {
 
         describe('legacy datetime formats', () => {
 
-            // See the visualization at https://ijmacd.github.io/rfc3339-iso8601/
-            const dateTests = [
             // Test Structure
             // [TEST_STRING, DESCRIPTION, EXPECTED_VALUE, EXPLICIT_UTC_OFFSET]
-
-                // Component Design goals
-                // CLI and above: Respect user's local offset
-                // API: Explicitly define and publish the assumed offset (e.g. Z)
-                // SDK: Allow both options above, and be backwards compatible.
-
-
-                // WIP Rules
-                // Rule 1: When an offset is not specified in the input string, assume the local offset.
-                // Rule 2: When a target offset is specified, format the date in the target offset.
-                // Rule 3a: When a target offset is not specified, format the date as Z.
-                // Rule 3b: When a target offset is not specified, format the date as the local offset ().
-
-                // Plan
-                // 1. Add an opt-in flag to drop support for unqualified dates/times
-                // 2. Same flag should treat the offset param as a rendering target
-
+            // For a comparison of formats see the visualization at https://ijmacd.github.io/rfc3339-iso8601/
+            const dateTests = [
                 // RFC 3339 & ISO 8601
-                // Current Behaviour
                 ['2022-11-28', 'YYYY-MM-DD', '2022-11-28T00:00:00.000Z'],
                 ['2022-11-28', 'YYYY-MM-DD', '2022-11-28T00:00:00.000Z', 'Z'],
                 ['2022-11-28', 'YYYY-MM-DD', '2022-11-28T00:00:00.000Z', 0],
@@ -508,9 +490,6 @@ describe('Serializer', () => {
             ];
             dateTests.forEach(([dateValue, message, expected, utcOffset]) => {
                 it(`should accept date-time values with the format '${message}' and offset '${utcOffset}'`, () => {
-                // Simulate running the tests in UTC+1, i.e. a non-zero local offset
-                // serializer.setDefaultOptions({ utcOffset: 60 });
-
                     json.date = dateValue;
                     const options = utcOffset !== undefined ? { utcOffset } : {};
                     const result = serializer.toJSON(serializer.fromJSON(json, options), options);

--- a/packages/concerto-core/test/serializer.js
+++ b/packages/concerto-core/test/serializer.js
@@ -420,9 +420,10 @@ describe('Serializer', () => {
         const dateTests = [
             // Test Structure
             // [TEST_STRING, DESCRIPTION, EXPECTED_VALUE, EXPLICIT_UTC_OFFSET]
+            // NOTE: the tests explicitly set the local offset to be +01:00
 
             // RFC 3339 & ISO 8601
-            ['2022-11-28', 'YYYY-MM-DD', '2022-11-28T00:00:00.000Z'],
+            ['2022-11-28', 'YYYY-MM-DD', '2022-11-28T00:00:00.000+01:00'],
             ['2022-11-28', 'YYYY-MM-DD', '2022-11-28T00:00:00.000Z', 'Z'],
             ['2022-11-28', 'YYYY-MM-DD', '2022-11-28T00:00:00.000Z', 0],
             ['2022-11-28', 'YYYY-MM-DD', '2022-11-28T00:00:00.000-05:00', '-05:00'],
@@ -456,23 +457,33 @@ describe('Serializer', () => {
             ['2022-11-28T01:02:03.987z', 'Lowercase z'],
 
             // ISO 8601
-            ['2022', 'YYYY', '2022-01-01T00:00:00.000Z'],
-            ['+002022-11-28', '+YYYYYY-MM-DD', '2022-11-28T00:00:00.000Z'],
+            ['2022', 'YYYY', '2022-01-01T00:00:00.000+01:00'],
+            ['2022', 'YYYY', '2022-01-01T00:00:00.000Z', 0],
+            ['+002022-11-28', '+YYYYYY-MM-DD', '2022-11-28T00:00:00.000+01:00'],
+            ['+002022-11-28', '+YYYYYY-MM-DD', '2022-11-28T00:00:00.000Z', 0],
 
             // ISO 8601 & HTML Living Standard
-            ['2022-11-28T01:02:03.987', 'YYYY-MM-DDTHH:mm:ss'],
-            ['2022-11-28T01:02:03.987', 'YYYY-MM-DDTHH:mm:ss', '2022-11-28T01:02:03.987-05:00' ,'-05:00'],
-            ['2022-11', 'YYYY-MM', '2022-11-01T00:00:00.000Z'],
+            ['2022-11-28T01:02:03', 'YYYY-MM-DDTHH:mm:ss', '2022-11-28T01:02:03.000+01:00'],
+            ['2022-11-28T01:02:03', 'YYYY-MM-DDTHH:mm:ss', '2022-11-28T01:02:03.000Z', 'Z'],
+            ['2022-11-28T01:02:03', 'YYYY-MM-DDTHH:mm:ss', '2022-11-28T01:02:03.000Z', 0],
+            ['2022-11-28T01:02:03', 'YYYY-MM-DDTHH:mm:ss', '2022-11-28T01:02:03.000-05:00', '-05:00'],
+            ['2022-11-28T01:02:03.987', 'YYYY-MM-DDTHH:mm:ss.SSS', '2022-11-28T01:02:03.987+01:00'],
+            ['2022-11-28T01:02:03.987', 'YYYY-MM-DDTHH:mm:ss.SSS', undefined, 0],
+            ['2022-11-28T01:02:03.987', 'YYYY-MM-DDTHH:mm:ss.SSS', '2022-11-28T01:02:03.987-05:00' ,'-05:00'],
+            ['2022-11', 'YYYY-MM', '2022-11-01T00:00:00.000+01:00'],
             ['2022-11', 'YYYY-MM', '2022-11-01T00:00:00.000-05:00', '-05:00'],
 
             // HTML Living Standard
-            ['2022-11-28 01:02:03.987', 'No separator, no offset information'],
+            ['2022-11-28 01:02:03.987', 'No separator, no offset information', '2022-11-28T01:02:03.987+01:00'],
             ['2022-11-28 01:02:03.987', 'No separator, no offset information', '2022-11-28T01:02:03.987-05:00', '-05:00'],
         ];
         dateTests.forEach(([dateValue, message, expected, utcOffset]) => {
             it(`should accept date-time values with the format '${message}' and offset '${utcOffset}'`, () => {
+                // Simulate running the tests in UTC+1, i.e. a non-zero local offset
+                serializer.setDefaultOptions({ utcOffset: 60 });
+
                 json.date = dateValue;
-                const options = { utcOffset };
+                const options = utcOffset !== undefined ? { utcOffset } : {};
                 const result = serializer.toJSON(serializer.fromJSON(json, options), options);
                 result.date.should.equal(expected || '2022-11-28T01:02:03.987Z');
             });

--- a/packages/concerto-core/test/serializer.js
+++ b/packages/concerto-core/test/serializer.js
@@ -416,105 +416,217 @@ describe('Serializer', () => {
             $class : 'org.acme.sample.DateTimeTest',
         };
 
-        // See the visualization at https://ijmacd.github.io/rfc3339-iso8601/
-        const dateTests = [
+        const DEFAULT_EXPECTED_VALUE =  '2022-11-28T01:02:03.987Z';
+
+        describe('legacy datetime formats', () => {
+
+            // See the visualization at https://ijmacd.github.io/rfc3339-iso8601/
+            const dateTests = [
             // Test Structure
             // [TEST_STRING, DESCRIPTION, EXPECTED_VALUE, EXPLICIT_UTC_OFFSET]
-            // NOTE: the tests explicitly set the local offset to be +01:00
 
-            // RFC 3339 & ISO 8601
-            ['2022-11-28', 'YYYY-MM-DD', '2022-11-28T00:00:00.000+01:00'],
-            ['2022-11-28', 'YYYY-MM-DD', '2022-11-28T00:00:00.000Z', 'Z'],
-            ['2022-11-28', 'YYYY-MM-DD', '2022-11-28T00:00:00.000Z', 0],
-            ['2022-11-28', 'YYYY-MM-DD', '2022-11-28T00:00:00.000-05:00', '-05:00'],
-            ['2022-11-28T01:02:03Z', 'YYYY-MM-DDTHH:mm:ssZ', '2022-11-28T01:02:03.000Z'],
-            ['2022-11-28T01:02:03Z', 'YYYY-MM-DDTHH:mm:ssZ', '2022-11-28T01:02:03.000Z', 'Z'],
-            ['2022-11-28T01:02:03Z', 'YYYY-MM-DDTHH:mm:ssZ', '2022-11-28T01:02:03.000Z', 0],
-            ['2022-11-28T01:02:03Z', 'YYYY-MM-DDTHH:mm:ssZ', '2022-11-27T20:02:03.000-05:00', '-05:00'],
-            ['2022-11-28T01:02:03-05:00', 'YYYY-MM-DDTHH:mm:ss-HH:mm', '2022-11-28T01:02:03.000-05:00', '-05:00'],
-            ['2022-11-28T01:02:03-08:00', 'YYYY-MM-DDTHH:mm:ss-HH:mm', '2022-11-28T09:02:03.000Z'],
-            ['2022-11-28T01:02:03.9Z', 'YYYY-MM-DDTHH:mm:ss.SZ', '2022-11-28T01:02:03.900Z'],
-            ['2022-11-28T01:02:03.98Z', 'YYYY-MM-DDTHH:mm:ss.SSZ', '2022-11-28T01:02:03.980Z'],
-            ['2022-11-28T01:02:03.987Z', 'YYYY-MM-DDTHH:mm:ss.SSSZ'],
-            ['2022-11-28T01:02:03+08:00', 'YYYY-MM-DDTHH:mm:ss+HH:mm', '2022-11-27T17:02:03.000Z'],
-            ['2022-11-28T01:02:03.987+08:00', 'YYYY-MM-DDTHH:mm:ss.SSS+HH:mm', '2022-11-27T17:02:03.987Z'],
-            ['2022-11-28T01:02:03.98765+08:00', 'YYYY-MM-DDTHH:mm:ss.SSSSSS+HH:mm', '2022-11-27T17:02:03.987Z'],
-            ['2022-11-28T01:02:03-08:00', 'YYYY-MM-DDTHH:mm:ss-HH:mm', '2022-11-28T09:02:03.000Z'],
-            ['2022-11-28T01:02:03.987-08:00', 'YYYY-MM-DDTHH:mm:ss.SSS-HH:mm', '2022-11-28T09:02:03.987Z'],
-            ['2022-11-28T01:02:03.98765-08:00', 'YYYY-MM-DDTHH:mm:ss.SSSSSS-HH:mm', '2022-11-28T09:02:03.987Z'],
+                // Component Design goals
+                // CLI and above: Respect user's local offset
+                // API: Explicitly define and publish the assumed offset (e.g. Z)
+                // SDK: Allow both options above, and be backwards compatible.
 
-            // Tests below this line are accepted but fall outside the specification for Concerto
-            // Future failures of these tests are not considered breaking changes.
 
-            // Truncated nanoseconds
-            ['2022-11-28T01:02:03.98765Z', 'YYYY-MM-DDTHH:mm:ss.SSSSSS'],
+                // WIP Rules
+                // Rule 1: When an offset is not specified in the input string, assume the local offset.
+                // Rule 2: When a target offset is specified, format the date in the target offset.
+                // Rule 3a: When a target offset is not specified, format the date as Z.
+                // Rule 3b: When a target offset is not specified, format the date as the local offset ().
 
-            // RFC 3339 && HTML Living Standard
-            ['2022-11-28 01:02:03.987Z', 'YYYY-MM-DD HH:mm:ss.SSSZ'],
+                // Plan
+                // 1. Add an opt-in flag to drop support for unqualified dates/times
+                // 2. Same flag should treat the offset param as a rendering target
 
-            // RFC 3339
-            ['2022-11-28t01:02:03.987Z', 'Lowercase t'],
-            ['2022-11-28T01:02:03.987z', 'Lowercase z'],
+                // RFC 3339 & ISO 8601
+                // Current Behaviour
+                ['2022-11-28', 'YYYY-MM-DD', '2022-11-28T00:00:00.000Z'],
+                ['2022-11-28', 'YYYY-MM-DD', '2022-11-28T00:00:00.000Z', 'Z'],
+                ['2022-11-28', 'YYYY-MM-DD', '2022-11-28T00:00:00.000Z', 0],
+                ['2022-11-28', 'YYYY-MM-DD', '2022-11-27T19:00:00.000-05:00', '-05:00'],
+                ['2022-11-28T01:02:03Z', 'YYYY-MM-DDTHH:mm:ssZ', '2022-11-28T01:02:03.000Z'],
+                ['2022-11-28T01:02:03Z', 'YYYY-MM-DDTHH:mm:ssZ', '2022-11-28T01:02:03.000Z', 'Z'],
+                ['2022-11-28T01:02:03Z', 'YYYY-MM-DDTHH:mm:ssZ', '2022-11-28T01:02:03.000Z', 0],
+                ['2022-11-28T01:02:03Z', 'YYYY-MM-DDTHH:mm:ssZ', '2022-11-27T20:02:03.000-05:00', '-05:00'],
+                ['2022-11-28T01:02:03-05:00', 'YYYY-MM-DDTHH:mm:ss-HH:mm', '2022-11-28T01:02:03.000-05:00', '-05:00'],
+                ['2022-11-28T01:02:03-08:00', 'YYYY-MM-DDTHH:mm:ss-HH:mm', '2022-11-28T09:02:03.000Z'],
+                ['2022-11-28T01:02:03.9Z', 'YYYY-MM-DDTHH:mm:ss.SZ', '2022-11-28T01:02:03.900Z'],
+                ['2022-11-28T01:02:03.98Z', 'YYYY-MM-DDTHH:mm:ss.SSZ', '2022-11-28T01:02:03.980Z'],
+                ['2022-11-28T01:02:03.987Z', 'YYYY-MM-DDTHH:mm:ss.SSSZ'],
+                ['2022-11-28T01:02:03+08:00', 'YYYY-MM-DDTHH:mm:ss+HH:mm', '2022-11-27T17:02:03.000Z'],
+                ['2022-11-28T01:02:03.987+08:00', 'YYYY-MM-DDTHH:mm:ss.SSS+HH:mm', '2022-11-27T17:02:03.987Z'],
+                ['2022-11-28T01:02:03.98765+08:00', 'YYYY-MM-DDTHH:mm:ss.SSSSSS+HH:mm', '2022-11-27T17:02:03.987Z'],
+                ['2022-11-28T01:02:03-08:00', 'YYYY-MM-DDTHH:mm:ss-HH:mm', '2022-11-28T09:02:03.000Z'],
+                ['2022-11-28T01:02:03.987-08:00', 'YYYY-MM-DDTHH:mm:ss.SSS-HH:mm', '2022-11-28T09:02:03.987Z'],
+                ['2022-11-28T01:02:03.98765-08:00', 'YYYY-MM-DDTHH:mm:ss.SSSSSS-HH:mm', '2022-11-28T09:02:03.987Z'],
 
-            // ISO 8601
-            ['2022', 'YYYY', '2022-01-01T00:00:00.000+01:00'],
-            ['2022', 'YYYY', '2022-01-01T00:00:00.000Z', 0],
-            ['+002022-11-28', '+YYYYYY-MM-DD', '2022-11-28T00:00:00.000+01:00'],
-            ['+002022-11-28', '+YYYYYY-MM-DD', '2022-11-28T00:00:00.000Z', 0],
+                // Tests below this line are accepted but fall outside the specification for Concerto
+                // Future failures of these tests are not considered breaking changes.
 
-            // ISO 8601 & HTML Living Standard
-            ['2022-11-28T01:02:03', 'YYYY-MM-DDTHH:mm:ss', '2022-11-28T01:02:03.000+01:00'],
-            ['2022-11-28T01:02:03', 'YYYY-MM-DDTHH:mm:ss', '2022-11-28T01:02:03.000Z', 'Z'],
-            ['2022-11-28T01:02:03', 'YYYY-MM-DDTHH:mm:ss', '2022-11-28T01:02:03.000Z', 0],
-            ['2022-11-28T01:02:03', 'YYYY-MM-DDTHH:mm:ss', '2022-11-28T01:02:03.000-05:00', '-05:00'],
-            ['2022-11-28T01:02:03.987', 'YYYY-MM-DDTHH:mm:ss.SSS', '2022-11-28T01:02:03.987+01:00'],
-            ['2022-11-28T01:02:03.987', 'YYYY-MM-DDTHH:mm:ss.SSS', undefined, 0],
-            ['2022-11-28T01:02:03.987', 'YYYY-MM-DDTHH:mm:ss.SSS', '2022-11-28T01:02:03.987-05:00' ,'-05:00'],
-            ['2022-11', 'YYYY-MM', '2022-11-01T00:00:00.000+01:00'],
-            ['2022-11', 'YYYY-MM', '2022-11-01T00:00:00.000-05:00', '-05:00'],
+                // Truncated nanoseconds
+                ['2022-11-28T01:02:03.98765Z', 'YYYY-MM-DDTHH:mm:ss.SSSSSS'],
 
-            // HTML Living Standard
-            ['2022-11-28 01:02:03.987', 'No separator, no offset information', '2022-11-28T01:02:03.987+01:00'],
-            ['2022-11-28 01:02:03.987', 'No separator, no offset information', '2022-11-28T01:02:03.987-05:00', '-05:00'],
-        ];
-        dateTests.forEach(([dateValue, message, expected, utcOffset]) => {
-            it(`should accept date-time values with the format '${message}' and offset '${utcOffset}'`, () => {
+                // RFC 3339 && HTML Living Standard
+                ['2022-11-28 01:02:03.987Z', 'YYYY-MM-DD HH:mm:ss.SSSZ'],
+
+                // RFC 3339
+                ['2022-11-28t01:02:03.987Z', 'Lowercase t'],
+                ['2022-11-28T01:02:03.987z', 'Lowercase z'],
+
+                // ISO 8601
+                ['2022', 'YYYY', '2022-01-01T00:00:00.000Z'],
+                ['2022', 'YYYY', '2022-01-01T00:00:00.000Z', 0],
+                ['+002022-11-28', '+YYYYYY-MM-DD', '2022-11-28T00:00:00.000Z'],
+                ['+002022-11-28', '+YYYYYY-MM-DD', '2022-11-28T00:00:00.000Z', 0],
+
+                // ISO 8601 & HTML Living Standard
+                ['2022-11-28T01:02:03', 'YYYY-MM-DDTHH:mm:ss', '2022-11-28T01:02:03.000Z'],
+                ['2022-11-28T01:02:03', 'YYYY-MM-DDTHH:mm:ss', '2022-11-28T01:02:03.000Z', 'Z'],
+                ['2022-11-28T01:02:03', 'YYYY-MM-DDTHH:mm:ss', '2022-11-28T01:02:03.000Z', 0],
+                ['2022-11-28T01:02:03', 'YYYY-MM-DDTHH:mm:ss', '2022-11-27T20:02:03.000-05:00', '-05:00'],
+                ['2022-11-28T01:02:03.987', 'YYYY-MM-DDTHH:mm:ss.SSS'],
+                ['2022-11-28T01:02:03.987', 'YYYY-MM-DDTHH:mm:ss.SSS', DEFAULT_EXPECTED_VALUE, 0],
+                ['2022-11-28T01:02:03.987', 'YYYY-MM-DDTHH:mm:ss.SSS', '2022-11-27T20:02:03.987-05:00' ,'-05:00'],
+                ['2022-11', 'YYYY-MM', '2022-11-01T00:00:00.000Z'],
+                ['2022-11', 'YYYY-MM', '2022-10-31T19:00:00.000-05:00', '-05:00'],
+
+                // HTML Living Standard
+                ['2022-11-28 01:02:03.987', 'No separator, no offset information'],
+                ['2022-11-28 01:02:03.987', 'No separator, no offset information', '2022-11-27T20:02:03.987-05:00', '-05:00'],
+                ['--11-28', '--MM-DD', '2001-11-28T00:00:00.000Z'],
+                ['11-28', 'MM-DD', '2001-11-28T00:00:00.000Z'],
+            ];
+            dateTests.forEach(([dateValue, message, expected, utcOffset]) => {
+                it(`should accept date-time values with the format '${message}' and offset '${utcOffset}'`, () => {
                 // Simulate running the tests in UTC+1, i.e. a non-zero local offset
-                serializer.setDefaultOptions({ utcOffset: 60 });
+                // serializer.setDefaultOptions({ utcOffset: 60 });
 
-                json.date = dateValue;
-                const options = utcOffset !== undefined ? { utcOffset } : {};
-                const result = serializer.toJSON(serializer.fromJSON(json, options), options);
-                result.date.should.equal(expected || '2022-11-28T01:02:03.987Z');
+                    json.date = dateValue;
+                    const options = utcOffset !== undefined ? { utcOffset } : {};
+                    const result = serializer.toJSON(serializer.fromJSON(json, options), options);
+                    result.date.should.equal(expected || DEFAULT_EXPECTED_VALUE);
+                });
+            });
+
+            const negativeDateTests =[
+                // ISO 8601
+                ['2022‐11‐28T01:02:03.987Z', 'U+2010 HYPHEN'],
+                ['2022−11−28T01:02:03.987Z', 'U+2212 MINUS'],
+                ['2022-11-28T11,7', 'YYYY-MM-DDTHH,1h'],
+                ['2022-W48', 'YYYY-Ww'],
+                ['2022-W48-1', 'YYYY-Ww-z'],
+                ['20', 'YYY'],
+                ['+0020221128T115723Z', '+YYYYYYMMDDTHHMMSSZ'],
+
+                // RFC 3339
+                ['2022-11-28_01:02:03.987Z', 'Underscore separator'],
+            ];
+
+            negativeDateTests.forEach(([dateValue, message, utcOffset = 0]) => {
+                it(`should not accept invalid dates or dateTime values, ${message}`, () => {
+                    json.date = dateValue;
+                    (() => {
+                        const options = { utcOffset };
+                        serializer.toJSON(serializer.fromJSON(json, options), options);
+                    }).should.throw('Expected value at path `$.date` to be of type `DateTime`');
+                });
             });
         });
 
-        const negativeDateTests =[
-            // ISO 8601
-            ['2022‐11‐28T01:02:03.987Z', 'U+2010 HYPHEN'],
-            ['2022−11−28T01:02:03.987Z', 'U+2212 MINUS'],
-            ['2022-11-28T11,7', 'YYYY-MM-DDTHH,1h'],
-            ['2022-W48', 'YYYY-Ww'],
-            ['2022-W48-1', 'YYYY-Ww-z'],
-            ['20', 'YYY'],
-            ['+0020221128T115723Z', '+YYYYYYMMDDTHHMMSSZ'],
+        describe('strict datetime format, strictQualifiedDateTimes parameter', () => {
+            // Test Structure
+            // [TEST_STRING, DESCRIPTION, EXPECTED_VALUE, EXPLICIT_UTC_OFFSET]
+            const dateTests = [
+                // RFC 3339 & ISO 8601
+                ['2022-11-28T01:02:03Z', 'YYYY-MM-DDTHH:mm:ssZ', '2022-11-28T01:02:03.000Z'],
+                ['2022-11-28T01:02:03Z', 'YYYY-MM-DDTHH:mm:ssZ', '2022-11-28T01:02:03.000Z', 'Z'],
+                ['2022-11-28T01:02:03Z', 'YYYY-MM-DDTHH:mm:ssZ', '2022-11-28T01:02:03.000Z', 0],
+                ['2022-11-28T01:02:03Z', 'YYYY-MM-DDTHH:mm:ssZ', '2022-11-27T20:02:03.000-05:00', '-05:00'],
+                ['2022-11-28T01:02:03-05:00', 'YYYY-MM-DDTHH:mm:ss-HH:mm', '2022-11-28T01:02:03.000-05:00', '-05:00'],
+                ['2022-11-28T01:02:03-08:00', 'YYYY-MM-DDTHH:mm:ss-HH:mm', '2022-11-28T09:02:03.000Z'],
+                ['2022-11-28T01:02:03.9Z', 'YYYY-MM-DDTHH:mm:ss.SZ', '2022-11-28T01:02:03.900Z'],
+                ['2022-11-28T01:02:03.98Z', 'YYYY-MM-DDTHH:mm:ss.SSZ', '2022-11-28T01:02:03.980Z'],
+                ['2022-11-28T01:02:03.987Z', 'YYYY-MM-DDTHH:mm:ss.SSSZ'],
+                ['2022-11-28T01:02:03+08:00', 'YYYY-MM-DDTHH:mm:ss+HH:mm', '2022-11-27T17:02:03.000Z'],
+                ['2022-11-28T01:02:03.987+08:00', 'YYYY-MM-DDTHH:mm:ss.SSS+HH:mm', '2022-11-27T17:02:03.987Z'],
+                ['2022-11-28T01:02:03.98765+08:00', 'YYYY-MM-DDTHH:mm:ss.SSSSSS+HH:mm', '2022-11-27T17:02:03.987Z'],
+                ['2022-11-28T01:02:03-08:00', 'YYYY-MM-DDTHH:mm:ss-HH:mm', '2022-11-28T09:02:03.000Z'],
+                ['2022-11-28T01:02:03.987-08:00', 'YYYY-MM-DDTHH:mm:ss.SSS-HH:mm', '2022-11-28T09:02:03.987Z'],
+                ['2022-11-28T01:02:03.98765-08:00', 'YYYY-MM-DDTHH:mm:ss.SSSSSS-HH:mm', '2022-11-28T09:02:03.987Z'],
+                ['2022-11-28T01:02:03.98765Z', 'YYYY-MM-DDTHH:mm:ss.SSSSSS'],
 
-            // RFC 3339
-            ['2022-11-28_01:02:03.987Z', 'Underscore separator'],
+            ];
+            dateTests.forEach(([dateValue, message, expected, utcOffset]) => {
+                it(`should accept date-time values with the format '${message}' and offset '${utcOffset}'`, () => {
+                    json.date = dateValue;
+                    const options = utcOffset !== undefined ? { utcOffset } : {};
+                    options.strictQualifiedDateTimes = true;
+                    const result = serializer.toJSON(serializer.fromJSON(json, options), options);
+                    result.date.should.equal(expected || DEFAULT_EXPECTED_VALUE);
+                });
+            });
 
-            // HTML Living Standard
-            // These formats do not repect the local offset, and so cannot be relied upon in a distributed system.
-            ['--11-28', '--MM-DD'],
-            ['11-28', 'MM-DD'],
-        ];
+            const negativeDateTests =[
+                // RFC 3339 & ISO 8601
+                ['2022-11-28', 'YYYY-MM-DD'],
+                ['2022-11-28', 'YYYY-MM-DD'],
+                ['2022-11-28', 'YYYY-MM-DD'],
+                ['2022-11-28', 'YYYY-MM-DD'],
 
-        negativeDateTests.forEach(([dateValue, message, utcOffset = 0]) => {
-            it(`should not accept invalid dates or dateTime values, ${message}`, () => {
-                json.date = dateValue;
-                (() => {
-                    const options = { utcOffset };
-                    serializer.toJSON(serializer.fromJSON(json, options), options);
-                }).should.throw('Expected value at path `$.date` to be of type `DateTime`');
+                // RFC 3339 && HTML Living Standard
+                ['2022-11-28 01:02:03.987Z', 'YYYY-MM-DD HH:mm:ss.SSSZ'],
+
+                // RFC 3339
+                ['2022-11-28t01:02:03.987Z', 'Lowercase t'],
+                ['2022-11-28T01:02:03.987z', 'Lowercase z'],
+                ['2022-11-28_01:02:03.987Z', 'Underscore separator'],
+
+                // ISO 8601
+                ['2022', 'YYYY'],
+                ['2022', 'YYYY'],
+                ['+002022-11-28', '+YYYYYY-MM-DD'],
+                ['+002022-11-28', '+YYYYYY-MM-DD'],
+                ['2022‐11‐28T01:02:03.987Z', 'U+2010 HYPHEN'],
+                ['2022−11−28T01:02:03.987Z', 'U+2212 MINUS'],
+                ['2022-11-28T11,7', 'YYYY-MM-DDTHH,1h'],
+                ['2022-W48', 'YYYY-Ww'],
+                ['2022-W48-1', 'YYYY-Ww-z'],
+                ['20', 'YYY'],
+                ['+0020221128T115723Z', '+YYYYYYMMDDTHHMMSSZ'],
+
+                // ISO 8601 & HTML Living Standard
+                ['2022-11-28T01:02:03', 'YYYY-MM-DDTHH:mm:ss'],
+                ['2022-11-28T01:02:03', 'YYYY-MM-DDTHH:mm:ss'],
+                ['2022-11-28T01:02:03', 'YYYY-MM-DDTHH:mm:ss'],
+                ['2022-11-28T01:02:03', 'YYYY-MM-DDTHH:mm:ss'],
+                ['2022-11-28T01:02:03.987', 'YYYY-MM-DDTHH:mm:ss.SSS'],
+                ['2022-11-28T01:02:03.987', 'YYYY-MM-DDTHH:mm:ss.SSS'],
+                ['2022-11-28T01:02:03.987', 'YYYY-MM-DDTHH:mm:ss.SSS'],
+                ['2022-11', 'YYYY-MM'],
+                ['2022-11', 'YYYY-MM'],
+
+                // HTML Living Standard
+                ['2022-11-28 01:02:03.987', 'No separator, no offset information'],
+                ['2022-11-28 01:02:03.987', 'No separator, no offset information'],
+                ['--11-28', '--MM-DD'],
+                ['11-28', 'MM-DD'],
+
+                // Other
+                ['2022-11-28T01:02:03.987-08', 'YYYY-MM-DDTHH:mm:ss.SSS-HH'],
+
+            ];
+
+            negativeDateTests.forEach(([dateValue, message, utcOffset = 0]) => {
+                it(`should not accept invalid dates or dateTime values, ${message}`, () => {
+                    json.date = dateValue;
+                    (() => {
+                        const options = { utcOffset, strictQualifiedDateTimes: true };
+                        serializer.toJSON(serializer.fromJSON(json, options), options);
+                    }).should.throw('Expected value at path `$.date` to be of type `DateTime`');
+                });
             });
         });
     });

--- a/packages/concerto-core/test/serializer.js
+++ b/packages/concerto-core/test/serializer.js
@@ -422,10 +422,13 @@ describe('Serializer', () => {
             // [TEST_STRING, DESCRIPTION, EXPECTED_VALUE, EXPLICIT_UTC_OFFSET]
 
             // RFC 3339 & ISO 8601
+            ['2022-11-28', 'YYYY-MM-DD', '2022-11-28T00:00:00.000Z'],
             ['2022-11-28', 'YYYY-MM-DD', '2022-11-28T00:00:00.000Z', 'Z'],
             ['2022-11-28', 'YYYY-MM-DD', '2022-11-28T00:00:00.000Z', 0],
             ['2022-11-28', 'YYYY-MM-DD', '2022-11-28T00:00:00.000-05:00', '-05:00'],
             ['2022-11-28T01:02:03Z', 'YYYY-MM-DDTHH:mm:ssZ', '2022-11-28T01:02:03.000Z'],
+            ['2022-11-28T01:02:03Z', 'YYYY-MM-DDTHH:mm:ssZ', '2022-11-28T01:02:03.000Z', 'Z'],
+            ['2022-11-28T01:02:03Z', 'YYYY-MM-DDTHH:mm:ssZ', '2022-11-28T01:02:03.000Z', 0],
             ['2022-11-28T01:02:03Z', 'YYYY-MM-DDTHH:mm:ssZ', '2022-11-27T20:02:03.000-05:00', '-05:00'],
             ['2022-11-28T01:02:03-05:00', 'YYYY-MM-DDTHH:mm:ss-HH:mm', '2022-11-28T01:02:03.000-05:00', '-05:00'],
             ['2022-11-28T01:02:03-08:00', 'YYYY-MM-DDTHH:mm:ss-HH:mm', '2022-11-28T09:02:03.000Z'],
@@ -466,8 +469,7 @@ describe('Serializer', () => {
             ['2022-11-28 01:02:03.987', 'No separator, no offset information'],
             ['2022-11-28 01:02:03.987', 'No separator, no offset information', '2022-11-28T01:02:03.987-05:00', '-05:00'],
         ];
-        const defaultUtcOffset = 'Z';
-        dateTests.forEach(([dateValue, message, expected, utcOffset = defaultUtcOffset]) => {
+        dateTests.forEach(([dateValue, message, expected, utcOffset]) => {
             it(`should accept date-time values with the format '${message}' and offset '${utcOffset}'`, () => {
                 json.date = dateValue;
                 const options = { utcOffset };

--- a/packages/concerto-core/test/serializer/jsongenerator.js
+++ b/packages/concerto-core/test/serializer/jsongenerator.js
@@ -111,7 +111,7 @@ describe('JSONGenerator', () => {
 
     beforeEach(() => {
         sandbox = sinon.createSandbox();
-        jsonGenerator = new JSONGenerator();
+        jsonGenerator = new JSONGenerator(null, null, null, null, null, 'Z');
         ergoJsonGenerator = new JSONGenerator(null,null,null,null,true);
         ergoJsonGeneratorId = new JSONGenerator(null,null,null,true,true);
     });

--- a/packages/concerto-core/types/lib/serializer/jsonpopulator.d.ts
+++ b/packages/concerto-core/types/lib/serializer/jsonpopulator.d.ts
@@ -18,11 +18,13 @@ declare class JSONPopulator {
      * place of relationships, false by default.
      * @param {boolean} [ergo] target ergo.
      * @param {number} [utcOffset] - UTC Offset for DateTime values.
+     * @param {number} [strictQualifiedDateTimes] - Only allow fully-qualified date-times with offsets.
      */
-    constructor(acceptResourcesForRelationships?: boolean, ergo?: boolean, utcOffset?: number);
+    constructor(acceptResourcesForRelationships?: boolean, ergo?: boolean, utcOffset?: number, strictQualifiedDateTimes?: number);
     acceptResourcesForRelationships: boolean;
     ergo: boolean;
     utcOffset: number;
+    strictQualifiedDateTimes: number;
     /**
      * Visitor design pattern
      * @param {Object} thing - the object being visited


### PR DESCRIPTION
<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->

<!--- Provide an overall summary of the pull request -->
This PR adds a new option to the `JSONGenerator` and `JSONPopulator` classes (and the `Serializer`) called `strictQualifiedDateTimes`. This allows client applications to drop support for unqualified, and ambiguous dates/datetimes.

This solves #552 in a backward-compatible way by not-allowing dates and date-times that don't have an offset. This also has the side-effect of making the `utcOffset` parameter only relevant to serialization; i.e. it becomes a rendering option. We always trust the offset provided when `strictQualifiedDateTimes` is `true`

When `strictQualifiedDateTimes` is `true`, only the following date-time formats are accepted.
- `YYYY-MM-DDTHH:mm:ssZ`
- `YYYY-MM-DDTHH:mm:ss.SZ`
- `YYYY-MM-DDTHH:mm:ss.SSZ`
- `YYYY-MM-DDTHH:mm:ss.SSSZ`
- `YYYY-MM-DDTHH:mm:ss+HH:mm`
- `YYYY-MM-DDTHH:mm:ss.S+HH:mm`
- `YYYY-MM-DDTHH:mm:ss.SS+HH:mm`
- `YYYY-MM-DDTHH:mm:ss.SSS+HH:mm`
- `YYYY-MM-DDTHH:mm:ss-HH:mm`
- `YYYY-MM-DDTHH:mm:ss.S-HH:mm`
- `YYYY-MM-DDTHH:mm:ss.SS-HH:mm`
- `YYYY-MM-DDTHH:mm:ss.SSS-HH:mm`

There are lots of formats that are no-longer accepted, for example (see the test for the full set): 
- `YYYY-MM-DD`
- `YYYY-MM-DDTHH:mm:ss`
- `YYYY-MM-DDTHH:mm:ss.S`
- `YYYY-MM-DDTHH:mm:ss.SS`
- `YYYY-MM-DDTHH:mm:ss.SSS`

### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
- Adds lots of format tests for the serialization/deserialization logic.
- Adds a new constructor argument called `strictQualifiedDateTimes` to `JSONGenerator` and `JSONPopulator`.

### Flags
<!--- Provide context or concerns a reviewer should be aware of -->
- This is a candidate for becoming the default behaviour in future.
- Currently, the existing behaviour is retained for backwards compatibility. This does permit some unexpected behaviour as described in #552.
- When using the `strictQualifiedDateTimes` flag, this has the effect of removing support dates (without explicit times). 
- Client applications such as Cicero, should take responsibility for (de)normalizing to this format.

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [x] Merging to `main` from `fork:branchname`
