### PR TITLE
feat(core): scalar inline defaults

### DIFF
--- a/packages/concerto-core/lib/introspect/field.js
+++ b/packages/concerto-core/lib/introspect/field.js
@@ -195,6 +195,11 @@ class Field extends Property {
         }
 
         fieldAst.name = this.ast.name;
+
+        if (this.getDefaultValue()) {
+            fieldAst.defaultValue = this.getDefaultValue();
+        }
+
         this.scalarField = new Field(this.getParent(), fieldAst);
         return this.scalarField;
     }

--- a/packages/concerto-cto/test/cto/scalar.cto
+++ b/packages/concerto-cto/test/cto/scalar.cto
@@ -66,3 +66,15 @@ concept Person identified by ssn {
   o SSN ssn
   o String givenName
 }
+
+scalar ExtendedSSN extends String regex=/\d{3}-\d{2}-\{4}+/
+
+concept PersonWithExtendedSsn identified by ssn {
+  o ExtendedSSN ssn default="999-99-9999"
+  o String givenName
+}
+
+concept PersonWithOverriddenExtendedSsn identified by ssn {
+  o SSN ssn default="999-99-9999"
+  o String givenName
+}

--- a/packages/concerto-cto/test/cto/scalar.json
+++ b/packages/concerto-cto/test/cto/scalar.json
@@ -351,6 +351,71 @@
                 "$class": "concerto.metamodel@1.0.0.IdentifiedBy",
                 "name": "ssn"
             }
+        },
+        {
+            "$class": "concerto.metamodel@1.0.0.StringScalar",
+            "validator": {
+                "$class": "concerto.metamodel@1.0.0.StringRegexValidator",
+                "pattern": "\\d{3}-\\d{2}-\\{4}+",
+                "flags": ""
+            },
+            "name": "ExtendedSSN"
+        },
+        {
+            "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+            "name": "PersonWithExtendedSsn",
+            "isAbstract": false,
+            "properties": [
+                {
+                    "$class": "concerto.metamodel@1.0.0.ObjectProperty",
+                    "name": "ssn",
+                    "type": {
+                        "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                        "name": "ExtendedSSN"
+                    },
+                    "isArray": false,
+                    "isOptional": false,
+                    "defaultValue": "999-99-9999"
+                },
+                {
+                    "$class": "concerto.metamodel@1.0.0.StringProperty",
+                    "name": "givenName",
+                    "isArray": false,
+                    "isOptional": false
+                }
+            ],
+            "identified": {
+                "$class": "concerto.metamodel@1.0.0.IdentifiedBy",
+                "name": "ssn"
+            }
+        },
+        {
+            "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+            "name": "PersonWithOverriddenExtendedSsn",
+            "isAbstract": false,
+            "properties": [
+                {
+                    "$class": "concerto.metamodel@1.0.0.ObjectProperty",
+                    "name": "ssn",
+                    "type": {
+                        "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                        "name": "SSN"
+                    },
+                    "isArray": false,
+                    "isOptional": false,
+                    "defaultValue": "999-99-9999"
+                },
+                {
+                    "$class": "concerto.metamodel@1.0.0.StringProperty",
+                    "name": "givenName",
+                    "isArray": false,
+                    "isOptional": false
+                }
+            ],
+            "identified": {
+                "$class": "concerto.metamodel@1.0.0.IdentifiedBy",
+                "name": "ssn"
+            }
         }
     ]
 }


### PR DESCRIPTION
# Closes #580 

> 💡 Proposed by Adam Milazzo.

We would like to be able to extend a scalar’s `default` property inside a class after its definition.

Example:

```
scalar SSN extends String regex=/\d{3}-\d{2}-\{4}+/

concept Person identified by ssn {
    o SSN ssn default="999-99-9999"
}
```

This would be effectively the same as:

```
scalar SSN extends String default="999-99-9999" regex=/\d{3}-\d{2}-\{4}+/

concept Person identified by ssn {
    o SSN ssn
}
```

Additionally, if a `default` is already defined, we would like to be able to override it inline.

Example:

```
scalar SSN extends String default="000-00-0000" regex=/\d{3}-\d{2}-\{4}+/

concept Person identified by ssn {
    o SSN ssn default="999-99-9999"
}
```

This would be effectively the same as:

```
scalar SSN extends String default="999-99-9999" regex=/\d{3}-\d{2}-\{4}+/

concept Person identified by ssn {
    o SSN ssn
}
```

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [x] Extend the documentation, if necessary
- [x] Merging to `main` from `fork:branchname`
