### PR TITLE
feat(tools): support inference from JSON sub schemas

### DIFF
--- a/packages/concerto-tools/lib/codegen/fromJsonSchema/cto/inferModel.js
+++ b/packages/concerto-tools/lib/codegen/fromJsonSchema/cto/inferModel.js
@@ -45,7 +45,7 @@ function normalizeType(type) {
             // In CTO we only have one place to store definitions, so we flatten the storage structure from JSON Schema
             .replace(/^#\/(definitions|\$defs|components\/schemas)\//, '')
             // Replace delimiters with underscore
-            .replaceAll(REGEX_ESCAPED_CHARS, '_')
+            .replace(REGEX_ESCAPED_CHARS, '_')
     );
 }
 
@@ -192,7 +192,7 @@ function inferEnum(definition, context) {
         if (typeof normalizedValue !== 'string' || normalizedValue.match(/^\d/)){
             normalizedValue = `_${normalizedValue}`;
         }
-        normalizedValue = normalizedValue.replaceAll(REGEX_ESCAPED_CHARS, '_');
+        normalizedValue = normalizedValue.replace(REGEX_ESCAPED_CHARS, '_');
         writer.writeLine(
             1,
             `o ${normalizedValue}`
@@ -245,7 +245,7 @@ function inferConcept(definition, context) {
                 validator = ` range=[${min},${exclusiveMax}]`;
             }
         } else if (type === 'String' && propertyDefinition.pattern) {
-            validator = ` regex=/${propertyDefinition.pattern.replaceAll('/', '\\/')}/`;
+            validator = ` regex=/${propertyDefinition.pattern.replace(/\//g, '\\/')}/`;
         }
 
         // Warning: The semantics of this default property differs between JSON Schema and Concerto

--- a/packages/concerto-tools/test/codegen/fromJsonSchema/cto/data/schema.json
+++ b/packages/concerto-tools/test/codegen/fromJsonSchema/cto/data/schema.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
-        "org.acme.Children": {
+        "Children": {
             "title": "Children",
             "description": "An instance of org.acme.Children",
             "type": "object",
@@ -31,21 +31,7 @@
                     "title": "Pet",
                     "description": "An instance of org.acme.Pet",
                     "type": "object",
-                    "properties": {
-                        "$class": {
-                            "type": "string",
-                            "default": "org.acme.Pet",
-                            "pattern": "^org\\.acme\\.Pet$",
-                            "description": "The class identifier for this type"
-                        },
-                        "name": {
-                            "type": "string"
-                        },
-                        "breed": {
-                            "type": "string"
-                        }
-                    },
-                    "required": ["$class", "name", "breed"]
+                    "$ref": "#/definitions/Pet"
                 },
                 "favoriteColors": {
                     "type": "array",
@@ -83,21 +69,7 @@
                         "title": "Pet",
                         "description": "An instance of org.acme.Pet",
                         "type": "object",
-                        "properties": {
-                            "$class": {
-                                "type": "string",
-                                "default": "org.acme.Pet",
-                                "pattern": "^org\\.acme\\.Pet$",
-                                "description": "The class identifier for this type"
-                            },
-                            "name": {
-                                "type": "string"
-                            },
-                            "breed": {
-                                "type": "string"
-                            }
-                        },
-                        "required": ["$class", "name", "breed"]
+                        "$ref": "#/definitions/Pet"
                     }
                 },
                 "stuff": {
@@ -123,21 +95,7 @@
                                 "title": "Pet",
                                 "description": "An instance of org.acme.Pet",
                                 "type": "object",
-                                "properties": {
-                                    "$class": {
-                                        "type": "string",
-                                        "default": "org.acme.Pet",
-                                        "pattern": "^org\\.acme\\.Pet$",
-                                        "description": "The class identifier for this type"
-                                    },
-                                    "name": {
-                                        "type": "string"
-                                    },
-                                    "breed": {
-                                        "type": "string"
-                                    }
-                                },
-                                "required": ["$class", "name", "breed"]
+                                "$ref": "#/definitions/Pet"
                             }
                         },
                         "required": ["$class", "sku", "price", "product"]
@@ -174,7 +132,7 @@
             "title": "Color",
             "enum": ["blue", "green", "red", "yellow", "orange"]
         },
-        "org.acme.Pet": {
+        "Pet": {
             "title": "Pet",
             "description": "An instance of org.acme.Pet",
             "type": "object",
@@ -194,7 +152,7 @@
             },
             "required": ["$class", "name", "breed"]
         },
-        "org.acme.Stuff": {
+        "Stuff": {
             "title": "Stuff",
             "description": "An instance of org.acme.Stuff",
             "type": "object",
@@ -215,26 +173,12 @@
                     "title": "Pet",
                     "description": "An instance of org.acme.Pet",
                     "type": "object",
-                    "properties": {
-                        "$class": {
-                            "type": "string",
-                            "default": "org.acme.Pet",
-                            "pattern": "^org\\.acme\\.Pet$",
-                            "description": "The class identifier for this type"
-                        },
-                        "name": {
-                            "type": "string"
-                        },
-                        "breed": {
-                            "type": "string"
-                        }
-                    },
-                    "required": ["$class", "name", "breed"]
+                    "$ref": "#/definitions/Pet"
                 }
             },
             "required": ["$class", "sku", "price", "product"]
         },
-        "org.acme.Company": {
+        "Company": {
             "title": "Company",
             "description": "An instance of org.acme.Company",
             "type": "object",
@@ -271,7 +215,7 @@
             },
             "required": ["$class", "name", "employees"]
         },
-        "org.acme.Employees": {
+        "Employees": {
             "title": "Employees",
             "description": "An instance of org.acme.Employees",
             "type": "object",
@@ -439,21 +383,7 @@
                                     "title": "Pet",
                                     "description": "An instance of org.acme.Pet",
                                     "type": "object",
-                                    "properties": {
-                                        "$class": {
-                                            "type": "string",
-                                            "default": "org.acme.Pet",
-                                            "pattern": "^org\\.acme\\.Pet$",
-                                            "description": "The class identifier for this type"
-                                        },
-                                        "name": {
-                                            "type": "string"
-                                        },
-                                        "breed": {
-                                            "type": "string"
-                                        }
-                                    },
-                                    "required": ["$class", "name", "breed"]
+                                    "$ref": "#/definitions/Pet"
                                 }
                             },
                             "required": ["$class", "sku", "price", "product"]

--- a/packages/concerto-tools/test/codegen/fromJsonSchema/cto/inferModel.js
+++ b/packages/concerto-tools/test/codegen/fromJsonSchema/cto/inferModel.js
@@ -79,16 +79,21 @@ enum Root {
                 xs: {
                     type: 'array',
                     items: {
-                        enum: ['one', 'two']
+                        enum: ['one', 'two', 3]
                     }
                 }
             }
         });
-        // TODO Generate definitions for inline sub-schemas.
         cto.should.equal(`namespace org.acme
 
 concept Root {
-   o String[] xs optional
+   o Root_Xs[] xs optional
+}
+
+enum Root_Xs {
+   o one
+   o two
+   o _3
 }
 
 `);


### PR DESCRIPTION
<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #<CORRESPONDING ISSUE NUMBER>
Improves inference of Concerto models from JSON Schema (and OpenAPI) definitions. Fixes a few bugs.

### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
- Adds a job queue, so that any inline definition (sub-schema) can be processed after all top-level definitions.
- Stops using the `title` property to infer a type name. `title` is a short description field.
- Now replaces multiple occurrences of reserved characters in type names
- Includes a workaround for enum values that are not permitted in Concerto such as `1`, `true` (by adding a `_` prefix).
- Moves to a plain JS `Array` rather than `TypedStack`. This avoids edge cases to deal with the `null` item on the bottom of the stack.

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [x] Merging to `main` from `fork:branchname`
