### PR TITLE
feat(core): infer $class when obvious

### DIFF
--- a/packages/concerto-core/lib/serializer/jsonpopulator.js
+++ b/packages/concerto-core/lib/serializer/jsonpopulator.js
@@ -209,7 +209,16 @@ class JSONPopulator {
             }
 
             // This throws if the type does not exist.
-            const classDeclaration = parameters.modelManager.getType(typeName);
+            let classDeclaration = parameters.modelManager.getType(typeName);
+
+            // It's possible that classDeclaration is abstract, however, if there's only one concrete
+            // subclass we can choose that instead
+            const subclasses = classDeclaration.getAssignableClassDeclarations()
+                .filter(clazz => !clazz.isAbstract());
+            if (subclasses.length === 1){
+                typeName = subclasses[0].getFullyQualifiedName();
+                classDeclaration = parameters.modelManager.getType(typeName);
+            }
 
             // create a new instance, using the identifier field name as the ID.
             let subResource = null;

--- a/packages/concerto-core/lib/serializer/jsonpopulator.js
+++ b/packages/concerto-core/lib/serializer/jsonpopulator.js
@@ -212,7 +212,7 @@ class JSONPopulator {
             let classDeclaration = parameters.modelManager.getType(typeName);
 
             // It's possible that classDeclaration is abstract, however, if there's only one concrete
-            // subclass we can choose that instead
+            // class/subclass we can choose that instead
             const subclasses = classDeclaration.getAssignableClassDeclarations()
                 .filter(clazz => !clazz.isAbstract());
             if (subclasses.length === 1){

--- a/packages/concerto-core/lib/serializer/objectvalidator.js
+++ b/packages/concerto-core/lib/serializer/objectvalidator.js
@@ -120,6 +120,15 @@ class ObjectValidator {
 
         const obj = parameters.stack.pop();
 
+        if (!obj.$class){
+            // Choose the only concrete subclass if it exists
+            const subclasses = classDeclaration.getAssignableClassDeclarations()
+                .filter(clazz => !clazz.isAbstract());
+            if (subclasses.length === 1){
+                obj.$class = subclasses[0].getFullyQualifiedName();
+            }
+        }
+
         if(this.concerto.isIdentifiable(obj)) {
             parameters.rootResourceIdentifier = this.concerto.getFullyQualifiedIdentifier(obj);
         }
@@ -326,6 +335,13 @@ class ObjectValidator {
         else {
             // a field that points to a transaction, asset, participant...
             let classDeclaration = this.concerto.getModelManager().getType(field.getFullyQualifiedTypeName());
+            if (!obj.$class){
+                const subclasses = classDeclaration.getAssignableClassDeclarations()
+                    .filter(clazz => !clazz.isAbstract());
+                if (subclasses.length === 1){
+                    obj.$class = subclasses[0].getFullyQualifiedName();
+                }
+            }
             try {
                 classDeclaration = this.concerto.getModelManager().getType(obj.$class);
             } catch (err) {

--- a/packages/concerto-core/lib/serializer/objectvalidator.js
+++ b/packages/concerto-core/lib/serializer/objectvalidator.js
@@ -121,7 +121,7 @@ class ObjectValidator {
         const obj = parameters.stack.pop();
 
         if (!obj.$class){
-            // Choose the only concrete subclass if it exists
+            // Choose the only concrete class/subclass if it exists
             const subclasses = classDeclaration.getAssignableClassDeclarations()
                 .filter(clazz => !clazz.isAbstract());
             if (subclasses.length === 1){

--- a/packages/concerto-core/test/serializer/objectvalidator.js
+++ b/packages/concerto-core/test/serializer/objectvalidator.js
@@ -81,6 +81,29 @@ describe('ObjectValidator', function () {
             }).should.throw(/Missing concerto instance/);
         });
     });
+
+    describe('#visit', () => {
+        it('should infer $class when it can be determined from the context', () => {
+            const data = {
+                // $class : 'test.Vehicle',
+                color: 'red',
+                wheels : [{
+                    // $class : 'test.Wheel',
+                    brand : 'Michelin'
+                }],
+                owner: {
+                    // $class : 'test.Person',
+                    email: 'foo@bar.com'
+                }
+            };
+            const parameters = {
+                stack: new TypedStack(data),
+            };
+            objectValidator.visit(concerto.getModelManager().getType('test.Vehicle'), parameters);
+        });
+    });
+
+
     describe('#checkEnum', () => {
         it('should fail if instance is not an array', () => {
             const data = {


### PR DESCRIPTION
<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #542 
This change allows us to validate and deserialize JSON objects where the root type is known, but where no $class properties for nested objects are provided. This will work for basic cases where there is only one possible concrete subtype. 

For example, an object such as this will validate provided that we tell the validator what the root type is.

```json
{
    "$class" : "test.Vehicle",
    "color": "red",
    "wheels" : [{
        "brand" : "Michelin"
    }],
    "owner": {
        "email": "foo@bar.com"
    }
}
```

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [x] Merging to `main` from `fork:branchname`
