### PR TITLE
fix(core): properly unbox scalar properties

### DIFF
--- a/packages/concerto-core/lib/introspect/property.js
+++ b/packages/concerto-core/lib/introspect/property.js
@@ -91,45 +91,56 @@ class Property extends Decorated {
         // if this object property references a scalar
         // then replace the scalar with an equivalent property
         // i.e. we unbox the scalar here.
-        let ast = this.ast;
         if(
-            ast?.type &&
-          ast.$class === `${MetaModelNamespace}.ObjectProperty`
+            this.ast?.type &&
+            this.ast.$class === `${MetaModelNamespace}.ObjectProperty`
         ) {
-            const type = this.getModelFile().getType(ast.type.name);
-            if(type) {
-                if(type?.isScalarDeclaration?.()) {
-                    ast = type.ast;
-                }
+            const type = this.getModelFile().getType(this.ast.type.name);
+            if(type && type?.isScalarDeclaration?.()) {
+                this.ast = type.ast;
             }
         }
-
-        if (ast.$class === `${MetaModelNamespace}.BooleanProperty`) {
+        switch (this.ast.$class) {
+        case `${MetaModelNamespace}.EnumProperty`:
+            break;
+        case `${MetaModelNamespace}.BooleanScalar`:
+        case `${MetaModelNamespace}.BooleanProperty`:
             this.type = 'Boolean';
-        } else if (ast.$class === `${MetaModelNamespace}.StringProperty`) {
-            this.type = 'String';
-        } else if (ast.$class === `${MetaModelNamespace}.IntegerProperty`) {
-            this.type = 'Integer';
-        } else if (ast.$class === `${MetaModelNamespace}.LongProperty`) {
-            this.type = 'Long';
-        } else if (ast.$class === `${MetaModelNamespace}.DoubleProperty`) {
-            this.type = 'Double';
-        } else if (ast.$class === `${MetaModelNamespace}.DateTimeProperty`) {
+            break;
+        case `${MetaModelNamespace}.DateTimeProperty`:
+        case `${MetaModelNamespace}.DateTimeScalar`:
             this.type = 'DateTime';
-        } else if (ast.$class === `${MetaModelNamespace}.ObjectProperty`) {
-            this.type = ast.type ? ast.type.name : null;
-        } else if (ast.$class === `${MetaModelNamespace}.RelationshipProperty`) {
-            this.type = ast.type.name;
-        } else {
-            this.type = null;
+            break;
+        case `${MetaModelNamespace}.DoubleProperty`:
+        case `${MetaModelNamespace}.DoubleScalar`:
+            this.type = 'Double';
+            break;
+        case `${MetaModelNamespace}.IntegerProperty`:
+        case `${MetaModelNamespace}.IntegerScalar`:
+            this.type = 'Integer';
+            break;
+        case `${MetaModelNamespace}.LongProperty`:
+        case `${MetaModelNamespace}.LongScalar`:
+            this.type = 'Long';
+            break;
+        case `${MetaModelNamespace}.StringProperty`:
+        case `${MetaModelNamespace}.StringScalar`:
+            this.type = 'String';
+            break;
+        case `${MetaModelNamespace}.ObjectProperty`:
+            this.type = this.ast.type ? this.ast.type.name : null;
+            break;
+        case `${MetaModelNamespace}.RelationshipProperty`:
+            this.type = this.ast.type.name;
+            break;
         }
         this.array = false;
 
-        if(ast.isArray) {
+        if(this.ast.isArray) {
             this.array = true;
         }
 
-        if(ast.isOptional) {
+        if(this.ast.isOptional) {
             this.optional = true;
         }
         else {
@@ -192,7 +203,6 @@ class Property extends Decorated {
         if(!modelFile) {
             throw new Error('Parent of property ' + this.name + ' does not have a ModelFile!');
         }
-
         const result = modelFile.getFullyQualifiedTypeName(this.type);
         if(!result) {
             throw new Error('Failed to find fully qualified type name for property ' + this.name + ' with type ' + this.type );

--- a/packages/concerto-core/test/introspect/field.js
+++ b/packages/concerto-core/test/introspect/field.js
@@ -17,6 +17,7 @@
 const { MetaModelNamespace } = require('@accordproject/concerto-metamodel');
 
 const ClassDeclaration = require('../../lib/introspect/classdeclaration');
+const ScalarDeclaration = require('../../lib/introspect/scalardeclaration');
 const Field = require('../../lib/introspect/field');
 const ModelFile = require('../../lib/introspect/modelfile');
 
@@ -27,11 +28,20 @@ describe('Field', () => {
 
     let mockClassDeclaration;
     let mockModelFile;
+    let mockScalarDeclaration;
 
     beforeEach(() => {
         mockClassDeclaration = sinon.createStubInstance(ClassDeclaration);
         mockModelFile = sinon.createStubInstance(ModelFile);
+        mockScalarDeclaration = sinon.createStubInstance(ScalarDeclaration);
         mockClassDeclaration.getModelFile.returns(mockModelFile);
+        mockModelFile.getType.returns(mockScalarDeclaration);
+        mockScalarDeclaration.isScalarDeclaration.returns(true);
+        mockScalarDeclaration.ast = {
+            $class: `${MetaModelNamespace}.StringScalar`,
+            name: 'MyScalar',
+            defaultValue: 'abc'
+        };
     });
 
     describe('#constructor', () => {
@@ -102,6 +112,18 @@ describe('Field', () => {
                 isOptional: true
             });
             f.optional.should.equal(true);
+        });
+
+        it('should unbox a Scalar Property', () => {
+            let p = new Field(mockClassDeclaration, {
+                $class: `${MetaModelNamespace}.ObjectProperty`,
+                name: 'property',
+                type: {
+                    name: 'MyScalar',
+                }
+            });
+            p.type.should.equal('String');
+            p.ast.defaultValue.should.equal('abc');
         });
 
     });

--- a/packages/concerto-core/test/introspect/property.js
+++ b/packages/concerto-core/test/introspect/property.js
@@ -97,7 +97,7 @@ describe('Property', () => {
     describe('#hasInstance', () => {
         it('should return true for a valid Property', () => {
             let p = new Property(mockClassDeclaration, {
-                $class: `${MetaModelNamespace}.StringScalar`,
+                $class: `${MetaModelNamespace}.StringProperty`,
                 name: 'property',
             });
             (p instanceof Property).should.be.true;

--- a/packages/concerto-core/test/introspect/property.js
+++ b/packages/concerto-core/test/introspect/property.js
@@ -97,7 +97,7 @@ describe('Property', () => {
     describe('#hasInstance', () => {
         it('should return true for a valid Property', () => {
             let p = new Property(mockClassDeclaration, {
-                $class: `${MetaModelNamespace}.StringProperty`,
+                $class: `${MetaModelNamespace}.StringScalar`,
                 name: 'property',
             });
             (p instanceof Property).should.be.true;


### PR DESCRIPTION
A further fix to the new `scalar` feature. This fix properly unboxes Scalar properties.

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [x] Merging to `main` from `fork:branchname`
