### PR TITLE
fix(*): update metamodel cto to reflect metamodel json

### DIFF
--- a/packages/concerto-metamodel/lib/metamodel.cto
+++ b/packages/concerto-metamodel/lib/metamodel.cto
@@ -1,0 +1,226 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@DotNetNamespace("AccordProject.Concerto.Metamodel")
+namespace concerto.metamodel@1.0.0
+
+concept Position {
+  o Integer line
+  o Integer column
+  o Integer offset
+}
+
+concept Range {
+  o Position start
+  o Position end
+  o String source optional
+}
+
+concept TypeIdentifier {
+  o String name
+  o String namespace optional
+}
+
+abstract concept DecoratorLiteral {
+  o Range location optional
+}
+
+concept DecoratorString extends DecoratorLiteral {
+  o String value
+}
+
+concept DecoratorNumber extends DecoratorLiteral {
+  o Double value
+}
+
+concept DecoratorBoolean extends DecoratorLiteral {
+  o Boolean value
+}
+
+concept DecoratorTypeReference extends DecoratorLiteral {
+  o TypeIdentifier type
+  o Boolean isArray default=false
+}
+
+concept Decorator {
+  o String name
+  o DecoratorLiteral[] arguments optional
+  o Range location optional
+}
+
+concept Identified {
+}
+
+concept IdentifiedBy extends Identified {
+  o String name
+}
+
+abstract concept Declaration {
+  o String name regex=/^(\p{Lu}|\p{Ll}|\p{Lt}|\p{Lm}|\p{Lo}|\p{Nl}|\$|_|\\u[0-9A-Fa-f]{4})(?:\p{Lu}|\p{Ll}|\p{Lt}|\p{Lm}|\p{Lo}|\p{Nl}|\$|_|\\u[0-9A-Fa-f]{4}|\p{Mn}|\p{Mc}|\p{Nd}|\p{Pc}|\u200C|\u200D)*$/u
+  o Decorator[] decorators optional
+  o Range location optional
+}
+
+concept EnumDeclaration extends Declaration {
+  o EnumProperty[] properties
+}
+
+concept EnumProperty {
+  o String name regex=/^(\p{Lu}|\p{Ll}|\p{Lt}|\p{Lm}|\p{Lo}|\p{Nl}|\$|_|\\u[0-9A-Fa-f]{4})(?:\p{Lu}|\p{Ll}|\p{Lt}|\p{Lm}|\p{Lo}|\p{Nl}|\$|_|\\u[0-9A-Fa-f]{4}|\p{Mn}|\p{Mc}|\p{Nd}|\p{Pc}|\u200C|\u200D)*$/u
+  o Decorator[] decorators optional
+  o Range location optional
+}
+
+concept ConceptDeclaration extends Declaration {
+  o Boolean isAbstract default=false
+  o Identified identified optional
+  o TypeIdentifier superType optional
+  o Property[] properties
+}
+
+concept AssetDeclaration extends ConceptDeclaration {
+}
+
+concept ParticipantDeclaration extends ConceptDeclaration {
+}
+
+concept TransactionDeclaration extends ConceptDeclaration {
+}
+
+concept EventDeclaration extends ConceptDeclaration {
+}
+
+abstract concept Property {
+  o String name regex=/^(\p{Lu}|\p{Ll}|\p{Lt}|\p{Lm}|\p{Lo}|\p{Nl}|\$|_|\\u[0-9A-Fa-f]{4})(?:\p{Lu}|\p{Ll}|\p{Lt}|\p{Lm}|\p{Lo}|\p{Nl}|\$|_|\\u[0-9A-Fa-f]{4}|\p{Mn}|\p{Mc}|\p{Nd}|\p{Pc}|\u200C|\u200D)*$/u
+  o Boolean isArray default=false
+  o Boolean isOptional default=false
+  o Decorator[] decorators optional
+  o Range location optional
+}
+
+concept RelationshipProperty extends Property {
+  o TypeIdentifier type
+}
+
+concept ObjectProperty extends Property {
+  o String defaultValue optional
+  o TypeIdentifier type
+}
+
+concept BooleanProperty extends Property {
+  o Boolean defaultValue optional
+}
+
+concept DateTimeProperty extends Property {
+}
+
+concept StringProperty extends Property {
+  o String defaultValue optional
+  o StringRegexValidator validator optional
+}
+
+concept StringRegexValidator {
+  o String pattern
+  o String flags
+}
+
+concept DoubleProperty extends Property {
+  o Double defaultValue optional
+  o DoubleDomainValidator validator optional
+}
+
+concept DoubleDomainValidator {
+  o Double lower optional
+  o Double upper optional
+}
+
+concept IntegerProperty extends Property {
+  o Integer defaultValue optional
+  o IntegerDomainValidator validator optional
+}
+
+concept IntegerDomainValidator {
+  o Integer lower optional
+  o Integer upper optional
+}
+
+concept LongProperty extends Property {
+  o Long defaultValue optional
+  o LongDomainValidator validator optional
+}
+
+concept LongDomainValidator {
+  o Long lower optional
+  o Long upper optional
+}
+
+abstract concept Import {
+  o String namespace
+  o String uri optional
+}
+
+concept ImportAll extends Import {
+}
+
+concept ImportType extends Import {
+  o String name
+}
+
+concept ImportTypes extends Import {
+  o String[] types
+}
+
+concept Model {
+  o String namespace
+  o String sourceUri optional
+  o String concertoVersion optional
+  o Import[] imports optional
+  o Declaration[] declarations optional
+  o Decorator[] decorators optional
+}
+
+concept Models {
+  o Model[] models
+}
+
+abstract concept ScalarDeclaration extends Declaration {
+}
+
+concept BooleanScalar extends ScalarDeclaration {
+  o Boolean defaultValue
+}
+
+concept IntegerScalar extends ScalarDeclaration {
+  o Integer defaultValue optional
+  o IntegerDomainValidator validator optional
+}
+
+concept LongScalar extends ScalarDeclaration {
+  o Long defaultValue optional
+  o LongDomainValidator validator optional
+}
+
+concept DoubleScalar extends ScalarDeclaration {
+  o Double defaultValue optional
+  o DoubleDomainValidator validator optional
+}
+
+concept StringScalar extends ScalarDeclaration {
+  o String defaultValue optional
+  o StringRegexValidator validator optional
+}
+
+concept DateTimeScalar extends ScalarDeclaration {
+  o String defaultValue optional
+}

--- a/packages/concerto-metamodel/lib/metamodel.json
+++ b/packages/concerto-metamodel/lib/metamodel.json
@@ -1,1020 +1,1031 @@
 {
-  "$class": "concerto.metamodel@1.0.0.Model",
-  "decorators": [],
-  "namespace": "concerto.metamodel@1.0.0",
-  "imports": [],
-  "declarations": [
-    {
-      "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
-      "name": "Position",
-      "isAbstract": false,
-      "properties": [
+    "$class": "concerto.metamodel@1.0.0.Model",
+    "decorators": [
         {
-          "$class": "concerto.metamodel@1.0.0.IntegerProperty",
-          "name": "line",
-          "isArray": false,
-          "isOptional": false
-        },
-        {
-          "$class": "concerto.metamodel@1.0.0.IntegerProperty",
-          "name": "column",
-          "isArray": false,
-          "isOptional": false
-        },
-        {
-          "$class": "concerto.metamodel@1.0.0.IntegerProperty",
-          "name": "offset",
-          "isArray": false,
-          "isOptional": false
+            "$class": "concerto.metamodel@1.0.0.Decorator",
+            "name": "DotNetNamespace",
+            "arguments": [
+                {
+                    "$class": "concerto.metamodel@1.0.0.DecoratorString",
+                    "value": "AccordProject.Concerto.Metamodel"
+                }
+            ]
         }
-      ]
-    },
-    {
-      "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
-      "name": "Range",
-      "isAbstract": false,
-      "properties": [
+    ],
+    "namespace": "concerto.metamodel@1.0.0",
+    "imports": [],
+    "declarations": [
         {
-          "$class": "concerto.metamodel@1.0.0.ObjectProperty",
-          "name": "start",
-          "type": {
-            "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-            "name": "Position"
-          },
-          "isArray": false,
-          "isOptional": false
+            "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+            "name": "Position",
+            "isAbstract": false,
+            "properties": [
+                {
+                    "$class": "concerto.metamodel@1.0.0.IntegerProperty",
+                    "name": "line",
+                    "isArray": false,
+                    "isOptional": false
+                },
+                {
+                    "$class": "concerto.metamodel@1.0.0.IntegerProperty",
+                    "name": "column",
+                    "isArray": false,
+                    "isOptional": false
+                },
+                {
+                    "$class": "concerto.metamodel@1.0.0.IntegerProperty",
+                    "name": "offset",
+                    "isArray": false,
+                    "isOptional": false
+                }
+            ]
         },
         {
-          "$class": "concerto.metamodel@1.0.0.ObjectProperty",
-          "name": "end",
-          "type": {
-            "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-            "name": "Position"
-          },
-          "isArray": false,
-          "isOptional": false
+            "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+            "name": "Range",
+            "isAbstract": false,
+            "properties": [
+                {
+                    "$class": "concerto.metamodel@1.0.0.ObjectProperty",
+                    "name": "start",
+                    "type": {
+                        "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                        "name": "Position"
+                    },
+                    "isArray": false,
+                    "isOptional": false
+                },
+                {
+                    "$class": "concerto.metamodel@1.0.0.ObjectProperty",
+                    "name": "end",
+                    "type": {
+                        "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                        "name": "Position"
+                    },
+                    "isArray": false,
+                    "isOptional": false
+                },
+                {
+                    "$class": "concerto.metamodel@1.0.0.StringProperty",
+                    "name": "source",
+                    "isArray": false,
+                    "isOptional": true
+                }
+            ]
         },
         {
-          "$class": "concerto.metamodel@1.0.0.StringProperty",
-          "name": "source",
-          "isArray": false,
-          "isOptional": true
-        }
-      ]
-    },
-    {
-      "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
-      "name": "TypeIdentifier",
-      "isAbstract": false,
-      "properties": [
-        {
-          "$class": "concerto.metamodel@1.0.0.StringProperty",
-          "name": "name",
-          "isArray": false,
-          "isOptional": false
+            "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+            "name": "TypeIdentifier",
+            "isAbstract": false,
+            "properties": [
+                {
+                    "$class": "concerto.metamodel@1.0.0.StringProperty",
+                    "name": "name",
+                    "isArray": false,
+                    "isOptional": false
+                },
+                {
+                    "$class": "concerto.metamodel@1.0.0.StringProperty",
+                    "name": "namespace",
+                    "isArray": false,
+                    "isOptional": true
+                }
+            ]
         },
         {
-          "$class": "concerto.metamodel@1.0.0.StringProperty",
-          "name": "namespace",
-          "isArray": false,
-          "isOptional": true
-        }
-      ]
-    },
-    {
-      "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
-      "name": "DecoratorLiteral",
-      "isAbstract": true,
-      "properties": [
-        {
-          "$class": "concerto.metamodel@1.0.0.ObjectProperty",
-          "name": "location",
-          "type": {
-            "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-            "name": "Range"
-          },
-          "isArray": false,
-          "isOptional": true
-        }
-      ]
-    },
-    {
-      "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
-      "name": "DecoratorString",
-      "isAbstract": false,
-      "properties": [
-        {
-          "$class": "concerto.metamodel@1.0.0.StringProperty",
-          "name": "value",
-          "isArray": false,
-          "isOptional": false
-        }
-      ],
-      "superType": {
-        "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-        "name": "DecoratorLiteral"
-      }
-    },
-    {
-      "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
-      "name": "DecoratorNumber",
-      "isAbstract": false,
-      "properties": [
-        {
-          "$class": "concerto.metamodel@1.0.0.DoubleProperty",
-          "name": "value",
-          "isArray": false,
-          "isOptional": false
-        }
-      ],
-      "superType": {
-        "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-        "name": "DecoratorLiteral"
-      }
-    },
-    {
-      "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
-      "name": "DecoratorBoolean",
-      "isAbstract": false,
-      "properties": [
-        {
-          "$class": "concerto.metamodel@1.0.0.BooleanProperty",
-          "name": "value",
-          "isArray": false,
-          "isOptional": false
-        }
-      ],
-      "superType": {
-        "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-        "name": "DecoratorLiteral"
-      }
-    },
-    {
-      "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
-      "name": "DecoratorTypeReference",
-      "isAbstract": false,
-      "properties": [
-        {
-          "$class": "concerto.metamodel@1.0.0.ObjectProperty",
-          "name": "type",
-          "type": {
-            "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-            "name": "TypeIdentifier"
-          },
-          "isArray": false,
-          "isOptional": false
+            "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+            "name": "DecoratorLiteral",
+            "isAbstract": true,
+            "properties": [
+                {
+                    "$class": "concerto.metamodel@1.0.0.ObjectProperty",
+                    "name": "location",
+                    "type": {
+                        "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                        "name": "Range"
+                    },
+                    "isArray": false,
+                    "isOptional": true
+                }
+            ]
         },
         {
-          "$class": "concerto.metamodel@1.0.0.BooleanProperty",
-          "name": "isArray",
-          "isArray": false,
-          "isOptional": false,
-          "defaultValue": false
+            "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+            "name": "DecoratorString",
+            "isAbstract": false,
+            "properties": [
+                {
+                    "$class": "concerto.metamodel@1.0.0.StringProperty",
+                    "name": "value",
+                    "isArray": false,
+                    "isOptional": false
+                }
+            ],
+            "superType": {
+                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                "name": "DecoratorLiteral"
+            }
+        },
+        {
+            "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+            "name": "DecoratorNumber",
+            "isAbstract": false,
+            "properties": [
+                {
+                    "$class": "concerto.metamodel@1.0.0.DoubleProperty",
+                    "name": "value",
+                    "isArray": false,
+                    "isOptional": false
+                }
+            ],
+            "superType": {
+                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                "name": "DecoratorLiteral"
+            }
+        },
+        {
+            "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+            "name": "DecoratorBoolean",
+            "isAbstract": false,
+            "properties": [
+                {
+                    "$class": "concerto.metamodel@1.0.0.BooleanProperty",
+                    "name": "value",
+                    "isArray": false,
+                    "isOptional": false
+                }
+            ],
+            "superType": {
+                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                "name": "DecoratorLiteral"
+            }
+        },
+        {
+            "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+            "name": "DecoratorTypeReference",
+            "isAbstract": false,
+            "properties": [
+                {
+                    "$class": "concerto.metamodel@1.0.0.ObjectProperty",
+                    "name": "type",
+                    "type": {
+                        "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                        "name": "TypeIdentifier"
+                    },
+                    "isArray": false,
+                    "isOptional": false
+                },
+                {
+                    "$class": "concerto.metamodel@1.0.0.BooleanProperty",
+                    "name": "isArray",
+                    "isArray": false,
+                    "isOptional": false,
+                    "defaultValue": false
+                }
+            ],
+            "superType": {
+                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                "name": "DecoratorLiteral"
+            }
+        },
+        {
+            "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+            "name": "Decorator",
+            "isAbstract": false,
+            "properties": [
+                {
+                    "$class": "concerto.metamodel@1.0.0.StringProperty",
+                    "name": "name",
+                    "isArray": false,
+                    "isOptional": false
+                },
+                {
+                    "$class": "concerto.metamodel@1.0.0.ObjectProperty",
+                    "name": "arguments",
+                    "type": {
+                        "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                        "name": "DecoratorLiteral"
+                    },
+                    "isArray": true,
+                    "isOptional": true
+                },
+                {
+                    "$class": "concerto.metamodel@1.0.0.ObjectProperty",
+                    "name": "location",
+                    "type": {
+                        "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                        "name": "Range"
+                    },
+                    "isArray": false,
+                    "isOptional": true
+                }
+            ]
+        },
+        {
+            "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+            "name": "Identified",
+            "isAbstract": false,
+            "properties": []
+        },
+        {
+            "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+            "name": "IdentifiedBy",
+            "isAbstract": false,
+            "properties": [
+                {
+                    "$class": "concerto.metamodel@1.0.0.StringProperty",
+                    "name": "name",
+                    "isArray": false,
+                    "isOptional": false
+                }
+            ],
+            "superType": {
+                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                "name": "Identified"
+            }
+        },
+        {
+            "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+            "name": "Declaration",
+            "isAbstract": true,
+            "properties": [
+                {
+                    "$class": "concerto.metamodel@1.0.0.StringProperty",
+                    "name": "name",
+                    "isArray": false,
+                    "isOptional": false,
+                    "validator": {
+                        "$class": "concerto.metamodel@1.0.0.StringRegexValidator",
+                        "pattern": "^(\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4})(?:\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4}|\\p{Mn}|\\p{Mc}|\\p{Nd}|\\p{Pc}|\\u200C|\\u200D)*$",
+                        "flags": "u"
+                    }
+                },
+                {
+                    "$class": "concerto.metamodel@1.0.0.ObjectProperty",
+                    "name": "decorators",
+                    "type": {
+                        "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                        "name": "Decorator"
+                    },
+                    "isArray": true,
+                    "isOptional": true
+                },
+                {
+                    "$class": "concerto.metamodel@1.0.0.ObjectProperty",
+                    "name": "location",
+                    "type": {
+                        "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                        "name": "Range"
+                    },
+                    "isArray": false,
+                    "isOptional": true
+                }
+            ]
+        },
+        {
+            "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+            "name": "EnumDeclaration",
+            "isAbstract": false,
+            "properties": [
+                {
+                    "$class": "concerto.metamodel@1.0.0.ObjectProperty",
+                    "name": "properties",
+                    "type": {
+                        "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                        "name": "EnumProperty"
+                    },
+                    "isArray": true,
+                    "isOptional": false
+                }
+            ],
+            "superType": {
+                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                "name": "Declaration"
+            }
+        },
+        {
+            "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+            "name": "EnumProperty",
+            "isAbstract": false,
+            "properties": [
+                {
+                    "$class": "concerto.metamodel@1.0.0.StringProperty",
+                    "name": "name",
+                    "isArray": false,
+                    "isOptional": false,
+                    "validator": {
+                        "$class": "concerto.metamodel@1.0.0.StringRegexValidator",
+                        "pattern": "^(\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4})(?:\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4}|\\p{Mn}|\\p{Mc}|\\p{Nd}|\\p{Pc}|\\u200C|\\u200D)*$",
+                        "flags": "u"
+                    }
+                },
+                {
+                    "$class": "concerto.metamodel@1.0.0.ObjectProperty",
+                    "name": "decorators",
+                    "type": {
+                        "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                        "name": "Decorator"
+                    },
+                    "isArray": true,
+                    "isOptional": true
+                },
+                {
+                    "$class": "concerto.metamodel@1.0.0.ObjectProperty",
+                    "name": "location",
+                    "type": {
+                        "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                        "name": "Range"
+                    },
+                    "isArray": false,
+                    "isOptional": true
+                }
+            ]
+        },
+        {
+            "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+            "name": "ConceptDeclaration",
+            "isAbstract": false,
+            "properties": [
+                {
+                    "$class": "concerto.metamodel@1.0.0.BooleanProperty",
+                    "name": "isAbstract",
+                    "isArray": false,
+                    "isOptional": false,
+                    "defaultValue": false
+                },
+                {
+                    "$class": "concerto.metamodel@1.0.0.ObjectProperty",
+                    "name": "identified",
+                    "type": {
+                        "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                        "name": "Identified"
+                    },
+                    "isArray": false,
+                    "isOptional": true
+                },
+                {
+                    "$class": "concerto.metamodel@1.0.0.ObjectProperty",
+                    "name": "superType",
+                    "type": {
+                        "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                        "name": "TypeIdentifier"
+                    },
+                    "isArray": false,
+                    "isOptional": true
+                },
+                {
+                    "$class": "concerto.metamodel@1.0.0.ObjectProperty",
+                    "name": "properties",
+                    "type": {
+                        "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                        "name": "Property"
+                    },
+                    "isArray": true,
+                    "isOptional": false
+                }
+            ],
+            "superType": {
+                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                "name": "Declaration"
+            }
+        },
+        {
+            "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+            "name": "AssetDeclaration",
+            "isAbstract": false,
+            "properties": [],
+            "superType": {
+                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                "name": "ConceptDeclaration"
+            }
+        },
+        {
+            "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+            "name": "ParticipantDeclaration",
+            "isAbstract": false,
+            "properties": [],
+            "superType": {
+                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                "name": "ConceptDeclaration"
+            }
+        },
+        {
+            "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+            "name": "TransactionDeclaration",
+            "isAbstract": false,
+            "properties": [],
+            "superType": {
+                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                "name": "ConceptDeclaration"
+            }
+        },
+        {
+            "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+            "name": "EventDeclaration",
+            "isAbstract": false,
+            "properties": [],
+            "superType": {
+                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                "name": "ConceptDeclaration"
+            }
+        },
+        {
+            "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+            "name": "Property",
+            "isAbstract": true,
+            "properties": [
+                {
+                    "$class": "concerto.metamodel@1.0.0.StringProperty",
+                    "name": "name",
+                    "isArray": false,
+                    "isOptional": false,
+                    "validator": {
+                        "$class": "concerto.metamodel@1.0.0.StringRegexValidator",
+                        "pattern": "^(\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4})(?:\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4}|\\p{Mn}|\\p{Mc}|\\p{Nd}|\\p{Pc}|\\u200C|\\u200D)*$",
+                        "flags": "u"
+                    }
+                },
+                {
+                    "$class": "concerto.metamodel@1.0.0.BooleanProperty",
+                    "name": "isArray",
+                    "isArray": false,
+                    "isOptional": false,
+                    "defaultValue": false
+                },
+                {
+                    "$class": "concerto.metamodel@1.0.0.BooleanProperty",
+                    "name": "isOptional",
+                    "isArray": false,
+                    "isOptional": false,
+                    "defaultValue": false
+                },
+                {
+                    "$class": "concerto.metamodel@1.0.0.ObjectProperty",
+                    "name": "decorators",
+                    "type": {
+                        "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                        "name": "Decorator"
+                    },
+                    "isArray": true,
+                    "isOptional": true
+                },
+                {
+                    "$class": "concerto.metamodel@1.0.0.ObjectProperty",
+                    "name": "location",
+                    "type": {
+                        "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                        "name": "Range"
+                    },
+                    "isArray": false,
+                    "isOptional": true
+                }
+            ]
+        },
+        {
+            "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+            "name": "RelationshipProperty",
+            "isAbstract": false,
+            "properties": [
+                {
+                    "$class": "concerto.metamodel@1.0.0.ObjectProperty",
+                    "name": "type",
+                    "type": {
+                        "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                        "name": "TypeIdentifier"
+                    },
+                    "isArray": false,
+                    "isOptional": false
+                }
+            ],
+            "superType": {
+                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                "name": "Property"
+            }
+        },
+        {
+            "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+            "name": "ObjectProperty",
+            "isAbstract": false,
+            "properties": [
+                {
+                    "$class": "concerto.metamodel@1.0.0.StringProperty",
+                    "name": "defaultValue",
+                    "isArray": false,
+                    "isOptional": true
+                },
+                {
+                    "$class": "concerto.metamodel@1.0.0.ObjectProperty",
+                    "name": "type",
+                    "type": {
+                        "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                        "name": "TypeIdentifier"
+                    },
+                    "isArray": false,
+                    "isOptional": false
+                }
+            ],
+            "superType": {
+                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                "name": "Property"
+            }
+        },
+        {
+            "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+            "name": "BooleanProperty",
+            "isAbstract": false,
+            "properties": [
+                {
+                    "$class": "concerto.metamodel@1.0.0.BooleanProperty",
+                    "name": "defaultValue",
+                    "isArray": false,
+                    "isOptional": true
+                }
+            ],
+            "superType": {
+                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                "name": "Property"
+            }
+        },
+        {
+            "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+            "name": "DateTimeProperty",
+            "isAbstract": false,
+            "properties": [],
+            "superType": {
+                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                "name": "Property"
+            }
+        },
+        {
+            "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+            "name": "StringProperty",
+            "isAbstract": false,
+            "properties": [
+                {
+                    "$class": "concerto.metamodel@1.0.0.StringProperty",
+                    "name": "defaultValue",
+                    "isArray": false,
+                    "isOptional": true
+                },
+                {
+                    "$class": "concerto.metamodel@1.0.0.ObjectProperty",
+                    "name": "validator",
+                    "type": {
+                        "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                        "name": "StringRegexValidator"
+                    },
+                    "isArray": false,
+                    "isOptional": true
+                }
+            ],
+            "superType": {
+                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                "name": "Property"
+            }
+        },
+        {
+            "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+            "name": "StringRegexValidator",
+            "isAbstract": false,
+            "properties": [
+                {
+                    "$class": "concerto.metamodel@1.0.0.StringProperty",
+                    "name": "pattern",
+                    "isArray": false,
+                    "isOptional": false
+                },
+                {
+                    "$class": "concerto.metamodel@1.0.0.StringProperty",
+                    "name": "flags",
+                    "isArray": false,
+                    "isOptional": false
+                }
+            ]
+        },
+        {
+            "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+            "name": "DoubleProperty",
+            "isAbstract": false,
+            "properties": [
+                {
+                    "$class": "concerto.metamodel@1.0.0.DoubleProperty",
+                    "name": "defaultValue",
+                    "isArray": false,
+                    "isOptional": true
+                },
+                {
+                    "$class": "concerto.metamodel@1.0.0.ObjectProperty",
+                    "name": "validator",
+                    "type": {
+                        "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                        "name": "DoubleDomainValidator"
+                    },
+                    "isArray": false,
+                    "isOptional": true
+                }
+            ],
+            "superType": {
+                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                "name": "Property"
+            }
+        },
+        {
+            "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+            "name": "DoubleDomainValidator",
+            "isAbstract": false,
+            "properties": [
+                {
+                    "$class": "concerto.metamodel@1.0.0.DoubleProperty",
+                    "name": "lower",
+                    "isArray": false,
+                    "isOptional": true
+                },
+                {
+                    "$class": "concerto.metamodel@1.0.0.DoubleProperty",
+                    "name": "upper",
+                    "isArray": false,
+                    "isOptional": true
+                }
+            ]
+        },
+        {
+            "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+            "name": "IntegerProperty",
+            "isAbstract": false,
+            "properties": [
+                {
+                    "$class": "concerto.metamodel@1.0.0.IntegerProperty",
+                    "name": "defaultValue",
+                    "isArray": false,
+                    "isOptional": true
+                },
+                {
+                    "$class": "concerto.metamodel@1.0.0.ObjectProperty",
+                    "name": "validator",
+                    "type": {
+                        "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                        "name": "IntegerDomainValidator"
+                    },
+                    "isArray": false,
+                    "isOptional": true
+                }
+            ],
+            "superType": {
+                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                "name": "Property"
+            }
+        },
+        {
+            "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+            "name": "IntegerDomainValidator",
+            "isAbstract": false,
+            "properties": [
+                {
+                    "$class": "concerto.metamodel@1.0.0.IntegerProperty",
+                    "name": "lower",
+                    "isArray": false,
+                    "isOptional": true
+                },
+                {
+                    "$class": "concerto.metamodel@1.0.0.IntegerProperty",
+                    "name": "upper",
+                    "isArray": false,
+                    "isOptional": true
+                }
+            ]
+        },
+        {
+            "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+            "name": "LongProperty",
+            "isAbstract": false,
+            "properties": [
+                {
+                    "$class": "concerto.metamodel@1.0.0.LongProperty",
+                    "name": "defaultValue",
+                    "isArray": false,
+                    "isOptional": true
+                },
+                {
+                    "$class": "concerto.metamodel@1.0.0.ObjectProperty",
+                    "name": "validator",
+                    "type": {
+                        "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                        "name": "LongDomainValidator"
+                    },
+                    "isArray": false,
+                    "isOptional": true
+                }
+            ],
+            "superType": {
+                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                "name": "Property"
+            }
+        },
+        {
+            "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+            "name": "LongDomainValidator",
+            "isAbstract": false,
+            "properties": [
+                {
+                    "$class": "concerto.metamodel@1.0.0.LongProperty",
+                    "name": "lower",
+                    "isArray": false,
+                    "isOptional": true
+                },
+                {
+                    "$class": "concerto.metamodel@1.0.0.LongProperty",
+                    "name": "upper",
+                    "isArray": false,
+                    "isOptional": true
+                }
+            ]
+        },
+        {
+            "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+            "name": "Import",
+            "isAbstract": true,
+            "properties": [
+                {
+                    "$class": "concerto.metamodel@1.0.0.StringProperty",
+                    "name": "namespace",
+                    "isArray": false,
+                    "isOptional": false
+                },
+                {
+                    "$class": "concerto.metamodel@1.0.0.StringProperty",
+                    "name": "uri",
+                    "isArray": false,
+                    "isOptional": true
+                }
+            ]
+        },
+        {
+            "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+            "name": "ImportAll",
+            "isAbstract": false,
+            "properties": [],
+            "superType": {
+                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                "name": "Import"
+            }
+        },
+        {
+            "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+            "name": "ImportType",
+            "isAbstract": false,
+            "properties": [
+                {
+                    "$class": "concerto.metamodel@1.0.0.StringProperty",
+                    "name": "name",
+                    "isArray": false,
+                    "isOptional": false
+                }
+            ],
+            "superType": {
+                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                "name": "Import"
+            }
+        },
+        {
+            "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+            "name": "ImportTypes",
+            "isAbstract": false,
+            "properties": [
+                {
+                    "$class": "concerto.metamodel@1.0.0.StringProperty",
+                    "name": "types",
+                    "isArray": true,
+                    "isOptional": false
+                }
+            ],
+            "superType": {
+                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                "name": "Import"
+            }
+        },
+        {
+            "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+            "name": "Model",
+            "isAbstract": false,
+            "properties": [
+                {
+                    "$class": "concerto.metamodel@1.0.0.StringProperty",
+                    "name": "namespace",
+                    "isArray": false,
+                    "isOptional": false
+                },
+                {
+                    "$class": "concerto.metamodel@1.0.0.StringProperty",
+                    "name": "sourceUri",
+                    "isArray": false,
+                    "isOptional": true
+                },
+                {
+                    "$class": "concerto.metamodel@1.0.0.StringProperty",
+                    "name": "concertoVersion",
+                    "isArray": false,
+                    "isOptional": true
+                },
+                {
+                    "$class": "concerto.metamodel@1.0.0.ObjectProperty",
+                    "name": "imports",
+                    "type": {
+                        "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                        "name": "Import"
+                    },
+                    "isArray": true,
+                    "isOptional": true
+                },
+                {
+                    "$class": "concerto.metamodel@1.0.0.ObjectProperty",
+                    "name": "declarations",
+                    "type": {
+                        "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                        "name": "Declaration"
+                    },
+                    "isArray": true,
+                    "isOptional": true
+                },
+                {
+                    "$class": "concerto.metamodel@1.0.0.ObjectProperty",
+                    "name": "decorators",
+                    "type": {
+                        "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                        "name": "Decorator"
+                    },
+                    "isArray": true,
+                    "isOptional": true
+                }
+            ]
+        },
+        {
+            "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+            "name": "Models",
+            "isAbstract": false,
+            "properties": [
+                {
+                    "$class": "concerto.metamodel@1.0.0.ObjectProperty",
+                    "name": "models",
+                    "type": {
+                        "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                        "name": "Model"
+                    },
+                    "isArray": true,
+                    "isOptional": false
+                }
+            ]
+        },
+        {
+            "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+            "name": "ScalarDeclaration",
+            "isAbstract": true,
+            "properties": [],
+            "superType": {
+                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                "name": "Declaration"
+            }
+        },
+        {
+            "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+            "name": "BooleanScalar",
+            "isAbstract": false,
+            "properties": [
+                {
+                    "$class": "concerto.metamodel@1.0.0.BooleanProperty",
+                    "name": "defaultValue",
+                    "isArray": false,
+                    "isOptional": false
+                }
+            ],
+            "superType": {
+                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                "name": "ScalarDeclaration"
+            }
+        },
+        {
+            "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+            "name": "IntegerScalar",
+            "isAbstract": false,
+            "properties": [
+                {
+                    "$class": "concerto.metamodel@1.0.0.IntegerProperty",
+                    "name": "defaultValue",
+                    "isArray": false,
+                    "isOptional": true
+                },
+                {
+                    "$class": "concerto.metamodel@1.0.0.ObjectProperty",
+                    "name": "validator",
+                    "type": {
+                        "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                        "name": "IntegerDomainValidator"
+                    },
+                    "isArray": false,
+                    "isOptional": true
+                }
+            ],
+            "superType": {
+                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                "name": "ScalarDeclaration"
+            }
+        },
+        {
+            "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+            "name": "LongScalar",
+            "isAbstract": false,
+            "properties": [
+                {
+                    "$class": "concerto.metamodel@1.0.0.LongProperty",
+                    "name": "defaultValue",
+                    "isArray": false,
+                    "isOptional": true
+                },
+                {
+                    "$class": "concerto.metamodel@1.0.0.ObjectProperty",
+                    "name": "validator",
+                    "type": {
+                        "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                        "name": "LongDomainValidator"
+                    },
+                    "isArray": false,
+                    "isOptional": true
+                }
+            ],
+            "superType": {
+                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                "name": "ScalarDeclaration"
+            }
+        },
+        {
+            "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+            "name": "DoubleScalar",
+            "isAbstract": false,
+            "properties": [
+                {
+                    "$class": "concerto.metamodel@1.0.0.DoubleProperty",
+                    "name": "defaultValue",
+                    "isArray": false,
+                    "isOptional": true
+                },
+                {
+                    "$class": "concerto.metamodel@1.0.0.ObjectProperty",
+                    "name": "validator",
+                    "type": {
+                        "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                        "name": "DoubleDomainValidator"
+                    },
+                    "isArray": false,
+                    "isOptional": true
+                }
+            ],
+            "superType": {
+                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                "name": "ScalarDeclaration"
+            }
+        },
+        {
+            "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+            "name": "StringScalar",
+            "isAbstract": false,
+            "properties": [
+                {
+                    "$class": "concerto.metamodel@1.0.0.StringProperty",
+                    "name": "defaultValue",
+                    "isArray": false,
+                    "isOptional": true
+                },
+                {
+                    "$class": "concerto.metamodel@1.0.0.ObjectProperty",
+                    "name": "validator",
+                    "type": {
+                        "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                        "name": "StringRegexValidator"
+                    },
+                    "isArray": false,
+                    "isOptional": true
+                }
+            ],
+            "superType": {
+                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                "name": "ScalarDeclaration"
+            }
+        },
+        {
+            "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+            "name": "DateTimeScalar",
+            "isAbstract": false,
+            "properties": [
+                {
+                    "$class": "concerto.metamodel@1.0.0.StringProperty",
+                    "name": "defaultValue",
+                    "isArray": false,
+                    "isOptional": true
+                }
+            ],
+            "superType": {
+                "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                "name": "ScalarDeclaration"
+            }
         }
-      ],
-      "superType": {
-        "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-        "name": "DecoratorLiteral"
-      }
-    },
-    {
-      "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
-      "name": "Decorator",
-      "isAbstract": false,
-      "properties": [
-        {
-          "$class": "concerto.metamodel@1.0.0.StringProperty",
-          "name": "name",
-          "isArray": false,
-          "isOptional": false
-        },
-        {
-          "$class": "concerto.metamodel@1.0.0.ObjectProperty",
-          "name": "arguments",
-          "type": {
-            "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-            "name": "DecoratorLiteral"
-          },
-          "isArray": true,
-          "isOptional": true
-        },
-        {
-          "$class": "concerto.metamodel@1.0.0.ObjectProperty",
-          "name": "location",
-          "type": {
-            "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-            "name": "Range"
-          },
-          "isArray": false,
-          "isOptional": true
-        }
-      ]
-    },
-    {
-      "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
-      "name": "Identified",
-      "isAbstract": false,
-      "properties": []
-    },
-    {
-      "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
-      "name": "IdentifiedBy",
-      "isAbstract": false,
-      "properties": [
-        {
-          "$class": "concerto.metamodel@1.0.0.StringProperty",
-          "name": "name",
-          "isArray": false,
-          "isOptional": false
-        }
-      ],
-      "superType": {
-        "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-        "name": "Identified"
-      }
-    },
-    {
-      "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
-      "name": "Declaration",
-      "isAbstract": true,
-      "properties": [
-        {
-          "$class": "concerto.metamodel@1.0.0.StringProperty",
-          "name": "name",
-          "isArray": false,
-          "isOptional": false,
-          "validator": {
-            "$class": "concerto.metamodel@1.0.0.StringRegexValidator",
-            "pattern": "^(\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4})(?:\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4}|\\p{Mn}|\\p{Mc}|\\p{Nd}|\\p{Pc}|\\u200C|\\u200D)*$",
-            "flags": "u"
-          }
-        },
-        {
-          "$class": "concerto.metamodel@1.0.0.ObjectProperty",
-          "name": "decorators",
-          "type": {
-            "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-            "name": "Decorator"
-          },
-          "isArray": true,
-          "isOptional": true
-        },
-        {
-          "$class": "concerto.metamodel@1.0.0.ObjectProperty",
-          "name": "location",
-          "type": {
-            "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-            "name": "Range"
-          },
-          "isArray": false,
-          "isOptional": true
-        }
-      ]
-    },
-    {
-      "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
-      "name": "EnumDeclaration",
-      "isAbstract": false,
-      "properties": [
-        {
-          "$class": "concerto.metamodel@1.0.0.ObjectProperty",
-          "name": "properties",
-          "type": {
-            "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-            "name": "EnumProperty"
-          },
-          "isArray": true,
-          "isOptional": false
-        }
-      ],
-      "superType": {
-        "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-        "name": "Declaration"
-      }
-    },
-    {
-      "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
-      "name": "EnumProperty",
-      "isAbstract": false,
-      "properties": [
-        {
-          "$class": "concerto.metamodel@1.0.0.StringProperty",
-          "name": "name",
-          "isArray": false,
-          "isOptional": false,
-          "validator": {
-            "$class": "concerto.metamodel@1.0.0.StringRegexValidator",
-            "pattern": "^(\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4})(?:\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4}|\\p{Mn}|\\p{Mc}|\\p{Nd}|\\p{Pc}|\\u200C|\\u200D)*$",
-            "flags": "u"
-          }
-        },
-        {
-          "$class": "concerto.metamodel@1.0.0.ObjectProperty",
-          "name": "decorators",
-          "type": {
-            "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-            "name": "Decorator"
-          },
-          "isArray": true,
-          "isOptional": true
-        },
-        {
-          "$class": "concerto.metamodel@1.0.0.ObjectProperty",
-          "name": "location",
-          "type": {
-            "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-            "name": "Range"
-          },
-          "isArray": false,
-          "isOptional": true
-        }
-      ]
-    },
-    {
-      "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
-      "name": "ConceptDeclaration",
-      "isAbstract": false,
-      "properties": [
-        {
-          "$class": "concerto.metamodel@1.0.0.BooleanProperty",
-          "name": "isAbstract",
-          "isArray": false,
-          "isOptional": false,
-          "defaultValue": false
-        },
-        {
-          "$class": "concerto.metamodel@1.0.0.ObjectProperty",
-          "name": "identified",
-          "type": {
-            "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-            "name": "Identified"
-          },
-          "isArray": false,
-          "isOptional": true
-        },
-        {
-          "$class": "concerto.metamodel@1.0.0.ObjectProperty",
-          "name": "superType",
-          "type": {
-            "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-            "name": "TypeIdentifier"
-          },
-          "isArray": false,
-          "isOptional": true
-        },
-        {
-          "$class": "concerto.metamodel@1.0.0.ObjectProperty",
-          "name": "properties",
-          "type": {
-            "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-            "name": "Property"
-          },
-          "isArray": true,
-          "isOptional": false
-        }
-      ],
-      "superType": {
-        "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-        "name": "Declaration"
-      }
-    },
-    {
-      "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
-      "name": "AssetDeclaration",
-      "isAbstract": false,
-      "properties": [],
-      "superType": {
-        "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-        "name": "ConceptDeclaration"
-      }
-    },
-    {
-      "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
-      "name": "ParticipantDeclaration",
-      "isAbstract": false,
-      "properties": [],
-      "superType": {
-        "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-        "name": "ConceptDeclaration"
-      }
-    },
-    {
-      "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
-      "name": "TransactionDeclaration",
-      "isAbstract": false,
-      "properties": [],
-      "superType": {
-        "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-        "name": "ConceptDeclaration"
-      }
-    },
-    {
-      "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
-      "name": "EventDeclaration",
-      "isAbstract": false,
-      "properties": [],
-      "superType": {
-        "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-        "name": "ConceptDeclaration"
-      }
-    },
-    {
-      "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
-      "name": "Property",
-      "isAbstract": true,
-      "properties": [
-        {
-          "$class": "concerto.metamodel@1.0.0.StringProperty",
-          "name": "name",
-          "isArray": false,
-          "isOptional": false,
-          "validator": {
-            "$class": "concerto.metamodel@1.0.0.StringRegexValidator",
-            "pattern": "^(\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4})(?:\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4}|\\p{Mn}|\\p{Mc}|\\p{Nd}|\\p{Pc}|\\u200C|\\u200D)*$",
-            "flags": "u"
-          }
-        },
-        {
-          "$class": "concerto.metamodel@1.0.0.BooleanProperty",
-          "name": "isArray",
-          "isArray": false,
-          "isOptional": false,
-          "defaultValue": false
-        },
-        {
-          "$class": "concerto.metamodel@1.0.0.BooleanProperty",
-          "name": "isOptional",
-          "isArray": false,
-          "isOptional": false,
-          "defaultValue": false
-        },
-        {
-          "$class": "concerto.metamodel@1.0.0.ObjectProperty",
-          "name": "decorators",
-          "type": {
-            "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-            "name": "Decorator"
-          },
-          "isArray": true,
-          "isOptional": true
-        },
-        {
-          "$class": "concerto.metamodel@1.0.0.ObjectProperty",
-          "name": "location",
-          "type": {
-            "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-            "name": "Range"
-          },
-          "isArray": false,
-          "isOptional": true
-        }
-      ]
-    },
-    {
-      "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
-      "name": "RelationshipProperty",
-      "isAbstract": false,
-      "properties": [
-        {
-          "$class": "concerto.metamodel@1.0.0.ObjectProperty",
-          "name": "type",
-          "type": {
-            "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-            "name": "TypeIdentifier"
-          },
-          "isArray": false,
-          "isOptional": false
-        }
-      ],
-      "superType": {
-        "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-        "name": "Property"
-      }
-    },
-    {
-      "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
-      "name": "ObjectProperty",
-      "isAbstract": false,
-      "properties": [
-        {
-          "$class": "concerto.metamodel@1.0.0.StringProperty",
-          "name": "defaultValue",
-          "isArray": false,
-          "isOptional": true
-        },
-        {
-          "$class": "concerto.metamodel@1.0.0.ObjectProperty",
-          "name": "type",
-          "type": {
-            "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-            "name": "TypeIdentifier"
-          },
-          "isArray": false,
-          "isOptional": false
-        }
-      ],
-      "superType": {
-        "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-        "name": "Property"
-      }
-    },
-    {
-      "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
-      "name": "BooleanProperty",
-      "isAbstract": false,
-      "properties": [
-        {
-          "$class": "concerto.metamodel@1.0.0.BooleanProperty",
-          "name": "defaultValue",
-          "isArray": false,
-          "isOptional": true
-        }
-      ],
-      "superType": {
-        "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-        "name": "Property"
-      }
-    },
-    {
-      "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
-      "name": "DateTimeProperty",
-      "isAbstract": false,
-      "properties": [],
-      "superType": {
-        "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-        "name": "Property"
-      }
-    },
-    {
-      "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
-      "name": "StringProperty",
-      "isAbstract": false,
-      "properties": [
-        {
-          "$class": "concerto.metamodel@1.0.0.StringProperty",
-          "name": "defaultValue",
-          "isArray": false,
-          "isOptional": true
-        },
-        {
-          "$class": "concerto.metamodel@1.0.0.ObjectProperty",
-          "name": "validator",
-          "type": {
-            "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-            "name": "StringRegexValidator"
-          },
-          "isArray": false,
-          "isOptional": true
-        }
-      ],
-      "superType": {
-        "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-        "name": "Property"
-      }
-    },
-    {
-      "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
-      "name": "StringRegexValidator",
-      "isAbstract": false,
-      "properties": [
-        {
-          "$class": "concerto.metamodel@1.0.0.StringProperty",
-          "name": "pattern",
-          "isArray": false,
-          "isOptional": false
-        },
-        {
-          "$class": "concerto.metamodel@1.0.0.StringProperty",
-          "name": "flags",
-          "isArray": false,
-          "isOptional": false
-        }
-      ]
-    },
-    {
-      "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
-      "name": "DoubleProperty",
-      "isAbstract": false,
-      "properties": [
-        {
-          "$class": "concerto.metamodel@1.0.0.DoubleProperty",
-          "name": "defaultValue",
-          "isArray": false,
-          "isOptional": true
-        },
-        {
-          "$class": "concerto.metamodel@1.0.0.ObjectProperty",
-          "name": "validator",
-          "type": {
-            "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-            "name": "DoubleDomainValidator"
-          },
-          "isArray": false,
-          "isOptional": true
-        }
-      ],
-      "superType": {
-        "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-        "name": "Property"
-      }
-    },
-    {
-      "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
-      "name": "DoubleDomainValidator",
-      "isAbstract": false,
-      "properties": [
-        {
-          "$class": "concerto.metamodel@1.0.0.DoubleProperty",
-          "name": "lower",
-          "isArray": false,
-          "isOptional": true
-        },
-        {
-          "$class": "concerto.metamodel@1.0.0.DoubleProperty",
-          "name": "upper",
-          "isArray": false,
-          "isOptional": true
-        }
-      ]
-    },
-    {
-      "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
-      "name": "IntegerProperty",
-      "isAbstract": false,
-      "properties": [
-        {
-          "$class": "concerto.metamodel@1.0.0.IntegerProperty",
-          "name": "defaultValue",
-          "isArray": false,
-          "isOptional": true
-        },
-        {
-          "$class": "concerto.metamodel@1.0.0.ObjectProperty",
-          "name": "validator",
-          "type": {
-            "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-            "name": "IntegerDomainValidator"
-          },
-          "isArray": false,
-          "isOptional": true
-        }
-      ],
-      "superType": {
-        "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-        "name": "Property"
-      }
-    },
-    {
-      "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
-      "name": "IntegerDomainValidator",
-      "isAbstract": false,
-      "properties": [
-        {
-          "$class": "concerto.metamodel@1.0.0.IntegerProperty",
-          "name": "lower",
-          "isArray": false,
-          "isOptional": true
-        },
-        {
-          "$class": "concerto.metamodel@1.0.0.IntegerProperty",
-          "name": "upper",
-          "isArray": false,
-          "isOptional": true
-        }
-      ]
-    },
-    {
-      "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
-      "name": "LongProperty",
-      "isAbstract": false,
-      "properties": [
-        {
-          "$class": "concerto.metamodel@1.0.0.LongProperty",
-          "name": "defaultValue",
-          "isArray": false,
-          "isOptional": true
-        },
-        {
-          "$class": "concerto.metamodel@1.0.0.ObjectProperty",
-          "name": "validator",
-          "type": {
-            "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-            "name": "LongDomainValidator"
-          },
-          "isArray": false,
-          "isOptional": true
-        }
-      ],
-      "superType": {
-        "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-        "name": "Property"
-      }
-    },
-    {
-      "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
-      "name": "LongDomainValidator",
-      "isAbstract": false,
-      "properties": [
-        {
-          "$class": "concerto.metamodel@1.0.0.LongProperty",
-          "name": "lower",
-          "isArray": false,
-          "isOptional": true
-        },
-        {
-          "$class": "concerto.metamodel@1.0.0.LongProperty",
-          "name": "upper",
-          "isArray": false,
-          "isOptional": true
-        }
-      ]
-    },
-    {
-      "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
-      "name": "Import",
-      "isAbstract": true,
-      "properties": [
-        {
-          "$class": "concerto.metamodel@1.0.0.StringProperty",
-          "name": "namespace",
-          "isArray": false,
-          "isOptional": false
-        },
-        {
-          "$class": "concerto.metamodel@1.0.0.StringProperty",
-          "name": "uri",
-          "isArray": false,
-          "isOptional": true
-        }
-      ]
-    },
-    {
-      "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
-      "name": "ImportAll",
-      "isAbstract": false,
-      "properties": [],
-      "superType": {
-        "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-        "name": "Import"
-      }
-    },
-    {
-      "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
-      "name": "ImportType",
-      "isAbstract": false,
-      "properties": [
-        {
-          "$class": "concerto.metamodel@1.0.0.StringProperty",
-          "name": "name",
-          "isArray": false,
-          "isOptional": false
-        }
-      ],
-      "superType": {
-        "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-        "name": "Import"
-      }
-    },
-    {
-      "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
-      "name": "ImportTypes",
-      "isAbstract": false,
-      "properties": [
-        {
-          "$class": "concerto.metamodel@1.0.0.StringProperty",
-          "name": "types",
-          "isArray": true,
-          "isOptional": false
-        }
-      ],
-      "superType": {
-        "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-        "name": "Import"
-      }
-    },
-    {
-      "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
-      "name": "Model",
-      "isAbstract": false,
-      "properties": [
-        {
-          "$class": "concerto.metamodel@1.0.0.StringProperty",
-          "name": "namespace",
-          "isArray": false,
-          "isOptional": false
-        },
-        {
-          "$class": "concerto.metamodel@1.0.0.StringProperty",
-          "name": "sourceUri",
-          "isArray": false,
-          "isOptional": true
-        },
-        {
-          "$class": "concerto.metamodel@1.0.0.StringProperty",
-          "name": "concertoVersion",
-          "isArray": false,
-          "isOptional": true
-        },
-        {
-          "$class": "concerto.metamodel@1.0.0.ObjectProperty",
-          "name": "imports",
-          "type": {
-            "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-            "name": "Import"
-          },
-          "isArray": true,
-          "isOptional": true
-        },
-        {
-          "$class": "concerto.metamodel@1.0.0.ObjectProperty",
-          "name": "declarations",
-          "type": {
-            "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-            "name": "Declaration"
-          },
-          "isArray": true,
-          "isOptional": true
-        },
-        {
-          "$class": "concerto.metamodel@1.0.0.ObjectProperty",
-          "name": "decorators",
-          "type": {
-            "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-            "name": "Decorator"
-          },
-          "isArray": true,
-          "isOptional": true
-        }
-      ]
-    },
-    {
-      "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
-      "name": "Models",
-      "isAbstract": false,
-      "properties": [
-        {
-          "$class": "concerto.metamodel@1.0.0.ObjectProperty",
-          "name": "models",
-          "type": {
-            "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-            "name": "Model"
-          },
-          "isArray": true,
-          "isOptional": false
-        }
-      ]
-    },
-    {
-      "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
-      "name": "ScalarDeclaration",
-      "isAbstract": true,
-      "properties": [],
-      "superType": {
-        "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-        "name": "Declaration"
-      }
-    },
-    {
-      "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
-      "name": "BooleanScalar",
-      "isAbstract": false,
-      "properties": [
-        {
-          "$class": "concerto.metamodel@1.0.0.BooleanProperty",
-          "name": "defaultValue",
-          "isArray": false,
-          "isOptional": false
-        }
-      ],
-      "superType": {
-        "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-        "name": "ScalarDeclaration"
-      }
-    },
-    {
-      "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
-      "name": "IntegerScalar",
-      "isAbstract": false,
-      "properties": [
-        {
-          "$class": "concerto.metamodel@1.0.0.IntegerProperty",
-          "name": "defaultValue",
-          "isArray": false,
-          "isOptional": true
-        },
-        {
-          "$class": "concerto.metamodel@1.0.0.ObjectProperty",
-          "name": "validator",
-          "type": {
-            "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-            "name": "IntegerDomainValidator"
-          },
-          "isArray": false,
-          "isOptional": true
-        }
-      ],
-      "superType": {
-        "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-        "name": "ScalarDeclaration"
-      }
-    },
-    {
-      "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
-      "name": "LongScalar",
-      "isAbstract": false,
-      "properties": [
-        {
-          "$class": "concerto.metamodel@1.0.0.LongProperty",
-          "name": "defaultValue",
-          "isArray": false,
-          "isOptional": true
-        },
-        {
-          "$class": "concerto.metamodel@1.0.0.ObjectProperty",
-          "name": "validator",
-          "type": {
-            "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-            "name": "LongDomainValidator"
-          },
-          "isArray": false,
-          "isOptional": true
-        }
-      ],
-      "superType": {
-        "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-        "name": "ScalarDeclaration"
-      }
-    },
-    {
-      "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
-      "name": "DoubleScalar",
-      "isAbstract": false,
-      "properties": [
-        {
-          "$class": "concerto.metamodel@1.0.0.DoubleProperty",
-          "name": "defaultValue",
-          "isArray": false,
-          "isOptional": true
-        },
-        {
-          "$class": "concerto.metamodel@1.0.0.ObjectProperty",
-          "name": "validator",
-          "type": {
-            "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-            "name": "DoubleDomainValidator"
-          },
-          "isArray": false,
-          "isOptional": true
-        }
-      ],
-      "superType": {
-        "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-        "name": "ScalarDeclaration"
-      }
-    },
-    {
-      "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
-      "name": "StringScalar",
-      "isAbstract": false,
-      "properties": [
-        {
-          "$class": "concerto.metamodel@1.0.0.StringProperty",
-          "name": "defaultValue",
-          "isArray": false,
-          "isOptional": true
-        },
-        {
-          "$class": "concerto.metamodel@1.0.0.ObjectProperty",
-          "name": "validator",
-          "type": {
-            "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-            "name": "StringRegexValidator"
-          },
-          "isArray": false,
-          "isOptional": true
-        }
-      ],
-      "superType": {
-        "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-        "name": "ScalarDeclaration"
-      }
-    },
-    {
-      "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
-      "name": "DateTimeScalar",
-      "isAbstract": false,
-      "properties": [
-        {
-          "$class": "concerto.metamodel@1.0.0.StringProperty",
-          "name": "defaultValue",
-          "isArray": false,
-          "isOptional": true
-        }
-      ],
-      "superType": {
-        "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
-        "name": "ScalarDeclaration"
-      }
-    }
-  ]
+    ]
 }

--- a/packages/concerto-metamodel/lib/metamodelutil.js
+++ b/packages/concerto-metamodel/lib/metamodelutil.js
@@ -14,6 +14,9 @@
 
 'use strict';
 
+const fs = require('fs');
+const path = require('path');
+
 /**
  * The metamodel itself, as an AST.
  * @type unknown
@@ -24,190 +27,13 @@ const metaModelAst = require('./metamodel.json');
  * The namespace for the metamodel
  */
 const MetaModelNamespace = 'concerto.metamodel@1.0.0';
+
+const metaModelCtoPath = path.resolve(__dirname, 'metamodel.cto');
+
 /**
  * The metamodel itself, as a CTO string
  */
-const metaModelCto = `@DotNetNamespace("AccordProject.Concerto.Metamodel")
-namespace ${MetaModelNamespace}
-
-concept Position {
-  o Integer line
-  o Integer column
-  o Integer offset
-}
-concept Range {
-  o Position start
-  o Position end
-  o String source optional
-}
-
-concept TypeIdentifier {
-  o String name
-  o String namespace optional
-}
-
-abstract concept DecoratorLiteral {
-  o Range location optional
-}
-
-concept DecoratorString extends DecoratorLiteral {
-  o String value
-}
-
-concept DecoratorNumber extends DecoratorLiteral {
-  o Double value
-}
-
-concept DecoratorBoolean extends DecoratorLiteral {
-  o Boolean value
-}
-
-concept DecoratorTypeReference extends DecoratorLiteral {
-  o TypeIdentifier type
-  o Boolean isArray default=false
-}
-
-concept Decorator {
-  o String name
-  o DecoratorLiteral[] arguments optional
-  o Range location optional
-}
-
-concept Identified {
-}
-
-concept IdentifiedBy extends Identified {
-  o String name
-}
-
-abstract concept Declaration {
-  o String name regex=/^(\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4})(?:\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|\\\\u[0-9A-Fa-f]{4}|\\p{Mn}|\\p{Mc}|\\p{Nd}|\\p{Pc}|\\u200C|\\u200D)*$/u
-  o Decorator[] decorators optional
-  o Range location optional
-}
-
-concept EnumDeclaration extends Declaration {
-  o EnumProperty[] properties
-}
-
-concept EnumProperty {
-  o String name regex=/^(\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4})(?:\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|\\\\u[0-9A-Fa-f]{4}|\\p{Mn}|\\p{Mc}|\\p{Nd}|\\p{Pc}|\\u200C|\\u200D)*$/u
-  o Decorator[] decorators optional
-  o Range location optional
-}
-
-concept ConceptDeclaration extends Declaration {
-  o Boolean isAbstract default=false
-  o Identified identified optional
-  o TypeIdentifier superType optional
-  o Property[] properties
-}
-
-concept AssetDeclaration extends ConceptDeclaration {
-}
-
-concept ParticipantDeclaration extends ConceptDeclaration {
-}
-
-concept TransactionDeclaration extends ConceptDeclaration {
-}
-
-concept EventDeclaration extends ConceptDeclaration {
-}
-
-abstract concept Property {
-  o String name regex=/^(\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4})(?:\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|\\\\u[0-9A-Fa-f]{4}|\\p{Mn}|\\p{Mc}|\\p{Nd}|\\p{Pc}|\\u200C|\\u200D)*$/u
-  o Boolean isArray default=false
-  o Boolean isOptional default=false
-  o Decorator[] decorators optional
-  o Range location optional
-}
-
-concept RelationshipProperty extends Property {
-  o TypeIdentifier type
-}
-
-concept ObjectProperty extends Property {
-  o String defaultValue optional
-  o TypeIdentifier type
-}
-
-concept BooleanProperty extends Property {
-  o Boolean defaultValue optional
-}
-
-concept DateTimeProperty extends Property {
-}
-
-concept StringProperty extends Property {
-  o String defaultValue optional
-  o StringRegexValidator validator optional
-}
-
-concept StringRegexValidator {
-  o String pattern
-  o String flags
-}
-
-concept DoubleProperty extends Property {
-  o Double defaultValue optional
-  o DoubleDomainValidator validator optional
-}
-
-concept DoubleDomainValidator {
-  o Double lower optional
-  o Double upper optional
-}
-
-concept IntegerProperty extends Property {
-  o Integer defaultValue optional
-  o IntegerDomainValidator validator optional
-}
-
-concept IntegerDomainValidator {
-  o Integer lower optional
-  o Integer upper optional
-}
-
-concept LongProperty extends Property {
-  o Long defaultValue optional
-  o LongDomainValidator validator optional
-}
-
-concept LongDomainValidator {
-  o Long lower optional
-  o Long upper optional
-}
-
-abstract concept Import {
-  o String namespace
-  o String uri optional
-}
-
-concept ImportAll extends Import {
-}
-
-concept ImportType extends Import {
-  o String name
-}
-
-concept ImportTypes extends Import {
-  o String[] types
-}
-
-concept Model {
-  o String namespace
-  o String sourceUri optional
-  o String concertoVersion optional
-  o Import[] imports optional
-  o Declaration[] declarations optional
-  o Decorator[] decorators optional
-}
-
-concept Models {
-  o Model[] models
-}
-`;
+const metaModelCto = fs.readFileSync(metaModelCtoPath, 'utf-8');
 
 /**
  * Find the model for a given namespace


### PR DESCRIPTION
The changes in #546 did not update the CTO representation of the metamodel we ship in the code, and so this change updates the CTO to match the new metamodel JSON. It also updates the metamodel JSON with the missing `@DotNetNamespace` decorator that has been removed.

This metamodel management process is broken and needs a revisit, but this will fix it for now.

Signed-off-by: Simon Stone <Simon.Stone@docusign.com>