### PR TITLE
fix(tools): don't capitalize types in JSON Schema inference by default 

### DIFF
--- a/packages/concerto-cli/lib/commands.js
+++ b/packages/concerto-cli/lib/commands.js
@@ -576,19 +576,19 @@ class Commands {
      * @param {string} namespace The namepspace for the output model
      * @param {string} [typeName] The name of the root concept
      * @param {string} [format] The source format
-     * @param {string} [output] The target file.
+     * @param {string} [options] Processing options for inference
      *
      * @returns {string} a CTO string
      */
-    static inferConcertoSchema(input, namespace, typeName = 'Root', format = 'jsonSchema', output) {
+    static inferConcertoSchema(input, namespace, typeName = 'Root', format = 'jsonSchema', options) {
         let schema = JSON.parse(fs.readFileSync(input, 'utf8'));
 
         if (format.toLowerCase() === 'openapi'){
             const jsonSchema = toJsonSchema(schema);
             migrate.draft2020(jsonSchema);
-            return CodeGen.InferFromJsonSchema(namespace, typeName, jsonSchema);
+            return CodeGen.InferFromJsonSchema(namespace, typeName, jsonSchema, options);
         }
-        return CodeGen.InferFromJsonSchema(namespace, typeName, schema);
+        return CodeGen.InferFromJsonSchema(namespace, typeName, schema, options);
     }
 }
 

--- a/packages/concerto-tools/lib/codegen/fromJsonSchema/cto/inferModel.js
+++ b/packages/concerto-tools/lib/codegen/fromJsonSchema/cto/inferModel.js
@@ -21,16 +21,6 @@ const draft6MetaSchema = require('ajv/dist/refs/json-schema-draft-06.json');
 const draft7MetaSchema = require('ajv/dist/refs/json-schema-draft-07.json');
 const addFormats = require('ajv-formats');
 
-/**
- * Capitalize the first letter of a string
- * @param {string} string the input string
- * @returns {string} input with first letter capitalized
- * @private
- */
-function capitalizeFirstLetter(string) {
-    return string.charAt(0).toUpperCase() + string.slice(1);
-}
-
 const REGEX_ESCAPED_CHARS = /[\s\\.-]/g;
 
 /**
@@ -40,13 +30,11 @@ const REGEX_ESCAPED_CHARS = /[\s\\.-]/g;
  * @private
  */
 function normalizeType(type) {
-    return capitalizeFirstLetter(
-        type
-            // In CTO we only have one place to store definitions, so we flatten the storage structure from JSON Schema
-            .replace(/^#\/(definitions|\$defs|components\/schemas)\//, '')
-            // Replace delimiters with underscore
-            .replace(REGEX_ESCAPED_CHARS, '_')
-    );
+    return type
+    // In CTO we only have one place to store definitions, so we flatten the storage structure from JSON Schema
+        .replace(/^#\/(definitions|\$defs|components\/schemas)\//, '')
+    // Replace delimiters with underscore
+        .replace(REGEX_ESCAPED_CHARS, '_');
 }
 
 /**

--- a/packages/concerto-tools/test/codegen/fromJsonSchema/cto/inferModel.js
+++ b/packages/concerto-tools/test/codegen/fromJsonSchema/cto/inferModel.js
@@ -26,6 +26,8 @@ const Concerto = require('@accordproject/concerto-core').Concerto;
 
 const inferModel = require('../../../../lib/codegen/fromJsonSchema/cto/inferModel.js');
 
+const options = { capitalizeFirstLetterOfTypeName: true };
+
 describe('inferModel', function () {
     beforeEach(() => {
     });
@@ -34,7 +36,7 @@ describe('inferModel', function () {
         const example = JSON.parse(fs.readFileSync(path.resolve(__dirname, '../cto/data/example.json'), 'utf8'));
         const schema = JSON.parse(fs.readFileSync(path.resolve(__dirname, '../cto/data/schema.json'), 'utf8'));
         const expectedCto = fs.readFileSync(path.resolve(__dirname, '../cto/data/full.cto'), 'utf8');
-        const cto = inferModel('org.acme', 'Root', schema);
+        const cto = inferModel('org.acme', 'Root', schema, options);
         cto.should.equal(expectedCto);
 
         const ajv = new Ajv({ strict: true })
@@ -60,7 +62,7 @@ describe('inferModel', function () {
         const cto = inferModel('org.acme', 'Root', {
             $schema: 'http://json-schema.org/draft-07/schema#',
             enum: ['one', 'two']
-        });
+        }, options);
         cto.should.equal(`namespace org.acme
 
 enum Root {
@@ -83,7 +85,7 @@ enum Root {
                     }
                 }
             }
-        });
+        }, options);
         cto.should.equal(`namespace org.acme
 
 concept Root {
@@ -109,8 +111,8 @@ enum Root_Xs {
                     'items': { '$ref': '#' }
                 }
             }
-        }
-        );
+        },
+        options);
         cto.should.equal(`namespace org.acme
 
 concept Root {
@@ -123,7 +125,7 @@ concept Root {
 
     it('should generate Concerto for for a schema that uses the 2020 draft', async () => {
         const schema = JSON.parse(fs.readFileSync(path.resolve(__dirname, '../cto/data/2020-schema.json'), 'utf8'));
-        const cto = inferModel('org.acme', 'Root', schema);
+        const cto = inferModel('org.acme', 'Root', schema, options);
         cto.should.equal(`namespace com.example
 
 concept Veggie {
@@ -141,7 +143,7 @@ concept Arrays {
 
     it('should generate Concerto for for a schema that property modifiers', async () => {
         const schema = JSON.parse(fs.readFileSync(path.resolve(__dirname, '../cto/data/modifiers-schema.json'), 'utf8'));
-        const cto = inferModel('org.acme', 'Root', schema);
+        const cto = inferModel('org.acme', 'Root', schema, options);
         cto.should.equal(`namespace com.example
 
 concept Geographical_location {
@@ -166,7 +168,7 @@ concept Geographical_location {
                         const: 'value'
                     }
                 }
-            });
+            }, options);
         }).should.throw('Unsupported definition: {"const":"value"}');
     });
 
@@ -181,7 +183,7 @@ concept Geographical_location {
                         additionalProperties: true,
                     }
                 }
-            });
+            }, options);
         }).should.throw('\'additionalProperties\' are not supported in Concerto');
     });
 
@@ -199,7 +201,7 @@ concept Geographical_location {
                     }
                 }
             }
-        });
+        }, options);
         cto.should.equal(`namespace org.acme
 
 concept Foo {


### PR DESCRIPTION
For schemas or OpenAPI definitions that include duplicate type names which only differ in the capitalization of the first character, the current behaviour creates a duplicate definition (which is invalid).

This change makes capitalisation of the first character an optional feature through the `capitalizeFirstLetterOfTypeName` option in the API, or the `--capitalizeFirst` flag in the CLI.

## Example
See `AccountSignatureProviders` and `accountSignatureProviders` in https://github.com/docusign/OpenAPI-Specifications/blob/master/esignature.rest.swagger-v2.1.json