### PR TITLE
feat(core): allow scalar strings to be used as identifiers

### DIFF
--- a/packages/concerto-core/lib/introspect/classdeclaration.js
+++ b/packages/concerto-core/lib/introspect/classdeclaration.js
@@ -239,7 +239,12 @@ class ClassDeclaration extends Decorated {
                 }), this.modelFile, this.ast.location);
             } else {
                 // check that identifiers are strings
-                if (idField.getType() !== 'String') {
+                const isPrimitiveString = idField.getType() === 'String';
+                const modelFile = idField.getParent().getModelFile();
+                const declaration = modelFile.getType(idField.getType());
+                const isScalarString = declaration !== null && declaration.isScalarDeclaration?.() && declaration.getType?.() === 'String';
+
+                if (!isPrimitiveString && !isScalarString) {
                     let formatter = Globalize('en').messageFormatter('classdeclaration-validate-identifiernotstring');
                     throw new IllegalModelException(formatter({
                         'class': this.name,

--- a/packages/concerto-core/lib/model/typed.js
+++ b/packages/concerto-core/lib/model/typed.js
@@ -16,6 +16,7 @@
 
 const dayjs = require('dayjs');
 const utc = require('dayjs/plugin/utc');
+const ModelUtil = require('../modelutil');
 dayjs.extend(utc);
 
 // Types needed for TypeScript generation.
@@ -143,27 +144,36 @@ class Typed {
 
         for (let n = 0; n < fields.length; n++) {
             let field = fields[n];
+            let defaultValue;
+            let type;
             if (field.isField?.()) {
-                let defaultValue = field.getDefaultValue();
+                defaultValue = field.getDefaultValue();
+                type = field.getType();
+            }
+            if (ModelUtil.isScalar(field)){
+                const modelFile = field.getParent().getModelFile();
+                const scalarDeclaration = modelFile.getType(field.getType());
+                defaultValue = scalarDeclaration.getDefaultValue();
+                type = scalarDeclaration.getType();
+            }
 
-                if (defaultValue) {
-                    if (field.getType() === 'String') {
-                        this.setPropertyValue(field.getName(), defaultValue);
-                    } else if (field.getType() === 'Integer') {
-                        this.setPropertyValue(field.getName(), parseInt(defaultValue));
-                    } else if (field.getType() === 'Long') {
-                        this.setPropertyValue(field.getName(), parseInt(defaultValue));
-                    } else if (field.getType() === 'Double') {
-                        this.setPropertyValue(field.getName(), parseFloat(defaultValue));
-                    } else if (field.getType() === 'Boolean') {
-                        this.setPropertyValue(field.getName(), (defaultValue === true));
-                    } else if (field.getType() === 'DateTime') {
-                        const dateTime = dayjs.utc(defaultValue);
-                        this.setPropertyValue(field.getName(), dateTime);
-                    } else {
-                        // following precident set in jsonpopulator.js - if we get this far the field should be an enum
-                        this.setPropertyValue(field.getName(), defaultValue);
-                    }
+            if (defaultValue) {
+                if (type === 'String') {
+                    this.setPropertyValue(field.getName(), defaultValue);
+                } else if (type === 'Integer') {
+                    this.setPropertyValue(field.getName(), parseInt(defaultValue));
+                } else if (type === 'Long') {
+                    this.setPropertyValue(field.getName(), parseInt(defaultValue));
+                } else if (type === 'Double') {
+                    this.setPropertyValue(field.getName(), parseFloat(defaultValue));
+                } else if (type === 'Boolean') {
+                    this.setPropertyValue(field.getName(), (defaultValue === true));
+                } else if (type === 'DateTime') {
+                    const dateTime = dayjs.utc(defaultValue);
+                    this.setPropertyValue(field.getName(), dateTime);
+                } else {
+                    // following precident set in jsonpopulator.js - if we get this far the field should be an enum
+                    this.setPropertyValue(field.getName(), defaultValue);
                 }
             }
         }

--- a/packages/concerto-core/lib/serializer/instancegenerator.js
+++ b/packages/concerto-core/lib/serializer/instancegenerator.js
@@ -114,36 +114,37 @@ class InstanceGenerator {
      * @return {*} A value for the specified field.
      */
     getFieldValue(field, parameters) {
+        let fieldOrScalarDeclaration = field;
         let type = field.getFullyQualifiedTypeName();
         if (ModelUtil.isScalar(field)){
             const modelFile = field.getParent().getModelFile();
-            const declaration = modelFile.getType(field.getType());
-            type = declaration.getType();
+            fieldOrScalarDeclaration =  modelFile.getType(field.getType());
+            type = fieldOrScalarDeclaration.getType();
         }
         if (ModelUtil.isPrimitiveType(type)) {
             switch(type) {
             case 'DateTime':
                 return parameters.valueGenerator.getDateTime();
             case 'Integer':
-                if(field.validator){
-                    return parameters.valueGenerator.getRange(field.validator.lowerBound, field.validator.upperBound, type);
+                if(fieldOrScalarDeclaration.validator){
+                    return parameters.valueGenerator.getRange(fieldOrScalarDeclaration.validator.lowerBound, field.validator.upperBound, type);
                 }
                 return parameters.valueGenerator.getInteger();
             case 'Long':
-                if(field.validator){
-                    return parameters.valueGenerator.getRange(field.validator.lowerBound, field.validator.upperBound, type);
+                if(fieldOrScalarDeclaration.validator){
+                    return parameters.valueGenerator.getRange(fieldOrScalarDeclaration.validator.lowerBound, field.validator.upperBound, type);
                 }
                 return parameters.valueGenerator.getLong();
             case 'Double':
-                if(field.validator){
-                    return parameters.valueGenerator.getRange(field.validator.lowerBound, field.validator.upperBound, type);
+                if(fieldOrScalarDeclaration.validator){
+                    return parameters.valueGenerator.getRange(fieldOrScalarDeclaration.validator.lowerBound, field.validator.upperBound, type);
                 }
                 return parameters.valueGenerator.getDouble();
             case 'Boolean':
                 return parameters.valueGenerator.getBoolean();
             default:
-                if(field.validator){
-                    return parameters.valueGenerator.getRegex(field.validator.regex);
+                if(fieldOrScalarDeclaration.validator){
+                    return parameters.valueGenerator.getRegex(fieldOrScalarDeclaration.validator.regex);
                 }
                 return parameters.valueGenerator.getString();
             }

--- a/packages/concerto-core/lib/serializer/instancegenerator.js
+++ b/packages/concerto-core/lib/serializer/instancegenerator.js
@@ -77,7 +77,7 @@ class InstanceGenerator {
      * @private
      */
     visitField(field, parameters) {
-        if(!field.isPrimitive()){
+        if(!field.isPrimitive() && !ModelUtil.isScalar(field)){
             let type = field.getFullyQualifiedTypeName();
             let classDeclaration = parameters.modelManager.getType(type);
             classDeclaration = this.findConcreteSubclass(classDeclaration);
@@ -115,7 +115,11 @@ class InstanceGenerator {
      */
     getFieldValue(field, parameters) {
         let type = field.getFullyQualifiedTypeName();
-
+        if (ModelUtil.isScalar(field)){
+            const modelFile = field.getParent().getModelFile();
+            const declaration = modelFile.getType(field.getType());
+            type = declaration.getType();
+        }
         if (ModelUtil.isPrimitiveType(type)) {
             switch(type) {
             case 'DateTime':

--- a/packages/concerto-core/test/data/parser/classdeclaration.scalaridentifier.cto
+++ b/packages/concerto-core/test/data/parser/classdeclaration.scalaridentifier.cto
@@ -1,0 +1,21 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace com.testing
+
+scalar SSN extends String default="000-00-0000" regex=/\d{3}-\d{2}-\{4}+/
+
+concept Person identified by ssn {
+    o SSN ssn
+}

--- a/packages/concerto-core/test/introspect/classdeclaration.js
+++ b/packages/concerto-core/test/introspect/classdeclaration.js
@@ -122,6 +122,11 @@ describe('ClassDeclaration', () => {
                 err.message.should.match(/Class someAsset is not declared as abstract. It must define an identifying field./);
             }
         });
+
+        it('should not throw when a scalar is used as an identifier', () => {
+            const clazz = introspectUtils.loadLastDeclaration('test/data/parser/classdeclaration.scalaridentifier.cto', ConceptDeclaration);
+            clazz.validate();
+        });
     });
 
     describe('#accept', () => {

--- a/packages/concerto-core/test/serializer/instancegenerator.js
+++ b/packages/concerto-core/test/serializer/instancegenerator.js
@@ -430,13 +430,14 @@ describe('InstanceGenerator', () => {
         it('should generate default value for a Scalar field', function () {
             let resource = test(`namespace org.acme.test
 
-            scalar SSN extends String
+            scalar SSN extends String regex=/^(?!(000|666|9))\\d{3}-(?!00)\\d{2}-(?!0000)\\d{4}$/
 
             asset MyAsset identified by id {
                 o String id
                 o SSN ssn
             }`);
             resource.ssn.should.be.a('String');
+            resource.ssn.should.match(/^(?!(000|666|9))\d{3}-(?!00)\d{2}-(?!0000)\d{4}$/);
         });
     });
 

--- a/packages/concerto-core/test/serializer/instancegenerator.js
+++ b/packages/concerto-core/test/serializer/instancegenerator.js
@@ -431,13 +431,17 @@ describe('InstanceGenerator', () => {
             let resource = test(`namespace org.acme.test
 
             scalar SSN extends String regex=/^(?!(000|666|9))\\d{3}-(?!00)\\d{2}-(?!0000)\\d{4}$/
+            scalar ScalarWithDefault extends String default="000-00-0000"
 
             asset MyAsset identified by id {
                 o String id
                 o SSN ssn
+                o ScalarWithDefault ssn2
             }`);
             resource.ssn.should.be.a('String');
+            resource.ssn2.should.be.a('String');
             resource.ssn.should.match(/^(?!(000|666|9))\d{3}-(?!00)\d{2}-(?!0000)\d{4}$/);
+            resource.ssn2.should.equal('000-00-0000');
         });
     });
 

--- a/packages/concerto-core/test/serializer/instancegenerator.js
+++ b/packages/concerto-core/test/serializer/instancegenerator.js
@@ -430,7 +430,7 @@ describe('InstanceGenerator', () => {
         it('should generate default value for a Scalar field', function () {
             let resource = test(`namespace org.acme.test
 
-            scalar SSN extends String regex=/^(?!(000|666|9))\\d{3}-(?!00)\\d{2}-(?!0000)\\d{4}$/
+            scalar SSN extends String regex=/^\\d{3}-\\d{2}-\\d{4}$/
             scalar ScalarWithDefault extends String default="000-00-0000"
 
             asset MyAsset identified by id {
@@ -440,7 +440,7 @@ describe('InstanceGenerator', () => {
             }`);
             resource.ssn.should.be.a('String');
             resource.ssn2.should.be.a('String');
-            resource.ssn.should.match(/^(?!(000|666|9))\d{3}-(?!00)\d{2}-(?!0000)\d{4}$/);
+            resource.ssn.should.match(/^\d{3}-\d{2}-\d{4}$/);
             resource.ssn2.should.equal('000-00-0000');
         });
     });

--- a/packages/concerto-core/test/serializer/instancegenerator.js
+++ b/packages/concerto-core/test/serializer/instancegenerator.js
@@ -427,6 +427,17 @@ describe('InstanceGenerator', () => {
             resource.theValue.getType().should.equal('MyEvent');
         });
 
+        it('should generate default value for a Scalar field', function () {
+            let resource = test(`namespace org.acme.test
+
+            scalar SSN extends String
+
+            asset MyAsset identified by id {
+                o String id
+                o SSN ssn
+            }`);
+            resource.ssn.should.be.a('String');
+        });
     });
 
     describe('#findConcreteSubclass', () => {


### PR DESCRIPTION
<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #559
- Allows scalar types that extend `String` to be used as identifiers.
- Also fixes value generation for scalar types with validators
- Also fixes default value generation for scalar types with defaults

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [x] Merging to `main` from `fork:branchname`
