### PR TITLE
fix(tools) : protobuf generation with unversioned namespaces

### DIFF
--- a/packages/concerto-cli/test/cli.js
+++ b/packages/concerto-cli/test/cli.js
@@ -190,6 +190,12 @@ describe('concerto-cli', () => {
             fs.readdirSync(dir.path).length.should.be.above(0);
             dir.cleanup();
         });
+        it('should compile to an Protobuf model', async () => {
+            const dir = await tmp.dir({ unsafeCleanup: true });
+            await Commands.compile('Protobuf', models, dir.path, {offline:false});
+            fs.readdirSync(dir.path).length.should.be.above(0);
+            dir.cleanup();
+        });
         it('should not compile to an unknown model', async () => {
             const dir = await tmp.dir({ unsafeCleanup: true });
             await Commands.compile('BLAH', models, dir.path, {offline:false});

--- a/packages/concerto-tools/lib/codegen/fromcto/protobuf/protobufvisitor.js
+++ b/packages/concerto-tools/lib/codegen/fromcto/protobuf/protobufvisitor.js
@@ -16,6 +16,7 @@
 
 const debug = require('debug')('concerto-core:jsonschemavisitor');
 const util = require('util');
+const ModelUtil = require('@accordproject/concerto-core').ModelUtil;
 
 /**
  * Convert the contents of a {@link ModelManager} to Proto3 files.
@@ -33,7 +34,8 @@ class ProtobufVisitor {
      */
     concertoNamespaceToProto3SafePackageName(concertoNamespace) {
         // Proto3 needs the namespace to have a standard Java-like format, so the "@" and the dots in the version need to be replaces with underscores.
-        return `${concertoNamespace.split('@')[0]}.v${concertoNamespace.split('@')[1].replace(/\./ig, '_')}`;
+        const {name,version} = ModelUtil.parseNamespace(concertoNamespace);
+        return `${name}.v${version ? version.replaceAll('.','_') : ''}`;
     }
 
     /**
@@ -101,7 +103,7 @@ class ProtobufVisitor {
      */
     createImportLineStrings(imports) {
         return imports
-            .filter(importObject => importObject.namespace.split('@')[0] !== 'concerto')
+            .filter(importObject => ModelUtil.parseNamespace(importObject.namespace).name !== 'concerto')
             .map(importObject => `${this.concertoNamespaceToProto3SafePackageName(importObject.namespace)}.proto`);
     }
 

--- a/packages/concerto-tools/lib/codegen/fromcto/protobuf/protobufvisitor.js
+++ b/packages/concerto-tools/lib/codegen/fromcto/protobuf/protobufvisitor.js
@@ -35,7 +35,7 @@ class ProtobufVisitor {
     concertoNamespaceToProto3SafePackageName(concertoNamespace) {
         // Proto3 needs the namespace to have a standard Java-like format, so the "@" and the dots in the version need to be replaces with underscores.
         const {name,version} = ModelUtil.parseNamespace(concertoNamespace);
-        return `${name}.v${version ? version.replaceAll('.','_') : ''}`;
+        return `${name}.v${version ? version.replace(/\./g,'_') : ''}`;
     }
 
     /**

--- a/packages/concerto-tools/test/codegen/__snapshots__/codegen.js.snap
+++ b/packages/concerto-tools/test/codegen/__snapshots__/codegen.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`codegen #formats check we can convert all formats to CTO 1`] = `
+exports[`codegen #formats check we can convert all formats from namespace unversioned CTO 1`] = `
 {
   "key": "main.go",
   "value": "package main
@@ -17,7 +17,3303 @@ func main() {
 }
 `;
 
-exports[`codegen #formats check we can convert all formats to CTO 2`] = `
+exports[`codegen #formats check we can convert all formats from namespace unversioned CTO 2`] = `
+{
+  "key": "orgacme.hr.go",
+  "value": "package main
+import "time"
+type State int
+const (
+   MA State = 1 + iota
+   NY
+   CO
+   WA
+   IL
+   CA
+)
+type Department int
+const (
+   Sales Department = 1 + iota
+   Marketing
+   Finance
+   HR
+   Engineering
+   Design
+)
+type Equipment struct {
+   Asset
+   SerialNumber string \`json:"serialNumber"\`
+}
+type LaptopMake int
+const (
+   Apple LaptopMake = 1 + iota
+   Microsoft
+)
+type Laptop struct {
+   Equipment
+   Make LaptopMake \`json:"make"\`
+}
+type Person struct {
+   Participant
+   Email string \`json:"email"\`
+   FirstName string \`json:"firstName"\`
+   LastName string \`json:"lastName"\`
+   MiddleNames string \`json:"middleNames"\`
+   HomeAddress Address \`json:"homeAddress"\`
+   Ssn SSN \`json:"ssn"\`
+}
+type Employee struct {
+   Person
+   EmployeeId string \`json:"employeeId"\`
+   Department Department \`json:"department"\`
+   OfficeAddress Address \`json:"officeAddress"\`
+   CompanyAssets []Equipment \`json:"companyAssets"\`
+}
+type Contractor struct {
+   Person
+   Company Company \`json:"company"\`
+}
+type Manager struct {
+   Employee
+}
+type CompanyEvent struct {
+   Event
+}
+type Onboarded struct {
+   CompanyEvent
+}
+",
+}
+`;
+
+exports[`codegen #formats check we can convert all formats from namespace unversioned CTO 3`] = `
+{
+  "key": "schema.json",
+  "value": "{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "org.acme.hr.State": {
+      "title": "State",
+      "description": "An instance of org.acme.hr.State",
+      "enum": [
+        "MA",
+        "NY",
+        "CO",
+        "WA",
+        "IL",
+        "CA"
+      ]
+    },
+    "org.acme.hr.Address": {
+      "title": "Address",
+      "description": "An instance of org.acme.hr.Address",
+      "type": "object",
+      "properties": {
+        "$class": {
+          "type": "string",
+          "default": "org.acme.hr.Address",
+          "pattern": "^org\\\\.acme\\\\.hr\\\\.Address$",
+          "description": "The class identifier for this type"
+        },
+        "street": {
+          "type": "string"
+        },
+        "city": {
+          "type": "string"
+        },
+        "state": {
+          "$ref": "#/definitions/org.acme.hr.State"
+        },
+        "zipCode": {
+          "type": "string"
+        },
+        "country": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "$class",
+        "street",
+        "city",
+        "zipCode",
+        "country"
+      ]
+    },
+    "org.acme.hr.Company": {
+      "title": "Company",
+      "description": "An instance of org.acme.hr.Company",
+      "type": "object",
+      "properties": {
+        "$class": {
+          "type": "string",
+          "default": "org.acme.hr.Company",
+          "pattern": "^org\\\\.acme\\\\.hr\\\\.Company$",
+          "description": "The class identifier for this type"
+        },
+        "name": {
+          "type": "string"
+        },
+        "headquarters": {
+          "$ref": "#/definitions/org.acme.hr.Address"
+        }
+      },
+      "required": [
+        "$class",
+        "name",
+        "headquarters"
+      ]
+    },
+    "org.acme.hr.Department": {
+      "title": "Department",
+      "description": "An instance of org.acme.hr.Department",
+      "enum": [
+        "Sales",
+        "Marketing",
+        "Finance",
+        "HR",
+        "Engineering",
+        "Design"
+      ]
+    },
+    "org.acme.hr.Equipment": {
+      "title": "Equipment",
+      "description": "An instance of org.acme.hr.Equipment",
+      "type": "object",
+      "properties": {
+        "$class": {
+          "type": "string",
+          "default": "org.acme.hr.Equipment",
+          "pattern": "^org\\\\.acme\\\\.hr\\\\.Equipment$",
+          "description": "The class identifier for this type"
+        },
+        "serialNumber": {
+          "type": "string",
+          "description": "The instance identifier for this type"
+        }
+      },
+      "required": [
+        "$class",
+        "serialNumber"
+      ],
+      "$decorators": {
+        "resource": []
+      }
+    },
+    "org.acme.hr.LaptopMake": {
+      "title": "LaptopMake",
+      "description": "An instance of org.acme.hr.LaptopMake",
+      "enum": [
+        "Apple",
+        "Microsoft"
+      ]
+    },
+    "org.acme.hr.Laptop": {
+      "title": "Laptop",
+      "description": "An instance of org.acme.hr.Laptop",
+      "type": "object",
+      "properties": {
+        "$class": {
+          "type": "string",
+          "default": "org.acme.hr.Laptop",
+          "pattern": "^org\\\\.acme\\\\.hr\\\\.Laptop$",
+          "description": "The class identifier for this type"
+        },
+        "make": {
+          "$ref": "#/definitions/org.acme.hr.LaptopMake"
+        },
+        "serialNumber": {
+          "type": "string",
+          "description": "The instance identifier for this type"
+        }
+      },
+      "required": [
+        "$class",
+        "make",
+        "serialNumber"
+      ]
+    },
+    "org.acme.hr.SSN": {
+      "type": "string",
+      "pattern": "\\\\d{3}-\\\\d{2}-\\\\{4}+"
+    },
+    "org.acme.hr.Person": {
+      "title": "Person",
+      "description": "An instance of org.acme.hr.Person",
+      "type": "object",
+      "properties": {
+        "$class": {
+          "type": "string",
+          "default": "org.acme.hr.Person",
+          "pattern": "^org\\\\.acme\\\\.hr\\\\.Person$",
+          "description": "The class identifier for this type"
+        },
+        "email": {
+          "type": "string",
+          "description": "The instance identifier for this type"
+        },
+        "firstName": {
+          "type": "string"
+        },
+        "lastName": {
+          "type": "string"
+        },
+        "middleNames": {
+          "type": "string"
+        },
+        "homeAddress": {
+          "$ref": "#/definitions/org.acme.hr.Address"
+        },
+        "ssn": {
+          "$ref": "#/definitions/org.acme.hr.SSN"
+        }
+      },
+      "required": [
+        "$class",
+        "email",
+        "firstName",
+        "lastName",
+        "homeAddress",
+        "ssn"
+      ],
+      "$decorators": {
+        "resource": []
+      }
+    },
+    "org.acme.hr.Employee": {
+      "title": "Employee",
+      "description": "An instance of org.acme.hr.Employee",
+      "type": "object",
+      "properties": {
+        "$class": {
+          "type": "string",
+          "default": "org.acme.hr.Employee",
+          "pattern": "^org\\\\.acme\\\\.hr\\\\.Employee$",
+          "description": "The class identifier for this type"
+        },
+        "employeeId": {
+          "type": "string"
+        },
+        "department": {
+          "$ref": "#/definitions/org.acme.hr.Department"
+        },
+        "officeAddress": {
+          "$ref": "#/definitions/org.acme.hr.Address"
+        },
+        "companyAssets": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/org.acme.hr.Equipment"
+          }
+        },
+        "manager": {
+          "type": "string",
+          "description": "The identifier of an instance of org.acme.hr.Manager"
+        },
+        "email": {
+          "type": "string",
+          "description": "The instance identifier for this type"
+        },
+        "firstName": {
+          "type": "string"
+        },
+        "lastName": {
+          "type": "string"
+        },
+        "middleNames": {
+          "type": "string"
+        },
+        "homeAddress": {
+          "$ref": "#/definitions/org.acme.hr.Address"
+        },
+        "ssn": {
+          "$ref": "#/definitions/org.acme.hr.SSN"
+        }
+      },
+      "required": [
+        "$class",
+        "employeeId",
+        "department",
+        "officeAddress",
+        "companyAssets",
+        "email",
+        "firstName",
+        "lastName",
+        "homeAddress",
+        "ssn"
+      ]
+    },
+    "org.acme.hr.Contractor": {
+      "title": "Contractor",
+      "description": "An instance of org.acme.hr.Contractor",
+      "type": "object",
+      "properties": {
+        "$class": {
+          "type": "string",
+          "default": "org.acme.hr.Contractor",
+          "pattern": "^org\\\\.acme\\\\.hr\\\\.Contractor$",
+          "description": "The class identifier for this type"
+        },
+        "company": {
+          "$ref": "#/definitions/org.acme.hr.Company"
+        },
+        "manager": {
+          "type": "string",
+          "description": "The identifier of an instance of org.acme.hr.Manager"
+        },
+        "email": {
+          "type": "string",
+          "description": "The instance identifier for this type"
+        },
+        "firstName": {
+          "type": "string"
+        },
+        "lastName": {
+          "type": "string"
+        },
+        "middleNames": {
+          "type": "string"
+        },
+        "homeAddress": {
+          "$ref": "#/definitions/org.acme.hr.Address"
+        },
+        "ssn": {
+          "$ref": "#/definitions/org.acme.hr.SSN"
+        }
+      },
+      "required": [
+        "$class",
+        "company",
+        "email",
+        "firstName",
+        "lastName",
+        "homeAddress",
+        "ssn"
+      ]
+    },
+    "org.acme.hr.Manager": {
+      "title": "Manager",
+      "description": "An instance of org.acme.hr.Manager",
+      "type": "object",
+      "properties": {
+        "$class": {
+          "type": "string",
+          "default": "org.acme.hr.Manager",
+          "pattern": "^org\\\\.acme\\\\.hr\\\\.Manager$",
+          "description": "The class identifier for this type"
+        },
+        "reports": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "description": "The identifier of an instance of org.acme.hr.Person"
+          }
+        },
+        "employeeId": {
+          "type": "string"
+        },
+        "department": {
+          "$ref": "#/definitions/org.acme.hr.Department"
+        },
+        "officeAddress": {
+          "$ref": "#/definitions/org.acme.hr.Address"
+        },
+        "companyAssets": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/org.acme.hr.Equipment"
+          }
+        },
+        "manager": {
+          "type": "string",
+          "description": "The identifier of an instance of org.acme.hr.Manager"
+        },
+        "email": {
+          "type": "string",
+          "description": "The instance identifier for this type"
+        },
+        "firstName": {
+          "type": "string"
+        },
+        "lastName": {
+          "type": "string"
+        },
+        "middleNames": {
+          "type": "string"
+        },
+        "homeAddress": {
+          "$ref": "#/definitions/org.acme.hr.Address"
+        },
+        "ssn": {
+          "$ref": "#/definitions/org.acme.hr.SSN"
+        }
+      },
+      "required": [
+        "$class",
+        "employeeId",
+        "department",
+        "officeAddress",
+        "companyAssets",
+        "email",
+        "firstName",
+        "lastName",
+        "homeAddress",
+        "ssn"
+      ]
+    },
+    "org.acme.hr.CompanyEvent": {
+      "title": "CompanyEvent",
+      "description": "An instance of org.acme.hr.CompanyEvent",
+      "type": "object",
+      "properties": {
+        "$class": {
+          "type": "string",
+          "default": "org.acme.hr.CompanyEvent",
+          "pattern": "^org\\\\.acme\\\\.hr\\\\.CompanyEvent$",
+          "description": "The class identifier for this type"
+        }
+      },
+      "required": [
+        "$class"
+      ]
+    },
+    "org.acme.hr.Onboarded": {
+      "title": "Onboarded",
+      "description": "An instance of org.acme.hr.Onboarded",
+      "type": "object",
+      "properties": {
+        "$class": {
+          "type": "string",
+          "default": "org.acme.hr.Onboarded",
+          "pattern": "^org\\\\.acme\\\\.hr\\\\.Onboarded$",
+          "description": "The class identifier for this type"
+        },
+        "employee": {
+          "type": "string",
+          "description": "The identifier of an instance of org.acme.hr.Employee"
+        }
+      },
+      "required": [
+        "$class",
+        "employee"
+      ]
+    },
+    "org.acme.hr.ChangeOfAddress": {
+      "title": "ChangeOfAddress",
+      "description": "An instance of org.acme.hr.ChangeOfAddress",
+      "type": "object",
+      "properties": {
+        "$class": {
+          "type": "string",
+          "default": "org.acme.hr.ChangeOfAddress",
+          "pattern": "^org\\\\.acme\\\\.hr\\\\.ChangeOfAddress$",
+          "description": "The class identifier for this type"
+        },
+        "Person": {
+          "type": "string",
+          "description": "The identifier of an instance of org.acme.hr.Person"
+        },
+        "newAddress": {
+          "$ref": "#/definitions/org.acme.hr.Address"
+        }
+      },
+      "required": [
+        "$class",
+        "Person",
+        "newAddress"
+      ]
+    }
+  }
+}
+",
+}
+`;
+
+exports[`codegen #formats check we can convert all formats from namespace unversioned CTO 4`] = `
+{
+  "key": "concerto@1.0.0.xsd",
+  "value": "<?xml version="1.0"?>
+<xs:schema xmlns:concerto="concerto" targetNamespace="concerto" elementFormDefault="qualified" xmlns:xs="http://www.w3.org/2001/XMLSchema" 
+>
+<xs:complexType name="Concept">
+   <xs:sequence>
+   </xs:sequence>
+</xs:complexType>
+<xs:element name="Concept" type="concerto:Concept"/>
+<xs:complexType name="Asset">
+   <xs:complexContent>
+   <xs:extension base="concerto:Concept">
+   <xs:sequence>
+      <xs:element name="_identifier" type="xs:string"/>
+   </xs:sequence>
+   </xs:extension>
+   </xs:complexContent>
+</xs:complexType>
+<xs:element name="Asset" type="concerto:Asset"/>
+<xs:complexType name="Participant">
+   <xs:complexContent>
+   <xs:extension base="concerto:Concept">
+   <xs:sequence>
+      <xs:element name="_identifier" type="xs:string"/>
+   </xs:sequence>
+   </xs:extension>
+   </xs:complexContent>
+</xs:complexType>
+<xs:element name="Participant" type="concerto:Participant"/>
+<xs:complexType name="Transaction">
+   <xs:complexContent>
+   <xs:extension base="concerto:Concept">
+   <xs:sequence>
+      <xs:element name="_timestamp" type="xs:dateTime"/>
+   </xs:sequence>
+   </xs:extension>
+   </xs:complexContent>
+</xs:complexType>
+<xs:element name="Transaction" type="concerto:Transaction"/>
+<xs:complexType name="Event">
+   <xs:complexContent>
+   <xs:extension base="concerto:Concept">
+   <xs:sequence>
+      <xs:element name="_timestamp" type="xs:dateTime"/>
+   </xs:sequence>
+   </xs:extension>
+   </xs:complexContent>
+</xs:complexType>
+<xs:element name="Event" type="concerto:Event"/>
+</xs:schema>
+",
+}
+`;
+
+exports[`codegen #formats check we can convert all formats from namespace unversioned CTO 5`] = `
+{
+  "key": "concerto.xsd",
+  "value": "<?xml version="1.0"?>
+<xs:schema xmlns:concerto="concerto" targetNamespace="concerto" elementFormDefault="qualified" xmlns:xs="http://www.w3.org/2001/XMLSchema" 
+>
+<xs:complexType name="Concept">
+   <xs:sequence>
+   </xs:sequence>
+</xs:complexType>
+<xs:element name="Concept" type="concerto:Concept"/>
+<xs:complexType name="Asset">
+   <xs:complexContent>
+   <xs:extension base="concerto:Concept">
+   <xs:sequence>
+      <xs:element name="_identifier" type="xs:string"/>
+   </xs:sequence>
+   </xs:extension>
+   </xs:complexContent>
+</xs:complexType>
+<xs:element name="Asset" type="concerto:Asset"/>
+<xs:complexType name="Participant">
+   <xs:complexContent>
+   <xs:extension base="concerto:Concept">
+   <xs:sequence>
+      <xs:element name="_identifier" type="xs:string"/>
+   </xs:sequence>
+   </xs:extension>
+   </xs:complexContent>
+</xs:complexType>
+<xs:element name="Participant" type="concerto:Participant"/>
+<xs:complexType name="Transaction">
+   <xs:complexContent>
+   <xs:extension base="concerto:Concept">
+   <xs:sequence>
+   </xs:sequence>
+   </xs:extension>
+   </xs:complexContent>
+</xs:complexType>
+<xs:element name="Transaction" type="concerto:Transaction"/>
+<xs:complexType name="Event">
+   <xs:complexContent>
+   <xs:extension base="concerto:Concept">
+   <xs:sequence>
+   </xs:sequence>
+   </xs:extension>
+   </xs:complexContent>
+</xs:complexType>
+<xs:element name="Event" type="concerto:Event"/>
+</xs:schema>
+",
+}
+`;
+
+exports[`codegen #formats check we can convert all formats from namespace unversioned CTO 6`] = `
+{
+  "key": "org.acme.hr.xsd",
+  "value": "<?xml version="1.0"?>
+<xs:schema xmlns:org.acme.hr="org.acme.hr" targetNamespace="org.acme.hr" elementFormDefault="qualified" xmlns:xs="http://www.w3.org/2001/XMLSchema" 
+xmlns:concerto="concerto"
+>
+<xs:import namespace="concerto" schemaLocation="concerto@1.0.0.xsd"/>
+<xs:simpleType name="State">
+   <xs:restriction base="xs:string">
+      <xs:enumeration value="MA"/>
+      <xs:enumeration value="NY"/>
+      <xs:enumeration value="CO"/>
+      <xs:enumeration value="WA"/>
+      <xs:enumeration value="IL"/>
+      <xs:enumeration value="CA"/>
+   </xs:restriction>
+</xs:simpleType>
+<xs:element name="State" type="org.acme.hr:State"/>
+<xs:complexType name="Address">
+   <xs:complexContent>
+   <xs:extension base="concerto:Concept">
+   <xs:sequence>
+      <xs:element name="street" type="xs:string"/>
+      <xs:element name="city" type="xs:string"/>
+      <xs:element name="state" type="org.acme.hr:State"/>
+      <xs:element name="zipCode" type="xs:string"/>
+      <xs:element name="country" type="xs:string"/>
+   </xs:sequence>
+   </xs:extension>
+   </xs:complexContent>
+</xs:complexType>
+<xs:element name="Address" type="org.acme.hr:Address"/>
+<xs:complexType name="Company">
+   <xs:complexContent>
+   <xs:extension base="concerto:Concept">
+   <xs:sequence>
+      <xs:element name="name" type="xs:string"/>
+      <xs:element name="headquarters" type="org.acme.hr:Address"/>
+   </xs:sequence>
+   </xs:extension>
+   </xs:complexContent>
+</xs:complexType>
+<xs:element name="Company" type="org.acme.hr:Company"/>
+<xs:simpleType name="Department">
+   <xs:restriction base="xs:string">
+      <xs:enumeration value="Sales"/>
+      <xs:enumeration value="Marketing"/>
+      <xs:enumeration value="Finance"/>
+      <xs:enumeration value="HR"/>
+      <xs:enumeration value="Engineering"/>
+      <xs:enumeration value="Design"/>
+   </xs:restriction>
+</xs:simpleType>
+<xs:element name="Department" type="org.acme.hr:Department"/>
+<xs:complexType name="Equipment">
+   <xs:complexContent>
+   <xs:extension base="concerto:Asset">
+   <xs:sequence>
+      <xs:element name="serialNumber" type="xs:string"/>
+   </xs:sequence>
+   </xs:extension>
+   </xs:complexContent>
+</xs:complexType>
+<xs:element name="Equipment" type="org.acme.hr:Equipment"/>
+<xs:simpleType name="LaptopMake">
+   <xs:restriction base="xs:string">
+      <xs:enumeration value="Apple"/>
+      <xs:enumeration value="Microsoft"/>
+   </xs:restriction>
+</xs:simpleType>
+<xs:element name="LaptopMake" type="org.acme.hr:LaptopMake"/>
+<xs:complexType name="Laptop">
+   <xs:complexContent>
+   <xs:extension base="org.acme.hr:Equipment">
+   <xs:sequence>
+      <xs:element name="make" type="org.acme.hr:LaptopMake"/>
+   </xs:sequence>
+   </xs:extension>
+   </xs:complexContent>
+</xs:complexType>
+<xs:element name="Laptop" type="org.acme.hr:Laptop"/>
+<xs:complexType name="Person">
+   <xs:complexContent>
+   <xs:extension base="concerto:Participant">
+   <xs:sequence>
+      <xs:element name="email" type="xs:string"/>
+      <xs:element name="firstName" type="xs:string"/>
+      <xs:element name="lastName" type="xs:string"/>
+      <xs:element name="middleNames" type="xs:string"/>
+      <xs:element name="homeAddress" type="org.acme.hr:Address"/>
+      <xs:element name="ssn" type="org.acme.hr:SSN"/>
+   </xs:sequence>
+   </xs:extension>
+   </xs:complexContent>
+</xs:complexType>
+<xs:element name="Person" type="org.acme.hr:Person"/>
+<xs:complexType name="Employee">
+   <xs:complexContent>
+   <xs:extension base="org.acme.hr:Person">
+   <xs:sequence>
+      <xs:element name="employeeId" type="xs:string"/>
+      <xs:element name="department" type="org.acme.hr:Department"/>
+      <xs:element name="officeAddress" type="org.acme.hr:Address"/>
+      <xs:element name="companyAssets" type="org.acme.hr:Equipment" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="manager" type="org.acme.hr:Manager"/>
+   </xs:sequence>
+   </xs:extension>
+   </xs:complexContent>
+</xs:complexType>
+<xs:element name="Employee" type="org.acme.hr:Employee"/>
+<xs:complexType name="Contractor">
+   <xs:complexContent>
+   <xs:extension base="org.acme.hr:Person">
+   <xs:sequence>
+      <xs:element name="company" type="org.acme.hr:Company"/>
+      <xs:element name="manager" type="org.acme.hr:Manager"/>
+   </xs:sequence>
+   </xs:extension>
+   </xs:complexContent>
+</xs:complexType>
+<xs:element name="Contractor" type="org.acme.hr:Contractor"/>
+<xs:complexType name="Manager">
+   <xs:complexContent>
+   <xs:extension base="org.acme.hr:Employee">
+   <xs:sequence>
+      <xs:element name="reports" type="org.acme.hr:Person" minOccurs="0" maxOccurs="unbounded"/>
+   </xs:sequence>
+   </xs:extension>
+   </xs:complexContent>
+</xs:complexType>
+<xs:element name="Manager" type="org.acme.hr:Manager"/>
+<xs:complexType name="CompanyEvent">
+   <xs:complexContent>
+   <xs:extension base="concerto:Event">
+   <xs:sequence>
+   </xs:sequence>
+   </xs:extension>
+   </xs:complexContent>
+</xs:complexType>
+<xs:element name="CompanyEvent" type="org.acme.hr:CompanyEvent"/>
+<xs:complexType name="Onboarded">
+   <xs:complexContent>
+   <xs:extension base="org.acme.hr:CompanyEvent">
+   <xs:sequence>
+      <xs:element name="employee" type="org.acme.hr:Employee"/>
+   </xs:sequence>
+   </xs:extension>
+   </xs:complexContent>
+</xs:complexType>
+<xs:element name="Onboarded" type="org.acme.hr:Onboarded"/>
+<xs:complexType name="ChangeOfAddress">
+   <xs:complexContent>
+   <xs:extension base="concerto:Transaction">
+   <xs:sequence>
+      <xs:element name="Person" type="org.acme.hr:Person"/>
+      <xs:element name="newAddress" type="org.acme.hr:Address"/>
+   </xs:sequence>
+   </xs:extension>
+   </xs:complexContent>
+</xs:complexType>
+<xs:element name="ChangeOfAddress" type="org.acme.hr:ChangeOfAddress"/>
+</xs:schema>
+",
+}
+`;
+
+exports[`codegen #formats check we can convert all formats from namespace unversioned CTO 7`] = `
+{
+  "key": "model.puml",
+  "value": "@startuml
+title
+Model
+endtitle
+class org.acme.hr.State << (E,grey) >> {
+   + MA
+   + NY
+   + CO
+   + WA
+   + IL
+   + CA
+}
+org.acme.hr.State --|> concerto.Concept
+class org.acme.hr.Address {
+   + String street
+   + String city
+   + State state
+   + String zipCode
+   + String country
+}
+org.acme.hr.Address --|> concerto.Concept
+class org.acme.hr.Company {
+   + String name
+   + Address headquarters
+}
+org.acme.hr.Company --|> concerto.Concept
+class org.acme.hr.Department << (E,grey) >> {
+   + Sales
+   + Marketing
+   + Finance
+   + HR
+   + Engineering
+   + Design
+}
+org.acme.hr.Department --|> concerto.Concept
+class org.acme.hr.Equipment << (A,green) >> {
+   + String serialNumber
+}
+org.acme.hr.Equipment --|> concerto.Asset
+class org.acme.hr.LaptopMake << (E,grey) >> {
+   + Apple
+   + Microsoft
+}
+org.acme.hr.LaptopMake --|> concerto.Concept
+class org.acme.hr.Laptop << (A,green) >> {
+   + LaptopMake make
+}
+org.acme.hr.Laptop --|> org.acme.hr.Equipment
+class org.acme.hr.Person << (P,lightblue) >> {
+   + String email
+   + String firstName
+   + String lastName
+   + String middleNames
+   + Address homeAddress
+   + SSN ssn
+}
+org.acme.hr.Person --|> concerto.Participant
+class org.acme.hr.Employee << (P,lightblue) >> {
+   + String employeeId
+   + Department department
+   + Address officeAddress
+   + Equipment[] companyAssets
+   + Manager manager
+}
+org.acme.hr.Employee --|> org.acme.hr.Person
+class org.acme.hr.Contractor << (P,lightblue) >> {
+   + Company company
+   + Manager manager
+}
+org.acme.hr.Contractor --|> org.acme.hr.Person
+class org.acme.hr.Manager << (P,lightblue) >> {
+   + Person[] reports
+}
+org.acme.hr.Manager --|> org.acme.hr.Employee
+class org.acme.hr.CompanyEvent {
+}
+org.acme.hr.CompanyEvent --|> concerto.Event
+class org.acme.hr.Onboarded {
+   + Employee employee
+}
+org.acme.hr.Onboarded --|> org.acme.hr.CompanyEvent
+class org.acme.hr.ChangeOfAddress << (T,yellow) >> {
+   + Person Person
+   + Address newAddress
+}
+org.acme.hr.ChangeOfAddress --|> concerto.Transaction
+@enduml
+",
+}
+`;
+
+exports[`codegen #formats check we can convert all formats from namespace unversioned CTO 8`] = `
+{
+  "key": "concerto@1.0.0.ts",
+  "value": "/* eslint-disable @typescript-eslint/no-empty-interface */
+// Generated code for namespace: concerto@1.0.0
+
+// imports
+
+// Warning: Beware of circular dependencies when modifying these imports
+import type {
+	IState,
+	IAddress,
+	ICompany,
+	IDepartment,
+	ILaptopMake
+} from './org.acme.hr';
+
+// Warning: Beware of circular dependencies when modifying these imports
+import type {
+	IEquipment
+} from './org.acme.hr';
+
+// Warning: Beware of circular dependencies when modifying these imports
+import type {
+	IPerson
+} from './org.acme.hr';
+
+// Warning: Beware of circular dependencies when modifying these imports
+import type {
+	IChangeOfAddress
+} from './org.acme.hr';
+
+// Warning: Beware of circular dependencies when modifying these imports
+import type {
+	ICompanyEvent
+} from './org.acme.hr';
+
+// interfaces
+export interface IConcept {
+   $class: string;
+}
+
+export type ConceptUnion = IState | 
+IAddress | 
+ICompany | 
+IDepartment | 
+ILaptopMake;
+
+export interface IAsset extends IConcept {
+   $identifier: string;
+}
+
+export type AssetUnion = IEquipment;
+
+export interface IParticipant extends IConcept {
+   $identifier: string;
+}
+
+export type ParticipantUnion = IPerson;
+
+export interface ITransaction extends IConcept {
+   $timestamp: Date;
+}
+
+export type TransactionUnion = IChangeOfAddress;
+
+export interface IEvent extends IConcept {
+   $timestamp: Date;
+}
+
+export type EventUnion = ICompanyEvent;
+
+",
+}
+`;
+
+exports[`codegen #formats check we can convert all formats from namespace unversioned CTO 9`] = `
+{
+  "key": "concerto.ts",
+  "value": "/* eslint-disable @typescript-eslint/no-empty-interface */
+// Generated code for namespace: concerto
+
+// imports
+
+// interfaces
+export interface IConcept {
+   $class: string;
+}
+
+export interface IAsset extends IConcept {
+   $identifier: string;
+}
+
+export interface IParticipant extends IConcept {
+   $identifier: string;
+}
+
+export interface ITransaction extends IConcept {
+}
+
+export interface IEvent extends IConcept {
+}
+
+",
+}
+`;
+
+exports[`codegen #formats check we can convert all formats from namespace unversioned CTO 10`] = `
+{
+  "key": "org.acme.hr.ts",
+  "value": "/* eslint-disable @typescript-eslint/no-empty-interface */
+// Generated code for namespace: org.acme.hr
+
+// imports
+
+// Warning: Beware of circular dependencies when modifying these imports
+
+// Warning: Beware of circular dependencies when modifying these imports
+
+// Warning: Beware of circular dependencies when modifying these imports
+
+// Warning: Beware of circular dependencies when modifying these imports
+import {IConcept,IAsset,IParticipant,IEvent,ITransaction} from './concerto@1.0.0';
+
+// interfaces
+export enum State {
+   MA = 'MA',
+   NY = 'NY',
+   CO = 'CO',
+   WA = 'WA',
+   IL = 'IL',
+   CA = 'CA',
+}
+
+export interface IAddress extends IConcept {
+   street: string;
+   city: string;
+   state?: State;
+   zipCode: string;
+   country: string;
+}
+
+export interface ICompany extends IConcept {
+   name: string;
+   headquarters: IAddress;
+}
+
+export enum Department {
+   Sales = 'Sales',
+   Marketing = 'Marketing',
+   Finance = 'Finance',
+   HR = 'HR',
+   Engineering = 'Engineering',
+   Design = 'Design',
+}
+
+export interface IEquipment extends IAsset {
+   serialNumber: string;
+}
+
+export type EquipmentUnion = ILaptop;
+
+export enum LaptopMake {
+   Apple = 'Apple',
+   Microsoft = 'Microsoft',
+}
+
+export interface ILaptop extends IEquipment {
+   make: LaptopMake;
+}
+
+export interface IPerson extends IParticipant {
+   email: string;
+   firstName: string;
+   lastName: string;
+   middleNames?: string;
+   homeAddress: IAddress;
+   ssn: ISSN;
+}
+
+export type PersonUnion = IEmployee | 
+IContractor;
+
+export interface IEmployee extends IPerson {
+   employeeId: string;
+   department: Department;
+   officeAddress: IAddress;
+   companyAssets: IEquipment[];
+   manager?: IManager;
+}
+
+export type EmployeeUnion = IManager;
+
+export interface IContractor extends IPerson {
+   company: ICompany;
+   manager?: IManager;
+}
+
+export interface IManager extends IEmployee {
+   reports?: IPerson[];
+}
+
+export interface ICompanyEvent extends IEvent {
+}
+
+export type CompanyEventUnion = IOnboarded;
+
+export interface IOnboarded extends ICompanyEvent {
+   employee: IEmployee;
+}
+
+export interface IChangeOfAddress extends ITransaction {
+   Person: IPerson;
+   newAddress: IAddress;
+}
+
+",
+}
+`;
+
+exports[`codegen #formats check we can convert all formats from namespace unversioned CTO 11`] = `
+{
+  "key": "concerto/Concept.java",
+  "value": "// this code is generated and should not be modified
+package concerto;
+
+import com.fasterxml.jackson.annotation.*;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, property = "$class")
+public abstract class Concept {
+}
+",
+}
+`;
+
+exports[`codegen #formats check we can convert all formats from namespace unversioned CTO 12`] = `
+{
+  "key": "concerto/Asset.java",
+  "value": "// this code is generated and should not be modified
+package concerto;
+
+import com.fasterxml.jackson.annotation.*;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, property = "$class")
+@JsonIgnoreProperties({"id"})
+@JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = "$identifier")
+public abstract class Asset extends Concept {
+   private String $id;
+            @JsonProperty("$id")
+            public String get$id() {
+                return $id;
+            }
+            @JsonProperty("$id")
+            public void set$id(String i) {
+                $id = i;
+            }
+   
+   // the accessor for the identifying field
+   public String getID() {
+      return this.get$identifier();
+   }
+
+   private String $identifier;
+   public String get$identifier() {
+      return this.$identifier;
+   }
+   public void set$identifier(String $identifier) {
+      this.$identifier = $identifier;
+   }
+}
+",
+}
+`;
+
+exports[`codegen #formats check we can convert all formats from namespace unversioned CTO 13`] = `
+{
+  "key": "concerto/Participant.java",
+  "value": "// this code is generated and should not be modified
+package concerto;
+
+import com.fasterxml.jackson.annotation.*;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, property = "$class")
+@JsonIgnoreProperties({"id"})
+@JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = "$identifier")
+public abstract class Participant extends Concept {
+   private String $id;
+            @JsonProperty("$id")
+            public String get$id() {
+                return $id;
+            }
+            @JsonProperty("$id")
+            public void set$id(String i) {
+                $id = i;
+            }
+   
+   // the accessor for the identifying field
+   public String getID() {
+      return this.get$identifier();
+   }
+
+   private String $identifier;
+   public String get$identifier() {
+      return this.$identifier;
+   }
+   public void set$identifier(String $identifier) {
+      this.$identifier = $identifier;
+   }
+}
+",
+}
+`;
+
+exports[`codegen #formats check we can convert all formats from namespace unversioned CTO 14`] = `
+{
+  "key": "concerto/Transaction.java",
+  "value": "// this code is generated and should not be modified
+package concerto;
+
+import com.fasterxml.jackson.annotation.*;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, property = "$class")
+public abstract class Transaction extends Concept {
+}
+",
+}
+`;
+
+exports[`codegen #formats check we can convert all formats from namespace unversioned CTO 15`] = `
+{
+  "key": "concerto/Event.java",
+  "value": "// this code is generated and should not be modified
+package concerto;
+
+import com.fasterxml.jackson.annotation.*;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, property = "$class")
+public abstract class Event extends Concept {
+}
+",
+}
+`;
+
+exports[`codegen #formats check we can convert all formats from namespace unversioned CTO 16`] = `
+{
+  "key": "org/acme/hr/State.java",
+  "value": "// this code is generated and should not be modified
+package org.acme.hr;
+
+import com.fasterxml.jackson.annotation.*;
+@JsonIgnoreProperties({"$class"})
+public enum State {
+   MA,
+   NY,
+   CO,
+   WA,
+   IL,
+   CA,
+}
+",
+}
+`;
+
+exports[`codegen #formats check we can convert all formats from namespace unversioned CTO 17`] = `
+{
+  "key": "org/acme/hr/Address.java",
+  "value": "// this code is generated and should not be modified
+package org.acme.hr;
+
+import concerto.Concept;
+import concerto.Asset;
+import concerto.Transaction;
+import concerto.Participant;
+import concerto.Event;
+import com.fasterxml.jackson.annotation.*;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, property = "$class")
+public class Address extends Concept {
+   private String street;
+   private String city;
+   private State state;
+   private String zipCode;
+   private String country;
+   public String getStreet() {
+      return this.street;
+   }
+   public String getCity() {
+      return this.city;
+   }
+   public State getState() {
+      return this.state;
+   }
+   public String getZipCode() {
+      return this.zipCode;
+   }
+   public String getCountry() {
+      return this.country;
+   }
+   public void setStreet(String street) {
+      this.street = street;
+   }
+   public void setCity(String city) {
+      this.city = city;
+   }
+   public void setState(State state) {
+      this.state = state;
+   }
+   public void setZipCode(String zipCode) {
+      this.zipCode = zipCode;
+   }
+   public void setCountry(String country) {
+      this.country = country;
+   }
+}
+",
+}
+`;
+
+exports[`codegen #formats check we can convert all formats from namespace unversioned CTO 18`] = `
+{
+  "key": "org/acme/hr/Company.java",
+  "value": "// this code is generated and should not be modified
+package org.acme.hr;
+
+import concerto.Concept;
+import concerto.Asset;
+import concerto.Transaction;
+import concerto.Participant;
+import concerto.Event;
+import com.fasterxml.jackson.annotation.*;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, property = "$class")
+public class Company extends Concept {
+   private String name;
+   private Address headquarters;
+   public String getName() {
+      return this.name;
+   }
+   public Address getHeadquarters() {
+      return this.headquarters;
+   }
+   public void setName(String name) {
+      this.name = name;
+   }
+   public void setHeadquarters(Address headquarters) {
+      this.headquarters = headquarters;
+   }
+}
+",
+}
+`;
+
+exports[`codegen #formats check we can convert all formats from namespace unversioned CTO 19`] = `
+{
+  "key": "org/acme/hr/Department.java",
+  "value": "// this code is generated and should not be modified
+package org.acme.hr;
+
+import com.fasterxml.jackson.annotation.*;
+@JsonIgnoreProperties({"$class"})
+public enum Department {
+   Sales,
+   Marketing,
+   Finance,
+   HR,
+   Engineering,
+   Design,
+}
+",
+}
+`;
+
+exports[`codegen #formats check we can convert all formats from namespace unversioned CTO 20`] = `
+{
+  "key": "org/acme/hr/Equipment.java",
+  "value": "// this code is generated and should not be modified
+package org.acme.hr;
+
+import concerto.Concept;
+import concerto.Asset;
+import concerto.Transaction;
+import concerto.Participant;
+import concerto.Event;
+import com.fasterxml.jackson.annotation.*;
+
+@JsonIgnoreProperties({"id"})
+@JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = "serialNumber")
+public abstract class Equipment extends Asset {
+   
+   // the accessor for the identifying field
+   public String getID() {
+      return this.getSerialNumber();
+   }
+
+   private String serialNumber;
+   public String getSerialNumber() {
+      return this.serialNumber;
+   }
+   public void setSerialNumber(String serialNumber) {
+      this.serialNumber = serialNumber;
+   }
+}
+",
+}
+`;
+
+exports[`codegen #formats check we can convert all formats from namespace unversioned CTO 21`] = `
+{
+  "key": "org/acme/hr/LaptopMake.java",
+  "value": "// this code is generated and should not be modified
+package org.acme.hr;
+
+import com.fasterxml.jackson.annotation.*;
+@JsonIgnoreProperties({"$class"})
+public enum LaptopMake {
+   Apple,
+   Microsoft,
+}
+",
+}
+`;
+
+exports[`codegen #formats check we can convert all formats from namespace unversioned CTO 22`] = `
+{
+  "key": "org/acme/hr/Laptop.java",
+  "value": "// this code is generated and should not be modified
+package org.acme.hr;
+
+import concerto.Concept;
+import concerto.Asset;
+import concerto.Transaction;
+import concerto.Participant;
+import concerto.Event;
+import com.fasterxml.jackson.annotation.*;
+
+@JsonIgnoreProperties({"id"})
+@JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = "serialNumber")
+public class Laptop extends Equipment {
+   
+   // the accessor for the identifying field
+   public String getID() {
+      return this.getSerialNumber();
+   }
+
+   private LaptopMake make;
+   public LaptopMake getMake() {
+      return this.make;
+   }
+   public void setMake(LaptopMake make) {
+      this.make = make;
+   }
+}
+",
+}
+`;
+
+exports[`codegen #formats check we can convert all formats from namespace unversioned CTO 23`] = `
+{
+  "key": "org/acme/hr/Person.java",
+  "value": "// this code is generated and should not be modified
+package org.acme.hr;
+
+import concerto.Concept;
+import concerto.Asset;
+import concerto.Transaction;
+import concerto.Participant;
+import concerto.Event;
+import com.fasterxml.jackson.annotation.*;
+
+@JsonIgnoreProperties({"id"})
+@JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = "email")
+public abstract class Person extends Participant {
+   
+   // the accessor for the identifying field
+   public String getID() {
+      return this.getEmail();
+   }
+
+   private String email;
+   private String firstName;
+   private String lastName;
+   private String middleNames;
+   private Address homeAddress;
+   private SSN ssn;
+   public String getEmail() {
+      return this.email;
+   }
+   public String getFirstName() {
+      return this.firstName;
+   }
+   public String getLastName() {
+      return this.lastName;
+   }
+   public String getMiddleNames() {
+      return this.middleNames;
+   }
+   public Address getHomeAddress() {
+      return this.homeAddress;
+   }
+   public SSN getSsn() {
+      return this.ssn;
+   }
+   public void setEmail(String email) {
+      this.email = email;
+   }
+   public void setFirstName(String firstName) {
+      this.firstName = firstName;
+   }
+   public void setLastName(String lastName) {
+      this.lastName = lastName;
+   }
+   public void setMiddleNames(String middleNames) {
+      this.middleNames = middleNames;
+   }
+   public void setHomeAddress(Address homeAddress) {
+      this.homeAddress = homeAddress;
+   }
+   public void setSsn(SSN ssn) {
+      this.ssn = ssn;
+   }
+}
+",
+}
+`;
+
+exports[`codegen #formats check we can convert all formats from namespace unversioned CTO 24`] = `
+{
+  "key": "org/acme/hr/Employee.java",
+  "value": "// this code is generated and should not be modified
+package org.acme.hr;
+
+import concerto.Concept;
+import concerto.Asset;
+import concerto.Transaction;
+import concerto.Participant;
+import concerto.Event;
+import com.fasterxml.jackson.annotation.*;
+
+@JsonIgnoreProperties({"id"})
+@JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = "email")
+public class Employee extends Person {
+   
+   // the accessor for the identifying field
+   public String getID() {
+      return this.getEmail();
+   }
+
+   private String employeeId;
+   private Department department;
+   private Address officeAddress;
+   private Equipment[] companyAssets;
+   private Manager manager;
+   public String getEmployeeId() {
+      return this.employeeId;
+   }
+   public Department getDepartment() {
+      return this.department;
+   }
+   public Address getOfficeAddress() {
+      return this.officeAddress;
+   }
+   public Equipment[] getCompanyAssets() {
+      return this.companyAssets;
+   }
+   public Manager getManager() {
+      return this.manager;
+   }
+   public void setEmployeeId(String employeeId) {
+      this.employeeId = employeeId;
+   }
+   public void setDepartment(Department department) {
+      this.department = department;
+   }
+   public void setOfficeAddress(Address officeAddress) {
+      this.officeAddress = officeAddress;
+   }
+   public void setCompanyAssets(Equipment[] companyAssets) {
+      this.companyAssets = companyAssets;
+   }
+   public void setManager(Manager manager) {
+      this.manager = manager;
+   }
+}
+",
+}
+`;
+
+exports[`codegen #formats check we can convert all formats from namespace unversioned CTO 25`] = `
+{
+  "key": "org/acme/hr/Contractor.java",
+  "value": "// this code is generated and should not be modified
+package org.acme.hr;
+
+import concerto.Concept;
+import concerto.Asset;
+import concerto.Transaction;
+import concerto.Participant;
+import concerto.Event;
+import com.fasterxml.jackson.annotation.*;
+
+@JsonIgnoreProperties({"id"})
+@JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = "email")
+public class Contractor extends Person {
+   
+   // the accessor for the identifying field
+   public String getID() {
+      return this.getEmail();
+   }
+
+   private Company company;
+   private Manager manager;
+   public Company getCompany() {
+      return this.company;
+   }
+   public Manager getManager() {
+      return this.manager;
+   }
+   public void setCompany(Company company) {
+      this.company = company;
+   }
+   public void setManager(Manager manager) {
+      this.manager = manager;
+   }
+}
+",
+}
+`;
+
+exports[`codegen #formats check we can convert all formats from namespace unversioned CTO 26`] = `
+{
+  "key": "org/acme/hr/Manager.java",
+  "value": "// this code is generated and should not be modified
+package org.acme.hr;
+
+import concerto.Concept;
+import concerto.Asset;
+import concerto.Transaction;
+import concerto.Participant;
+import concerto.Event;
+import com.fasterxml.jackson.annotation.*;
+
+@JsonIgnoreProperties({"id"})
+@JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = "email")
+public class Manager extends Employee {
+   
+   // the accessor for the identifying field
+   public String getID() {
+      return this.getEmail();
+   }
+
+   private Person[] reports;
+   public Person[] getReports() {
+      return this.reports;
+   }
+   public void setReports(Person[] reports) {
+      this.reports = reports;
+   }
+}
+",
+}
+`;
+
+exports[`codegen #formats check we can convert all formats from namespace unversioned CTO 27`] = `
+{
+  "key": "org/acme/hr/CompanyEvent.java",
+  "value": "// this code is generated and should not be modified
+package org.acme.hr;
+
+import concerto.Concept;
+import concerto.Asset;
+import concerto.Transaction;
+import concerto.Participant;
+import concerto.Event;
+import com.fasterxml.jackson.annotation.*;
+
+public class CompanyEvent extends Event {
+}
+",
+}
+`;
+
+exports[`codegen #formats check we can convert all formats from namespace unversioned CTO 28`] = `
+{
+  "key": "org/acme/hr/Onboarded.java",
+  "value": "// this code is generated and should not be modified
+package org.acme.hr;
+
+import concerto.Concept;
+import concerto.Asset;
+import concerto.Transaction;
+import concerto.Participant;
+import concerto.Event;
+import com.fasterxml.jackson.annotation.*;
+
+public class Onboarded extends CompanyEvent {
+   private Employee employee;
+   public Employee getEmployee() {
+      return this.employee;
+   }
+   public void setEmployee(Employee employee) {
+      this.employee = employee;
+   }
+}
+",
+}
+`;
+
+exports[`codegen #formats check we can convert all formats from namespace unversioned CTO 29`] = `
+{
+  "key": "org/acme/hr/ChangeOfAddress.java",
+  "value": "// this code is generated and should not be modified
+package org.acme.hr;
+
+import concerto.Concept;
+import concerto.Asset;
+import concerto.Transaction;
+import concerto.Participant;
+import concerto.Event;
+import com.fasterxml.jackson.annotation.*;
+
+public class ChangeOfAddress extends Transaction {
+   private Person Person;
+   private Address newAddress;
+   public Person getPerson() {
+      return this.Person;
+   }
+   public Address getNewAddress() {
+      return this.newAddress;
+   }
+   public void setPerson(Person Person) {
+      this.Person = Person;
+   }
+   public void setNewAddress(Address newAddress) {
+      this.newAddress = newAddress;
+   }
+}
+",
+}
+`;
+
+exports[`codegen #formats check we can convert all formats from namespace unversioned CTO 30`] = `
+{
+  "key": "model.gql",
+  "value": "directive @resource on OBJECT | FIELD_DEFINITION
+scalar DateTime
+# namespace org.acme.hr
+enum State {
+   MA
+   NY
+   CO
+   WA
+   IL
+   CA
+}
+type Address {
+   street: String!
+   city: String!
+   state: State
+   zipCode: String!
+   country: String!
+}
+type Company {
+   name: String!
+   headquarters: Address!
+}
+enum Department {
+   Sales
+   Marketing
+   Finance
+   HR
+   Engineering
+   Design
+}
+type Equipment @resource {
+   serialNumber: String!
+   _identifier: String!
+}
+enum LaptopMake {
+   Apple
+   Microsoft
+}
+type Laptop {
+   make: LaptopMake!
+   serialNumber: String!
+   _identifier: String!
+}
+type Person @resource {
+   email: String!
+   firstName: String!
+   lastName: String!
+   middleNames: String
+   homeAddress: Address!
+   ssn: SSN!
+   _identifier: String!
+}
+type Employee {
+   employeeId: String!
+   department: Department!
+   officeAddress: Address!
+   companyAssets: [Equipment]!
+   manager: ID # Manager
+   email: String!
+   firstName: String!
+   lastName: String!
+   middleNames: String
+   homeAddress: Address!
+   ssn: SSN!
+   _identifier: String!
+}
+type Contractor {
+   company: Company!
+   manager: ID # Manager
+   email: String!
+   firstName: String!
+   lastName: String!
+   middleNames: String
+   homeAddress: Address!
+   ssn: SSN!
+   _identifier: String!
+}
+type Manager {
+   reports: [ID] # Person
+   employeeId: String!
+   department: Department!
+   officeAddress: Address!
+   companyAssets: [Equipment]!
+   manager: ID # Manager
+   email: String!
+   firstName: String!
+   lastName: String!
+   middleNames: String
+   homeAddress: Address!
+   ssn: SSN!
+   _identifier: String!
+}
+type CompanyEvent {
+   _timestamp: DateTime!
+}
+type Onboarded {
+   employee: ID! # Employee
+   _timestamp: DateTime!
+}
+type ChangeOfAddress {
+   Person: ID! # Person
+   newAddress: Address!
+   _timestamp: DateTime!
+}
+",
+}
+`;
+
+exports[`codegen #formats check we can convert all formats from namespace unversioned CTO 31`] = `
+{
+  "key": "concerto@1.0.0.cs",
+  "value": "namespace AccordProject.Concerto;
+[AccordProject.Concerto.Type(Namespace = "concerto", Version = "1.0.0", Name = "Concept")]
+[System.Text.Json.Serialization.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterFactorySystem))]
+public abstract class Concept {
+   [System.Text.Json.Serialization.JsonPropertyName("$class")]
+   public virtual string _class { get; } = "concerto@1.0.0.Concept";
+}
+[AccordProject.Concerto.Type(Namespace = "concerto", Version = "1.0.0", Name = "Asset")]
+[System.Text.Json.Serialization.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterFactorySystem))]
+public abstract class Asset : Concept {
+   [System.Text.Json.Serialization.JsonPropertyName("$class")]
+   public override string _class { get; } = "concerto@1.0.0.Asset";
+   [AccordProject.Concerto.Identifier()]
+   [System.Text.Json.Serialization.JsonPropertyName("$identifier")]
+   public string _identifier { get; set; }
+}
+[AccordProject.Concerto.Type(Namespace = "concerto", Version = "1.0.0", Name = "Participant")]
+[System.Text.Json.Serialization.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterFactorySystem))]
+public abstract class Participant : Concept {
+   [System.Text.Json.Serialization.JsonPropertyName("$class")]
+   public override string _class { get; } = "concerto@1.0.0.Participant";
+   [AccordProject.Concerto.Identifier()]
+   [System.Text.Json.Serialization.JsonPropertyName("$identifier")]
+   public string _identifier { get; set; }
+}
+[AccordProject.Concerto.Type(Namespace = "concerto", Version = "1.0.0", Name = "Transaction")]
+[System.Text.Json.Serialization.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterFactorySystem))]
+public abstract class Transaction : Concept {
+   [System.Text.Json.Serialization.JsonPropertyName("$class")]
+   public override string _class { get; } = "concerto@1.0.0.Transaction";
+   [System.Text.Json.Serialization.JsonPropertyName("$timestamp")]
+   public System.DateTime _timestamp { get; set; }
+}
+[AccordProject.Concerto.Type(Namespace = "concerto", Version = "1.0.0", Name = "Event")]
+[System.Text.Json.Serialization.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterFactorySystem))]
+public abstract class Event : Concept {
+   [System.Text.Json.Serialization.JsonPropertyName("$class")]
+   public override string _class { get; } = "concerto@1.0.0.Event";
+   [System.Text.Json.Serialization.JsonPropertyName("$timestamp")]
+   public System.DateTime _timestamp { get; set; }
+}
+",
+}
+`;
+
+exports[`codegen #formats check we can convert all formats from namespace unversioned CTO 32`] = `
+{
+  "key": "concerto.cs",
+  "value": "namespace AccordProject.Concerto;
+[AccordProject.Concerto.Type(Namespace = "concerto", Version = null, Name = "Concept")]
+[System.Text.Json.Serialization.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterFactorySystem))]
+public abstract class Concept {
+   [System.Text.Json.Serialization.JsonPropertyName("$class")]
+   public virtual string _class { get; } = "concerto.Concept";
+}
+[AccordProject.Concerto.Type(Namespace = "concerto", Version = null, Name = "Asset")]
+[System.Text.Json.Serialization.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterFactorySystem))]
+public abstract class Asset : Concept {
+   [System.Text.Json.Serialization.JsonPropertyName("$class")]
+   public override string _class { get; } = "concerto.Asset";
+   [AccordProject.Concerto.Identifier()]
+   [System.Text.Json.Serialization.JsonPropertyName("$identifier")]
+   public string _identifier { get; set; }
+}
+[AccordProject.Concerto.Type(Namespace = "concerto", Version = null, Name = "Participant")]
+[System.Text.Json.Serialization.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterFactorySystem))]
+public abstract class Participant : Concept {
+   [System.Text.Json.Serialization.JsonPropertyName("$class")]
+   public override string _class { get; } = "concerto.Participant";
+   [AccordProject.Concerto.Identifier()]
+   [System.Text.Json.Serialization.JsonPropertyName("$identifier")]
+   public string _identifier { get; set; }
+}
+[AccordProject.Concerto.Type(Namespace = "concerto", Version = null, Name = "Transaction")]
+[System.Text.Json.Serialization.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterFactorySystem))]
+public abstract class Transaction : Concept {
+   [System.Text.Json.Serialization.JsonPropertyName("$class")]
+   public override string _class { get; } = "concerto.Transaction";
+}
+[AccordProject.Concerto.Type(Namespace = "concerto", Version = null, Name = "Event")]
+[System.Text.Json.Serialization.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterFactorySystem))]
+public abstract class Event : Concept {
+   [System.Text.Json.Serialization.JsonPropertyName("$class")]
+   public override string _class { get; } = "concerto.Event";
+}
+",
+}
+`;
+
+exports[`codegen #formats check we can convert all formats from namespace unversioned CTO 33`] = `
+{
+  "key": "org.acme.hr.cs",
+  "value": "namespace org.acme.hr;
+using AccordProject.Concerto;
+[System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.JsonStringEnumConverter))]
+public enum State {
+      MA,
+      NY,
+      CO,
+      WA,
+      IL,
+      CA,
+}
+[AccordProject.Concerto.Type(Namespace = "org.acme.hr", Version = null, Name = "Address")]
+[System.Text.Json.Serialization.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterFactorySystem))]
+public class Address : Concept {
+   [System.Text.Json.Serialization.JsonPropertyName("$class")]
+   public override string _class { get; } = "org.acme.hr.Address";
+   public string street { get; set; }
+   public string city { get; set; }
+   public State? state { get; set; }
+   public string zipCode { get; set; }
+   public string country { get; set; }
+}
+[AccordProject.Concerto.Type(Namespace = "org.acme.hr", Version = null, Name = "Company")]
+[System.Text.Json.Serialization.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterFactorySystem))]
+public class Company : Concept {
+   [System.Text.Json.Serialization.JsonPropertyName("$class")]
+   public override string _class { get; } = "org.acme.hr.Company";
+   public string name { get; set; }
+   public Address headquarters { get; set; }
+}
+[System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.JsonStringEnumConverter))]
+public enum Department {
+      Sales,
+      Marketing,
+      Finance,
+      HR,
+      Engineering,
+      Design,
+}
+[AccordProject.Concerto.Type(Namespace = "org.acme.hr", Version = null, Name = "Equipment")]
+[System.Text.Json.Serialization.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterFactorySystem))]
+public abstract class Equipment : Asset {
+   [System.Text.Json.Serialization.JsonPropertyName("$class")]
+   public override string _class { get; } = "org.acme.hr.Equipment";
+   [AccordProject.Concerto.Identifier()]
+   public string serialNumber { get; set; }
+}
+[System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.JsonStringEnumConverter))]
+public enum LaptopMake {
+      Apple,
+      Microsoft,
+}
+[AccordProject.Concerto.Type(Namespace = "org.acme.hr", Version = null, Name = "Laptop")]
+[System.Text.Json.Serialization.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterFactorySystem))]
+public class Laptop : Equipment {
+   [System.Text.Json.Serialization.JsonPropertyName("$class")]
+   public override string _class { get; } = "org.acme.hr.Laptop";
+   public LaptopMake make { get; set; }
+}
+[AccordProject.Concerto.Type(Namespace = "org.acme.hr", Version = null, Name = "Person")]
+[System.Text.Json.Serialization.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterFactorySystem))]
+public abstract class Person : Participant {
+   [System.Text.Json.Serialization.JsonPropertyName("$class")]
+   public override string _class { get; } = "org.acme.hr.Person";
+   [AccordProject.Concerto.Identifier()]
+   public string email { get; set; }
+   public string firstName { get; set; }
+   public string lastName { get; set; }
+   public string middleNames { get; set; }
+   public Address homeAddress { get; set; }
+   public SSN ssn { get; set; }
+}
+[AccordProject.Concerto.Type(Namespace = "org.acme.hr", Version = null, Name = "Employee")]
+[System.Text.Json.Serialization.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterFactorySystem))]
+public class Employee : Person {
+   [System.Text.Json.Serialization.JsonPropertyName("$class")]
+   public override string _class { get; } = "org.acme.hr.Employee";
+   public string employeeId { get; set; }
+   public Department department { get; set; }
+   public Address officeAddress { get; set; }
+   public Equipment[] companyAssets { get; set; }
+   public Manager manager { get; set; }
+}
+[AccordProject.Concerto.Type(Namespace = "org.acme.hr", Version = null, Name = "Contractor")]
+[System.Text.Json.Serialization.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterFactorySystem))]
+public class Contractor : Person {
+   [System.Text.Json.Serialization.JsonPropertyName("$class")]
+   public override string _class { get; } = "org.acme.hr.Contractor";
+   public Company company { get; set; }
+   public Manager manager { get; set; }
+}
+[AccordProject.Concerto.Type(Namespace = "org.acme.hr", Version = null, Name = "Manager")]
+[System.Text.Json.Serialization.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterFactorySystem))]
+public class Manager : Employee {
+   [System.Text.Json.Serialization.JsonPropertyName("$class")]
+   public override string _class { get; } = "org.acme.hr.Manager";
+   public Person[] reports { get; set; }
+}
+[AccordProject.Concerto.Type(Namespace = "org.acme.hr", Version = null, Name = "CompanyEvent")]
+[System.Text.Json.Serialization.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterFactorySystem))]
+public class CompanyEvent : Event {
+   [System.Text.Json.Serialization.JsonPropertyName("$class")]
+   public override string _class { get; } = "org.acme.hr.CompanyEvent";
+}
+[AccordProject.Concerto.Type(Namespace = "org.acme.hr", Version = null, Name = "Onboarded")]
+[System.Text.Json.Serialization.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterFactorySystem))]
+public class Onboarded : CompanyEvent {
+   [System.Text.Json.Serialization.JsonPropertyName("$class")]
+   public override string _class { get; } = "org.acme.hr.Onboarded";
+   public Employee employee { get; set; }
+}
+[AccordProject.Concerto.Type(Namespace = "org.acme.hr", Version = null, Name = "ChangeOfAddress")]
+[System.Text.Json.Serialization.JsonConverter(typeof(AccordProject.Concerto.ConcertoConverterFactorySystem))]
+public class ChangeOfAddress : Transaction {
+   [System.Text.Json.Serialization.JsonPropertyName("$class")]
+   public override string _class { get; } = "org.acme.hr.ChangeOfAddress";
+   public Person Person { get; set; }
+   public Address newAddress { get; set; }
+}
+",
+}
+`;
+
+exports[`codegen #formats check we can convert all formats from namespace unversioned CTO 34`] = `
+{
+  "key": "concerto.csdl",
+  "value": "<?xml version="1.0"?>
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+<edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/cs01/vocabularies/Org.OData.Core.V1.xml">
+   <edmx:Include Namespace="Org.OData.Core.V1" Alias="Core" />
+</edmx:Reference>
+<edmx:DataServices>
+   <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="concerto">
+      <ComplexType Name="Concept" Abstract="true" >
+      </ComplexType>
+      <EntityType Name="Asset" Abstract="true" BaseType="concerto.Concept">
+         <Property Name="$identifier" Type="Edm.String"  >
+         </Property>
+      </EntityType>
+      <EntityType Name="Participant" Abstract="true" BaseType="concerto.Concept">
+         <Property Name="$identifier" Type="Edm.String"  >
+         </Property>
+      </EntityType>
+      <ComplexType Name="Transaction" Abstract="true" BaseType="concerto.Concept">
+      </ComplexType>
+      <ComplexType Name="Event" Abstract="true" BaseType="concerto.Concept">
+      </ComplexType>
+   <EntityContainer Name="concertoService">
+   </EntityContainer>
+   </Schema>
+</edmx:DataServices>
+</edmx:Edmx>
+",
+}
+`;
+
+exports[`codegen #formats check we can convert all formats from namespace unversioned CTO 35`] = `
+{
+  "key": "org.acme.hr.csdl",
+  "value": "<?xml version="1.0"?>
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+<edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/cs01/vocabularies/Org.OData.Core.V1.xml">
+   <edmx:Include Namespace="Org.OData.Core.V1" Alias="Core" />
+</edmx:Reference>
+<edmx:Reference Uri="./concerto.csdl">
+   <edmx:Include Namespace="concerto" />
+</edmx:Reference>
+<edmx:DataServices>
+   <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="org.acme.hr">
+      <EnumType Name="State">
+         <Member Name="MA">
+         </Member>
+         <Member Name="NY">
+         </Member>
+         <Member Name="CO">
+         </Member>
+         <Member Name="WA">
+         </Member>
+         <Member Name="IL">
+         </Member>
+         <Member Name="CA">
+         </Member>
+      </EnumType>
+      <ComplexType Name="Address"  BaseType="concerto.Concept">
+         <Property Name="street" Type="Edm.String"  >
+         </Property>
+         <Property Name="city" Type="Edm.String"  >
+         </Property>
+         <Property Name="state" Type="org.acme.hr.State" Nullable="true" >
+         </Property>
+         <Property Name="zipCode" Type="Edm.String"  >
+         </Property>
+         <Property Name="country" Type="Edm.String"  >
+         </Property>
+      </ComplexType>
+      <ComplexType Name="Company"  BaseType="concerto.Concept">
+         <Property Name="name" Type="Edm.String"  >
+         </Property>
+         <Property Name="headquarters" Type="org.acme.hr.Address"  >
+         </Property>
+      </ComplexType>
+      <EnumType Name="Department">
+         <Member Name="Sales">
+         </Member>
+         <Member Name="Marketing">
+         </Member>
+         <Member Name="Finance">
+         </Member>
+         <Member Name="HR">
+         </Member>
+         <Member Name="Engineering">
+         </Member>
+         <Member Name="Design">
+         </Member>
+      </EnumType>
+      <EntityType Name="Equipment" Abstract="true" BaseType="concerto.Asset">
+            <Annotation Term="resource" Bool="true"/>
+         <Key><PropertyRef Name="serialNumber"/></Key>
+         <Property Name="serialNumber" Type="Edm.String"  >
+         </Property>
+      </EntityType>
+      <EnumType Name="LaptopMake">
+         <Member Name="Apple">
+         </Member>
+         <Member Name="Microsoft">
+         </Member>
+      </EnumType>
+      <EntityType Name="Laptop"  BaseType="org.acme.hr.Equipment">
+         <Property Name="make" Type="org.acme.hr.LaptopMake"  >
+         </Property>
+      </EntityType>
+      <EntityType Name="Person" Abstract="true" BaseType="concerto.Participant">
+            <Annotation Term="resource" Bool="true"/>
+         <Key><PropertyRef Name="email"/></Key>
+         <Property Name="email" Type="Edm.String"  >
+         </Property>
+         <Property Name="firstName" Type="Edm.String"  >
+         </Property>
+         <Property Name="lastName" Type="Edm.String"  >
+         </Property>
+         <Property Name="middleNames" Type="Edm.String" Nullable="true" >
+         </Property>
+         <Property Name="homeAddress" Type="org.acme.hr.Address"  >
+         </Property>
+         <Property Name="ssn" Type="org.acme.hr.SSN"  >
+         </Property>
+      </EntityType>
+      <EntityType Name="Employee"  BaseType="org.acme.hr.Person">
+         <Property Name="employeeId" Type="Edm.String"  >
+         </Property>
+         <Property Name="department" Type="org.acme.hr.Department"  >
+         </Property>
+         <Property Name="officeAddress" Type="org.acme.hr.Address"  >
+         </Property>
+         <Property Name="companyAssets" Type="Collection(org.acme.hr.Equipment)"  >
+         </Property>
+         <NavigationProperty Name="manager" Type="org.acme.hr.Manager" Nullable="true">
+         </NavigationProperty>
+      </EntityType>
+      <EntityType Name="Contractor"  BaseType="org.acme.hr.Person">
+         <Property Name="company" Type="org.acme.hr.Company"  >
+         </Property>
+         <NavigationProperty Name="manager" Type="org.acme.hr.Manager" Nullable="true">
+         </NavigationProperty>
+      </EntityType>
+      <EntityType Name="Manager"  BaseType="org.acme.hr.Employee">
+         <NavigationProperty Name="reports" Type="Collection(org.acme.hr.Person)" Nullable="true">
+         </NavigationProperty>
+      </EntityType>
+      <ComplexType Name="CompanyEvent"  BaseType="concerto.Event">
+      </ComplexType>
+      <ComplexType Name="Onboarded"  BaseType="org.acme.hr.CompanyEvent">
+         <NavigationProperty Name="employee" Type="org.acme.hr.Employee" >
+         </NavigationProperty>
+      </ComplexType>
+      <ComplexType Name="ChangeOfAddress"  BaseType="concerto.Transaction">
+         <NavigationProperty Name="Person" Type="org.acme.hr.Person" >
+         </NavigationProperty>
+         <Property Name="newAddress" Type="org.acme.hr.Address"  >
+         </Property>
+      </ComplexType>
+   <EntityContainer Name="org.acme.hrService">
+      <EntitySet Name="Laptop" EntityType="org.acme.hr.Laptop"/>
+      <EntitySet Name="Employee" EntityType="org.acme.hr.Employee"/>
+      <EntitySet Name="Contractor" EntityType="org.acme.hr.Contractor"/>
+      <EntitySet Name="Manager" EntityType="org.acme.hr.Manager"/>
+   </EntityContainer>
+   </Schema>
+</edmx:DataServices>
+</edmx:Edmx>
+",
+}
+`;
+
+exports[`codegen #formats check we can convert all formats from namespace unversioned CTO 36`] = `
+{
+  "key": "model.mmd",
+  "value": "classDiagram
+class State {
+<< enumeration>>
+   MA
+   NY
+   CO
+   WA
+   IL
+   CA
+}
+
+State --|> Concept
+class Address {
+<< concept>>
+    +String street
+    +String city
+    +State state
+    +String zipCode
+    +String country
+}
+
+Address --|> Concept
+class Company {
+<< concept>>
+    +String name
+    +Address headquarters
+}
+
+Company --|> Concept
+class Department {
+<< enumeration>>
+   Sales
+   Marketing
+   Finance
+   HR
+   Engineering
+   Design
+}
+
+Department --|> Concept
+class Equipment {
+<< asset>>
+    +String serialNumber
+}
+
+Equipment --|> Asset
+class LaptopMake {
+<< enumeration>>
+   Apple
+   Microsoft
+}
+
+LaptopMake --|> Concept
+class Laptop {
+<< asset>>
+    +LaptopMake make
+}
+
+Laptop --|> Equipment
+class Person {
+<< participant>>
+    +String email
+    +String firstName
+    +String lastName
+    +String middleNames
+    +Address homeAddress
+    +SSN ssn
+}
+
+Person --|> Participant
+class Employee {
+<< participant>>
+    +String employeeId
+    +Department department
+    +Address officeAddress
+    +Equipment[] companyAssets
+}
+
+Employee "1" o-- "1" Manager : manager
+Employee --|> Person
+class Contractor {
+<< participant>>
+    +Company company
+}
+
+Contractor "1" o-- "1" Manager : manager
+Contractor --|> Person
+class Manager {
+<< participant>>
+}
+
+Manager "1" o-- "*" Person : reports
+Manager --|> Employee
+class CompanyEvent
+<< event>> CompanyEvent
+
+CompanyEvent --|> Event
+class Onboarded {
+<< event>>
+}
+
+Onboarded "1" o-- "1" Employee : employee
+Onboarded --|> CompanyEvent
+class ChangeOfAddress {
+<< transaction>>
+    +Address newAddress
+}
+
+ChangeOfAddress "1" o-- "1" Person : Person
+ChangeOfAddress --|> Transaction
+",
+}
+`;
+
+exports[`codegen #formats check we can convert all formats from namespace unversioned CTO 37`] = `
+{
+  "key": "models.md",
+  "value": "# Namespace org.acme.hr
+
+## Overview
+- 2 concepts
+- 3 enumerations
+- 2 assets
+- 4 participants
+- 1 transactions
+- 2 events
+- 15 total declarations
+
+## Imports
+- concerto@1.0.0.Concept
+- concerto@1.0.0.Asset
+- concerto@1.0.0.Transaction
+- concerto@1.0.0.Participant
+- concerto@1.0.0.Event
+
+## Diagram
+\`\`\`mermaid
+classDiagram
+class State {
+<< enumeration>>
+   MA
+   NY
+   CO
+   WA
+   IL
+   CA
+}
+
+State --|> Concept
+class Address {
+<< concept>>
+    +String street
+    +String city
+    +State state
+    +String zipCode
+    +String country
+}
+
+Address --|> Concept
+class Company {
+<< concept>>
+    +String name
+    +Address headquarters
+}
+
+Company --|> Concept
+class Department {
+<< enumeration>>
+   Sales
+   Marketing
+   Finance
+   HR
+   Engineering
+   Design
+}
+
+Department --|> Concept
+class Equipment {
+<< asset>>
+    +String serialNumber
+}
+
+Equipment --|> Asset
+class LaptopMake {
+<< enumeration>>
+   Apple
+   Microsoft
+}
+
+LaptopMake --|> Concept
+class Laptop {
+<< asset>>
+    +LaptopMake make
+}
+
+Laptop --|> Equipment
+class Person {
+<< participant>>
+    +String email
+    +String firstName
+    +String lastName
+    +String middleNames
+    +Address homeAddress
+    +SSN ssn
+}
+
+Person --|> Participant
+class Employee {
+<< participant>>
+    +String employeeId
+    +Department department
+    +Address officeAddress
+    +Equipment[] companyAssets
+}
+
+Employee "1" o-- "1" Manager : manager
+Employee --|> Person
+class Contractor {
+<< participant>>
+    +Company company
+}
+
+Contractor "1" o-- "1" Manager : manager
+Contractor --|> Person
+class Manager {
+<< participant>>
+}
+
+Manager "1" o-- "*" Person : reports
+Manager --|> Employee
+class CompanyEvent
+<< event>> CompanyEvent
+
+CompanyEvent --|> Event
+class Onboarded {
+<< event>>
+}
+
+Onboarded "1" o-- "1" Employee : employee
+Onboarded --|> CompanyEvent
+class ChangeOfAddress {
+<< transaction>>
+    +Address newAddress
+}
+
+ChangeOfAddress "1" o-- "1" Person : Person
+ChangeOfAddress --|> Transaction
+\`\`\`
+
+",
+}
+`;
+
+exports[`codegen #formats check we can convert all formats from namespace unversioned CTO 38`] = `
+{
+  "key": "org.acme.hr.v.proto",
+  "value": "syntax = "proto3";
+
+package org.acme.hr.v;
+
+import "google/protobuf/timestamp.proto";
+
+enum State {
+  State_CA = 0;
+  State_CO = 1;
+  State_IL = 2;
+  State_MA = 3;
+  State_NY = 4;
+  State_WA = 5;
+}
+
+message Address {
+  string city = 1;
+  string country = 2;
+  optional State state = 3;
+  string street = 4;
+  string zipCode = 5;
+}
+
+message Company {
+  Address headquarters = 1;
+  string name = 2;
+}
+
+enum Department {
+  Department_Design = 0;
+  Department_Engineering = 1;
+  Department_Finance = 2;
+  Department_HR = 3;
+  Department_Marketing = 4;
+  Department_Sales = 5;
+}
+
+message _Subclasses_of_class_Equipment {
+  oneof _class_oneof_Equipment {
+    Laptop _subclass_of_class_Equipment_Laptop = 1;
+  }
+}
+
+enum LaptopMake {
+  LaptopMake_Apple = 0;
+  LaptopMake_Microsoft = 1;
+}
+
+message Laptop {
+  LaptopMake make = 1;
+  string serialNumber = 2;
+}
+
+message _Subclasses_of_class_Person {
+  oneof _class_oneof_Person {
+    Contractor _subclass_of_class_Person_Contractor = 1;
+    Employee _subclass_of_class_Person_Employee = 2;
+    Manager _subclass_of_class_Person_Manager = 3;
+  }
+}
+
+message Employee {
+  repeated _Subclasses_of_class_Equipment companyAssets = 1;
+  Department department = 2;
+  string email = 3;
+  string employeeId = 4;
+  string firstName = 5;
+  Address homeAddress = 6;
+  string lastName = 7;
+  optional string manager = 8;
+  optional string middleNames = 9;
+  Address officeAddress = 10;
+  SSN ssn = 11;
+}
+
+message _Subclasses_of_class_Employee {
+  oneof _class_oneof_Employee {
+    Employee _subclass_of_class_Employee_Employee = 1;
+    Manager _subclass_of_class_Employee_Manager = 2;
+  }
+}
+
+message Contractor {
+  Company company = 1;
+  string email = 2;
+  string firstName = 3;
+  Address homeAddress = 4;
+  string lastName = 5;
+  optional string manager = 6;
+  optional string middleNames = 7;
+  SSN ssn = 8;
+}
+
+message Manager {
+  repeated _Subclasses_of_class_Equipment companyAssets = 1;
+  Department department = 2;
+  string email = 3;
+  string employeeId = 4;
+  string firstName = 5;
+  Address homeAddress = 6;
+  string lastName = 7;
+  optional string manager = 8;
+  optional string middleNames = 9;
+  Address officeAddress = 10;
+  repeated string reports = 11;
+  SSN ssn = 12;
+}
+
+message CompanyEvent {
+}
+
+message _Subclasses_of_class_CompanyEvent {
+  oneof _class_oneof_CompanyEvent {
+    CompanyEvent _subclass_of_class_CompanyEvent_CompanyEvent = 1;
+    Onboarded _subclass_of_class_CompanyEvent_Onboarded = 2;
+  }
+}
+
+message Onboarded {
+  string employee = 1;
+}
+
+message ChangeOfAddress {
+  Address newAddress = 1;
+  string Person = 2;
+}
+
+",
+}
+`;
+
+exports[`codegen #formats check we can convert all formats from namespace unversioned CTO 39`] = `
+{
+  "key": "openapi.json",
+  "value": "{
+  "openapi": "3.0.2",
+  "servers": [],
+  "info": {
+    "title": "Generated Open API from Concerto Models",
+    "version": "1.0.0"
+  },
+  "components": {
+    "schemas": {
+      "org.acme.hr.State": {
+        "title": "State",
+        "description": "An instance of org.acme.hr.State",
+        "enum": [
+          "MA",
+          "NY",
+          "CO",
+          "WA",
+          "IL",
+          "CA"
+        ]
+      },
+      "org.acme.hr.Address": {
+        "title": "Address",
+        "description": "An instance of org.acme.hr.Address",
+        "type": "object",
+        "properties": {
+          "$class": {
+            "type": "string",
+            "default": "org.acme.hr.Address",
+            "pattern": "^org\\\\.acme\\\\.hr\\\\.Address$",
+            "description": "The class identifier for this type"
+          },
+          "street": {
+            "type": "string"
+          },
+          "city": {
+            "type": "string"
+          },
+          "state": {
+            "$ref": "#/components/schemas/org.acme.hr.State"
+          },
+          "zipCode": {
+            "type": "string"
+          },
+          "country": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "$class",
+          "street",
+          "city",
+          "zipCode",
+          "country"
+        ]
+      },
+      "org.acme.hr.Company": {
+        "title": "Company",
+        "description": "An instance of org.acme.hr.Company",
+        "type": "object",
+        "properties": {
+          "$class": {
+            "type": "string",
+            "default": "org.acme.hr.Company",
+            "pattern": "^org\\\\.acme\\\\.hr\\\\.Company$",
+            "description": "The class identifier for this type"
+          },
+          "name": {
+            "type": "string"
+          },
+          "headquarters": {
+            "$ref": "#/components/schemas/org.acme.hr.Address"
+          }
+        },
+        "required": [
+          "$class",
+          "name",
+          "headquarters"
+        ]
+      },
+      "org.acme.hr.Department": {
+        "title": "Department",
+        "description": "An instance of org.acme.hr.Department",
+        "enum": [
+          "Sales",
+          "Marketing",
+          "Finance",
+          "HR",
+          "Engineering",
+          "Design"
+        ]
+      },
+      "org.acme.hr.Equipment": {
+        "title": "Equipment",
+        "description": "An instance of org.acme.hr.Equipment",
+        "type": "object",
+        "properties": {
+          "$class": {
+            "type": "string",
+            "default": "org.acme.hr.Equipment",
+            "pattern": "^org\\\\.acme\\\\.hr\\\\.Equipment$",
+            "description": "The class identifier for this type"
+          },
+          "serialNumber": {
+            "type": "string",
+            "description": "The instance identifier for this type"
+          }
+        },
+        "required": [
+          "$class",
+          "serialNumber"
+        ],
+        "$decorators": {
+          "resource": []
+        }
+      },
+      "org.acme.hr.LaptopMake": {
+        "title": "LaptopMake",
+        "description": "An instance of org.acme.hr.LaptopMake",
+        "enum": [
+          "Apple",
+          "Microsoft"
+        ]
+      },
+      "org.acme.hr.Laptop": {
+        "title": "Laptop",
+        "description": "An instance of org.acme.hr.Laptop",
+        "type": "object",
+        "properties": {
+          "$class": {
+            "type": "string",
+            "default": "org.acme.hr.Laptop",
+            "pattern": "^org\\\\.acme\\\\.hr\\\\.Laptop$",
+            "description": "The class identifier for this type"
+          },
+          "make": {
+            "$ref": "#/components/schemas/org.acme.hr.LaptopMake"
+          },
+          "serialNumber": {
+            "type": "string",
+            "description": "The instance identifier for this type"
+          }
+        },
+        "required": [
+          "$class",
+          "make",
+          "serialNumber"
+        ]
+      },
+      "org.acme.hr.SSN": {
+        "type": "string",
+        "pattern": "\\\\d{3}-\\\\d{2}-\\\\{4}+"
+      },
+      "org.acme.hr.Person": {
+        "title": "Person",
+        "description": "An instance of org.acme.hr.Person",
+        "type": "object",
+        "properties": {
+          "$class": {
+            "type": "string",
+            "default": "org.acme.hr.Person",
+            "pattern": "^org\\\\.acme\\\\.hr\\\\.Person$",
+            "description": "The class identifier for this type"
+          },
+          "email": {
+            "type": "string",
+            "description": "The instance identifier for this type"
+          },
+          "firstName": {
+            "type": "string"
+          },
+          "lastName": {
+            "type": "string"
+          },
+          "middleNames": {
+            "type": "string"
+          },
+          "homeAddress": {
+            "$ref": "#/components/schemas/org.acme.hr.Address"
+          },
+          "ssn": {
+            "$ref": "#/components/schemas/org.acme.hr.SSN"
+          }
+        },
+        "required": [
+          "$class",
+          "email",
+          "firstName",
+          "lastName",
+          "homeAddress",
+          "ssn"
+        ],
+        "$decorators": {
+          "resource": []
+        }
+      },
+      "org.acme.hr.Employee": {
+        "title": "Employee",
+        "description": "An instance of org.acme.hr.Employee",
+        "type": "object",
+        "properties": {
+          "$class": {
+            "type": "string",
+            "default": "org.acme.hr.Employee",
+            "pattern": "^org\\\\.acme\\\\.hr\\\\.Employee$",
+            "description": "The class identifier for this type"
+          },
+          "employeeId": {
+            "type": "string"
+          },
+          "department": {
+            "$ref": "#/components/schemas/org.acme.hr.Department"
+          },
+          "officeAddress": {
+            "$ref": "#/components/schemas/org.acme.hr.Address"
+          },
+          "companyAssets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/org.acme.hr.Equipment"
+            }
+          },
+          "manager": {
+            "type": "string",
+            "description": "The identifier of an instance of org.acme.hr.Manager"
+          },
+          "email": {
+            "type": "string",
+            "description": "The instance identifier for this type"
+          },
+          "firstName": {
+            "type": "string"
+          },
+          "lastName": {
+            "type": "string"
+          },
+          "middleNames": {
+            "type": "string"
+          },
+          "homeAddress": {
+            "$ref": "#/components/schemas/org.acme.hr.Address"
+          },
+          "ssn": {
+            "$ref": "#/components/schemas/org.acme.hr.SSN"
+          }
+        },
+        "required": [
+          "$class",
+          "employeeId",
+          "department",
+          "officeAddress",
+          "companyAssets",
+          "email",
+          "firstName",
+          "lastName",
+          "homeAddress",
+          "ssn"
+        ]
+      },
+      "org.acme.hr.Contractor": {
+        "title": "Contractor",
+        "description": "An instance of org.acme.hr.Contractor",
+        "type": "object",
+        "properties": {
+          "$class": {
+            "type": "string",
+            "default": "org.acme.hr.Contractor",
+            "pattern": "^org\\\\.acme\\\\.hr\\\\.Contractor$",
+            "description": "The class identifier for this type"
+          },
+          "company": {
+            "$ref": "#/components/schemas/org.acme.hr.Company"
+          },
+          "manager": {
+            "type": "string",
+            "description": "The identifier of an instance of org.acme.hr.Manager"
+          },
+          "email": {
+            "type": "string",
+            "description": "The instance identifier for this type"
+          },
+          "firstName": {
+            "type": "string"
+          },
+          "lastName": {
+            "type": "string"
+          },
+          "middleNames": {
+            "type": "string"
+          },
+          "homeAddress": {
+            "$ref": "#/components/schemas/org.acme.hr.Address"
+          },
+          "ssn": {
+            "$ref": "#/components/schemas/org.acme.hr.SSN"
+          }
+        },
+        "required": [
+          "$class",
+          "company",
+          "email",
+          "firstName",
+          "lastName",
+          "homeAddress",
+          "ssn"
+        ]
+      },
+      "org.acme.hr.Manager": {
+        "title": "Manager",
+        "description": "An instance of org.acme.hr.Manager",
+        "type": "object",
+        "properties": {
+          "$class": {
+            "type": "string",
+            "default": "org.acme.hr.Manager",
+            "pattern": "^org\\\\.acme\\\\.hr\\\\.Manager$",
+            "description": "The class identifier for this type"
+          },
+          "reports": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "description": "The identifier of an instance of org.acme.hr.Person"
+            }
+          },
+          "employeeId": {
+            "type": "string"
+          },
+          "department": {
+            "$ref": "#/components/schemas/org.acme.hr.Department"
+          },
+          "officeAddress": {
+            "$ref": "#/components/schemas/org.acme.hr.Address"
+          },
+          "companyAssets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/org.acme.hr.Equipment"
+            }
+          },
+          "manager": {
+            "type": "string",
+            "description": "The identifier of an instance of org.acme.hr.Manager"
+          },
+          "email": {
+            "type": "string",
+            "description": "The instance identifier for this type"
+          },
+          "firstName": {
+            "type": "string"
+          },
+          "lastName": {
+            "type": "string"
+          },
+          "middleNames": {
+            "type": "string"
+          },
+          "homeAddress": {
+            "$ref": "#/components/schemas/org.acme.hr.Address"
+          },
+          "ssn": {
+            "$ref": "#/components/schemas/org.acme.hr.SSN"
+          }
+        },
+        "required": [
+          "$class",
+          "employeeId",
+          "department",
+          "officeAddress",
+          "companyAssets",
+          "email",
+          "firstName",
+          "lastName",
+          "homeAddress",
+          "ssn"
+        ]
+      },
+      "org.acme.hr.CompanyEvent": {
+        "title": "CompanyEvent",
+        "description": "An instance of org.acme.hr.CompanyEvent",
+        "type": "object",
+        "properties": {
+          "$class": {
+            "type": "string",
+            "default": "org.acme.hr.CompanyEvent",
+            "pattern": "^org\\\\.acme\\\\.hr\\\\.CompanyEvent$",
+            "description": "The class identifier for this type"
+          }
+        },
+        "required": [
+          "$class"
+        ]
+      },
+      "org.acme.hr.Onboarded": {
+        "title": "Onboarded",
+        "description": "An instance of org.acme.hr.Onboarded",
+        "type": "object",
+        "properties": {
+          "$class": {
+            "type": "string",
+            "default": "org.acme.hr.Onboarded",
+            "pattern": "^org\\\\.acme\\\\.hr\\\\.Onboarded$",
+            "description": "The class identifier for this type"
+          },
+          "employee": {
+            "type": "string",
+            "description": "The identifier of an instance of org.acme.hr.Employee"
+          }
+        },
+        "required": [
+          "$class",
+          "employee"
+        ]
+      },
+      "org.acme.hr.ChangeOfAddress": {
+        "title": "ChangeOfAddress",
+        "description": "An instance of org.acme.hr.ChangeOfAddress",
+        "type": "object",
+        "properties": {
+          "$class": {
+            "type": "string",
+            "default": "org.acme.hr.ChangeOfAddress",
+            "pattern": "^org\\\\.acme\\\\.hr\\\\.ChangeOfAddress$",
+            "description": "The class identifier for this type"
+          },
+          "Person": {
+            "type": "string",
+            "description": "The identifier of an instance of org.acme.hr.Person"
+          },
+          "newAddress": {
+            "$ref": "#/components/schemas/org.acme.hr.Address"
+          }
+        },
+        "required": [
+          "$class",
+          "Person",
+          "newAddress"
+        ]
+      }
+    }
+  },
+  "paths": {
+    "/equipment": {
+      "summary": "Path used to manage the list of equipment.",
+      "description": "The REST endpoint/path used to list and create zero or more \`equipment\` entities.  This path contains a \`GET\` and \`POST\` operation to perform the list and create tasks, respectively.",
+      "get": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/org.acme.hr.Equipment"
+                  }
+                }
+              }
+            },
+            "description": "Successful response - returns an array of \`equipment\` entities."
+          }
+        },
+        "operationId": "listEquipment",
+        "summary": "List All Equipment",
+        "description": "Gets a list of all \`equipment\` entities."
+      },
+      "post": {
+        "requestBody": {
+          "description": "A new \`equipment\` to be created.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/org.acme.hr.Equipment"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Successful response."
+          }
+        },
+        "operationId": "createEquipment",
+        "summary": "Create a Equipment",
+        "description": "Creates a new instance of a \`equipment\`."
+      }
+    },
+    "/equipment/{serialNumber}": {
+      "summary": "Path used to manage a single equipment.",
+      "description": "The REST endpoint/path used to get, update, and delete single instances of a \`equipment\`.  This path contains \`GET\`, \`PUT\`, and \`DELETE\` operations used to perform the get, update, and delete tasks, respectively.",
+      "get": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/org.acme.hr.Equipment"
+                }
+              }
+            },
+            "description": "Successful response - returns a single \`equipment\`."
+          }
+        },
+        "operationId": "getEquipment",
+        "summary": "Get a equipment",
+        "description": "Gets the details of a single instance of a \`equipment\`."
+      },
+      "put": {
+        "requestBody": {
+          "description": "Updated \`equipment\` information.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/org.acme.hr.Equipment"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "202": {
+            "description": "Successful response."
+          }
+        },
+        "operationId": "replaceEquipment",
+        "summary": "Update a equipment",
+        "description": "Updates an existing \`equipment\`."
+      },
+      "delete": {
+        "responses": {
+          "204": {
+            "description": "Successful response."
+          }
+        },
+        "operationId": "deleteEquipment",
+        "summary": "Delete a equipment",
+        "description": "Deletes an existing \`equipment\`."
+      },
+      "parameters": [
+        {
+          "name": "serialNumber",
+          "description": "A unique identifier for a \`Equipment\`.",
+          "schema": {
+            "type": "string"
+          },
+          "in": "path",
+          "required": true
+        }
+      ]
+    },
+    "/people": {
+      "summary": "Path used to manage the list of people.",
+      "description": "The REST endpoint/path used to list and create zero or more \`person\` entities.  This path contains a \`GET\` and \`POST\` operation to perform the list and create tasks, respectively.",
+      "get": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/org.acme.hr.Person"
+                  }
+                }
+              }
+            },
+            "description": "Successful response - returns an array of \`person\` entities."
+          }
+        },
+        "operationId": "listPeople",
+        "summary": "List All People",
+        "description": "Gets a list of all \`person\` entities."
+      },
+      "post": {
+        "requestBody": {
+          "description": "A new \`person\` to be created.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/org.acme.hr.Person"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Successful response."
+          }
+        },
+        "operationId": "createPerson",
+        "summary": "Create a Person",
+        "description": "Creates a new instance of a \`person\`."
+      }
+    },
+    "/people/{email}": {
+      "summary": "Path used to manage a single person.",
+      "description": "The REST endpoint/path used to get, update, and delete single instances of a \`person\`.  This path contains \`GET\`, \`PUT\`, and \`DELETE\` operations used to perform the get, update, and delete tasks, respectively.",
+      "get": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/org.acme.hr.Person"
+                }
+              }
+            },
+            "description": "Successful response - returns a single \`person\`."
+          }
+        },
+        "operationId": "getPerson",
+        "summary": "Get a person",
+        "description": "Gets the details of a single instance of a \`person\`."
+      },
+      "put": {
+        "requestBody": {
+          "description": "Updated \`person\` information.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/org.acme.hr.Person"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "202": {
+            "description": "Successful response."
+          }
+        },
+        "operationId": "replacePerson",
+        "summary": "Update a person",
+        "description": "Updates an existing \`person\`."
+      },
+      "delete": {
+        "responses": {
+          "204": {
+            "description": "Successful response."
+          }
+        },
+        "operationId": "deletePerson",
+        "summary": "Delete a person",
+        "description": "Deletes an existing \`person\`."
+      },
+      "parameters": [
+        {
+          "name": "email",
+          "description": "A unique identifier for a \`Person\`.",
+          "schema": {
+            "type": "string"
+          },
+          "in": "path",
+          "required": true
+        }
+      ]
+    }
+  }
+}
+",
+}
+`;
+
+exports[`codegen #formats check we can convert all formats from namespace versioned CTO 1`] = `
+{
+  "key": "main.go",
+  "value": "package main
+import "fmt"
+type Relationship struct {
+   Namespace string \`json:"namespace"\`
+   Type string \`json:"type"\`
+   Identifier string \`json:"identifier"\`
+}
+func main() {
+   fmt.Printf("Hello, world.")
+}
+",
+}
+`;
+
+exports[`codegen #formats check we can convert all formats from namespace versioned CTO 2`] = `
 {
   "key": "orgacme.hr_1.0.0.go",
   "value": "package main
@@ -86,7 +3382,7 @@ type Onboarded struct {
 }
 `;
 
-exports[`codegen #formats check we can convert all formats to CTO 3`] = `
+exports[`codegen #formats check we can convert all formats from namespace versioned CTO 3`] = `
 {
   "key": "schema.json",
   "value": "{
@@ -528,7 +3824,7 @@ exports[`codegen #formats check we can convert all formats to CTO 3`] = `
 }
 `;
 
-exports[`codegen #formats check we can convert all formats to CTO 4`] = `
+exports[`codegen #formats check we can convert all formats from namespace versioned CTO 4`] = `
 {
   "key": "concerto@1.0.0.xsd",
   "value": "<?xml version="1.0"?>
@@ -584,7 +3880,7 @@ exports[`codegen #formats check we can convert all formats to CTO 4`] = `
 }
 `;
 
-exports[`codegen #formats check we can convert all formats to CTO 5`] = `
+exports[`codegen #formats check we can convert all formats from namespace versioned CTO 5`] = `
 {
   "key": "concerto.xsd",
   "value": "<?xml version="1.0"?>
@@ -638,7 +3934,7 @@ exports[`codegen #formats check we can convert all formats to CTO 5`] = `
 }
 `;
 
-exports[`codegen #formats check we can convert all formats to CTO 6`] = `
+exports[`codegen #formats check we can convert all formats from namespace versioned CTO 6`] = `
 {
   "key": "org.acme.hr@1.0.0.xsd",
   "value": "<?xml version="1.0"?>
@@ -805,7 +4101,7 @@ xmlns:concerto="concerto"
 }
 `;
 
-exports[`codegen #formats check we can convert all formats to CTO 7`] = `
+exports[`codegen #formats check we can convert all formats from namespace versioned CTO 7`] = `
 {
   "key": "model.puml",
   "value": "@startuml
@@ -899,7 +4195,7 @@ org.acme.hr.ChangeOfAddress --|> concerto.Transaction
 }
 `;
 
-exports[`codegen #formats check we can convert all formats to CTO 8`] = `
+exports[`codegen #formats check we can convert all formats from namespace versioned CTO 8`] = `
 {
   "key": "concerto@1.0.0.ts",
   "value": "/* eslint-disable @typescript-eslint/no-empty-interface */
@@ -975,7 +4271,7 @@ export type EventUnion = ICompanyEvent;
 }
 `;
 
-exports[`codegen #formats check we can convert all formats to CTO 9`] = `
+exports[`codegen #formats check we can convert all formats from namespace versioned CTO 9`] = `
 {
   "key": "concerto.ts",
   "value": "/* eslint-disable @typescript-eslint/no-empty-interface */
@@ -1006,7 +4302,7 @@ export interface IEvent extends IConcept {
 }
 `;
 
-exports[`codegen #formats check we can convert all formats to CTO 10`] = `
+exports[`codegen #formats check we can convert all formats from namespace versioned CTO 10`] = `
 {
   "key": "org.acme.hr@1.0.0.ts",
   "value": "/* eslint-disable @typescript-eslint/no-empty-interface */
@@ -1119,7 +4415,7 @@ export interface IChangeOfAddress extends ITransaction {
 }
 `;
 
-exports[`codegen #formats check we can convert all formats to CTO 11`] = `
+exports[`codegen #formats check we can convert all formats from namespace versioned CTO 11`] = `
 {
   "key": "concerto/Concept.java",
   "value": "// this code is generated and should not be modified
@@ -1134,7 +4430,7 @@ public abstract class Concept {
 }
 `;
 
-exports[`codegen #formats check we can convert all formats to CTO 12`] = `
+exports[`codegen #formats check we can convert all formats from namespace versioned CTO 12`] = `
 {
   "key": "concerto/Asset.java",
   "value": "// this code is generated and should not be modified
@@ -1173,7 +4469,7 @@ public abstract class Asset extends Concept {
 }
 `;
 
-exports[`codegen #formats check we can convert all formats to CTO 13`] = `
+exports[`codegen #formats check we can convert all formats from namespace versioned CTO 13`] = `
 {
   "key": "concerto/Participant.java",
   "value": "// this code is generated and should not be modified
@@ -1212,7 +4508,7 @@ public abstract class Participant extends Concept {
 }
 `;
 
-exports[`codegen #formats check we can convert all formats to CTO 14`] = `
+exports[`codegen #formats check we can convert all formats from namespace versioned CTO 14`] = `
 {
   "key": "concerto/Transaction.java",
   "value": "// this code is generated and should not be modified
@@ -1227,7 +4523,7 @@ public abstract class Transaction extends Concept {
 }
 `;
 
-exports[`codegen #formats check we can convert all formats to CTO 15`] = `
+exports[`codegen #formats check we can convert all formats from namespace versioned CTO 15`] = `
 {
   "key": "concerto/Event.java",
   "value": "// this code is generated and should not be modified
@@ -1242,7 +4538,7 @@ public abstract class Event extends Concept {
 }
 `;
 
-exports[`codegen #formats check we can convert all formats to CTO 16`] = `
+exports[`codegen #formats check we can convert all formats from namespace versioned CTO 16`] = `
 {
   "key": "org/acme/hr/State.java",
   "value": "// this code is generated and should not be modified
@@ -1262,7 +4558,7 @@ public enum State {
 }
 `;
 
-exports[`codegen #formats check we can convert all formats to CTO 17`] = `
+exports[`codegen #formats check we can convert all formats from namespace versioned CTO 17`] = `
 {
   "key": "org/acme/hr/Address.java",
   "value": "// this code is generated and should not be modified
@@ -1317,7 +4613,7 @@ public class Address extends Concept {
 }
 `;
 
-exports[`codegen #formats check we can convert all formats to CTO 18`] = `
+exports[`codegen #formats check we can convert all formats from namespace versioned CTO 18`] = `
 {
   "key": "org/acme/hr/Company.java",
   "value": "// this code is generated and should not be modified
@@ -1351,7 +4647,7 @@ public class Company extends Concept {
 }
 `;
 
-exports[`codegen #formats check we can convert all formats to CTO 19`] = `
+exports[`codegen #formats check we can convert all formats from namespace versioned CTO 19`] = `
 {
   "key": "org/acme/hr/Department.java",
   "value": "// this code is generated and should not be modified
@@ -1371,7 +4667,7 @@ public enum Department {
 }
 `;
 
-exports[`codegen #formats check we can convert all formats to CTO 20`] = `
+exports[`codegen #formats check we can convert all formats from namespace versioned CTO 20`] = `
 {
   "key": "org/acme/hr/Equipment.java",
   "value": "// this code is generated and should not be modified
@@ -1405,7 +4701,7 @@ public abstract class Equipment extends Asset {
 }
 `;
 
-exports[`codegen #formats check we can convert all formats to CTO 21`] = `
+exports[`codegen #formats check we can convert all formats from namespace versioned CTO 21`] = `
 {
   "key": "org/acme/hr/LaptopMake.java",
   "value": "// this code is generated and should not be modified
@@ -1421,7 +4717,7 @@ public enum LaptopMake {
 }
 `;
 
-exports[`codegen #formats check we can convert all formats to CTO 22`] = `
+exports[`codegen #formats check we can convert all formats from namespace versioned CTO 22`] = `
 {
   "key": "org/acme/hr/Laptop.java",
   "value": "// this code is generated and should not be modified
@@ -1455,7 +4751,7 @@ public class Laptop extends Equipment {
 }
 `;
 
-exports[`codegen #formats check we can convert all formats to CTO 23`] = `
+exports[`codegen #formats check we can convert all formats from namespace versioned CTO 23`] = `
 {
   "key": "org/acme/hr/Person.java",
   "value": "// this code is generated and should not be modified
@@ -1524,7 +4820,7 @@ public abstract class Person extends Participant {
 }
 `;
 
-exports[`codegen #formats check we can convert all formats to CTO 24`] = `
+exports[`codegen #formats check we can convert all formats from namespace versioned CTO 24`] = `
 {
   "key": "org/acme/hr/Employee.java",
   "value": "// this code is generated and should not be modified
@@ -1586,7 +4882,7 @@ public class Employee extends Person {
 }
 `;
 
-exports[`codegen #formats check we can convert all formats to CTO 25`] = `
+exports[`codegen #formats check we can convert all formats from namespace versioned CTO 25`] = `
 {
   "key": "org/acme/hr/Contractor.java",
   "value": "// this code is generated and should not be modified
@@ -1627,7 +4923,7 @@ public class Contractor extends Person {
 }
 `;
 
-exports[`codegen #formats check we can convert all formats to CTO 26`] = `
+exports[`codegen #formats check we can convert all formats from namespace versioned CTO 26`] = `
 {
   "key": "org/acme/hr/Manager.java",
   "value": "// this code is generated and should not be modified
@@ -1661,7 +4957,7 @@ public class Manager extends Employee {
 }
 `;
 
-exports[`codegen #formats check we can convert all formats to CTO 27`] = `
+exports[`codegen #formats check we can convert all formats from namespace versioned CTO 27`] = `
 {
   "key": "org/acme/hr/CompanyEvent.java",
   "value": "// this code is generated and should not be modified
@@ -1680,7 +4976,7 @@ public class CompanyEvent extends Event {
 }
 `;
 
-exports[`codegen #formats check we can convert all formats to CTO 28`] = `
+exports[`codegen #formats check we can convert all formats from namespace versioned CTO 28`] = `
 {
   "key": "org/acme/hr/Onboarded.java",
   "value": "// this code is generated and should not be modified
@@ -1706,7 +5002,7 @@ public class Onboarded extends CompanyEvent {
 }
 `;
 
-exports[`codegen #formats check we can convert all formats to CTO 29`] = `
+exports[`codegen #formats check we can convert all formats from namespace versioned CTO 29`] = `
 {
   "key": "org/acme/hr/ChangeOfAddress.java",
   "value": "// this code is generated and should not be modified
@@ -1739,7 +5035,7 @@ public class ChangeOfAddress extends Transaction {
 }
 `;
 
-exports[`codegen #formats check we can convert all formats to CTO 30`] = `
+exports[`codegen #formats check we can convert all formats from namespace versioned CTO 30`] = `
 {
   "key": "model.gql",
   "value": "directive @resource on OBJECT | FIELD_DEFINITION
@@ -1850,7 +5146,7 @@ type ChangeOfAddress {
 }
 `;
 
-exports[`codegen #formats check we can convert all formats to CTO 31`] = `
+exports[`codegen #formats check we can convert all formats from namespace versioned CTO 31`] = `
 {
   "key": "concerto@1.0.0.cs",
   "value": "namespace AccordProject.Concerto;
@@ -1898,7 +5194,7 @@ public abstract class Event : Concept {
 }
 `;
 
-exports[`codegen #formats check we can convert all formats to CTO 32`] = `
+exports[`codegen #formats check we can convert all formats from namespace versioned CTO 32`] = `
 {
   "key": "concerto.cs",
   "value": "namespace AccordProject.Concerto;
@@ -1942,7 +5238,7 @@ public abstract class Event : Concept {
 }
 `;
 
-exports[`codegen #formats check we can convert all formats to CTO 33`] = `
+exports[`codegen #formats check we can convert all formats from namespace versioned CTO 33`] = `
 {
   "key": "org.acme.hr@1.0.0.cs",
   "value": "namespace org.acme.hr;
@@ -2068,7 +5364,7 @@ public class ChangeOfAddress : Transaction {
 }
 `;
 
-exports[`codegen #formats check we can convert all formats to CTO 34`] = `
+exports[`codegen #formats check we can convert all formats from namespace versioned CTO 34`] = `
 {
   "key": "concerto.csdl",
   "value": "<?xml version="1.0"?>
@@ -2101,7 +5397,7 @@ exports[`codegen #formats check we can convert all formats to CTO 34`] = `
 }
 `;
 
-exports[`codegen #formats check we can convert all formats to CTO 35`] = `
+exports[`codegen #formats check we can convert all formats from namespace versioned CTO 35`] = `
 {
   "key": "org.acme.hr.csdl",
   "value": "<?xml version="1.0"?>
@@ -2239,7 +5535,7 @@ exports[`codegen #formats check we can convert all formats to CTO 35`] = `
 }
 `;
 
-exports[`codegen #formats check we can convert all formats to CTO 36`] = `
+exports[`codegen #formats check we can convert all formats from namespace versioned CTO 36`] = `
 {
   "key": "model.mmd",
   "value": "classDiagram
@@ -2356,7 +5652,7 @@ ChangeOfAddress --|> Transaction
 }
 `;
 
-exports[`codegen #formats check we can convert all formats to CTO 37`] = `
+exports[`codegen #formats check we can convert all formats from namespace versioned CTO 37`] = `
 {
   "key": "models.md",
   "value": "# Namespace org.acme.hr@1.0.0
@@ -2495,7 +5791,7 @@ ChangeOfAddress --|> Transaction
 }
 `;
 
-exports[`codegen #formats check we can convert all formats to CTO 38`] = `
+exports[`codegen #formats check we can convert all formats from namespace versioned CTO 38`] = `
 {
   "key": "org.acme.hr.v1_0_0.proto",
   "value": "syntax = "proto3";
@@ -2629,7 +5925,7 @@ message ChangeOfAddress {
 }
 `;
 
-exports[`codegen #formats check we can convert all formats to CTO 39`] = `
+exports[`codegen #formats check we can convert all formats from namespace versioned CTO 39`] = `
 {
   "key": "openapi.json",
   "value": "{


### PR DESCRIPTION
Signed-off-by: Dan Selman <danscode@selman.org>

# Closes #568 

Fixes the protobuf visitor so that it works with unversioned namespaces.

### Changes
- Fix to visitor
- Adds a test to ensure all visitors are tested with a versioned CTO file as well as an unversioned CTO file

### Flags
<!--- Provide context or concerns a reviewer should be aware of -->
- <ONE>
- <TWO>

### Screenshots or Video
<!--- Provide an easily accessible demonstration of the changes, if applicable -->

### Related Issues
- Issue #<NUMBER>
- Pull Request #<NUMBER>

### Author Checklist
- [ ] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [ ] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ ] Merging to `main` from `fork:branchname`
