### PR TITLE
feat(core): relax reserved property names

### DIFF
--- a/packages/concerto-core/lib/introspect/property.js
+++ b/packages/concerto-core/lib/introspect/property.js
@@ -29,8 +29,6 @@ if (global === undefined) {
 /* eslint-enable no-unused-vars */
 
 
-const RESERVED_PROPERTY_NAMES = ['null', 'true', 'false'];
-
 /**
  * Property representing an attribute of a class declaration,
  * either a Field or a Relationship.
@@ -76,10 +74,6 @@ class Property extends Decorated {
      */
     process() {
         super.process();
-
-        if (RESERVED_PROPERTY_NAMES.includes(this.ast.name)){
-            throw new Error(`Validator error for field 'name'. '${this.ast.name}' is a reserved name.`);
-        }
 
         this.name = this.ast.name;
         this.decorator = null;

--- a/packages/concerto-core/test/introspect/property.js
+++ b/packages/concerto-core/test/introspect/property.js
@@ -45,15 +45,13 @@ describe('Property', () => {
             }).should.throw(/No name for type/);
         });
 
-        it('throw an error for a reserved name', () => {
-            (() => {
-                new Property(mockClassDeclaration, {
-                    $class: `${MetaModelNamespace}.StringProperty`,
-                    name: 'null'
-                });
-            }).should.throw(/Validator error for field 'name'. 'null' is a reserved name./);
+        it('should not throw for an identifier named null', () => {
+            let p = new Property(mockClassDeclaration, {
+                $class: `${MetaModelNamespace}.StringProperty`,
+                name: 'null'
+            });
+            p.name.should.equal('null');
         });
-
 
         it('should save the incoming property type', () => {
             let p = new Property(mockClassDeclaration, {

--- a/packages/concerto-cto/lib/parser.js
+++ b/packages/concerto-cto/lib/parser.js
@@ -1697,32 +1697,15 @@ function peg$parse(input, options) {
   }
 
   function peg$parseIdentifier() {
-    var s0, s1, s2;
+    var s0, s1;
 
     s0 = peg$currPos;
-    s1 = peg$currPos;
-    peg$silentFails++;
-    s2 = peg$parseReservedWord();
-    peg$silentFails--;
-    if (s2 === peg$FAILED) {
-      s1 = undefined;
-    } else {
-      peg$currPos = s1;
-      s1 = peg$FAILED;
-    }
+    s1 = peg$parseIdentifierName();
     if (s1 !== peg$FAILED) {
-      s2 = peg$parseIdentifierName();
-      if (s2 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s0 = peg$f1(s2);
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
+      peg$savedPos = s0;
+      s1 = peg$f1(s1);
     }
+    s0 = s1;
 
     return s0;
   }
@@ -1760,42 +1743,45 @@ function peg$parse(input, options) {
 
     s0 = peg$parseUnicodeLetter();
     if (s0 === peg$FAILED) {
-      if (input.charCodeAt(peg$currPos) === 36) {
-        s0 = peg$c14;
-        peg$currPos++;
-      } else {
-        s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e20); }
-      }
+      s0 = peg$parseNd();
       if (s0 === peg$FAILED) {
-        if (input.charCodeAt(peg$currPos) === 95) {
-          s0 = peg$c15;
+        if (input.charCodeAt(peg$currPos) === 36) {
+          s0 = peg$c14;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$e21); }
+          if (peg$silentFails === 0) { peg$fail(peg$e20); }
         }
         if (s0 === peg$FAILED) {
-          s0 = peg$currPos;
-          if (input.charCodeAt(peg$currPos) === 92) {
-            s1 = peg$c16;
+          if (input.charCodeAt(peg$currPos) === 95) {
+            s0 = peg$c15;
             peg$currPos++;
           } else {
-            s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$e22); }
+            s0 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$e21); }
           }
-          if (s1 !== peg$FAILED) {
-            s2 = peg$parseUnicodeEscapeSequence();
-            if (s2 !== peg$FAILED) {
-              peg$savedPos = s0;
-              s0 = peg$f3(s2);
+          if (s0 === peg$FAILED) {
+            s0 = peg$currPos;
+            if (input.charCodeAt(peg$currPos) === 92) {
+              s1 = peg$c16;
+              peg$currPos++;
+            } else {
+              s1 = peg$FAILED;
+              if (peg$silentFails === 0) { peg$fail(peg$e22); }
+            }
+            if (s1 !== peg$FAILED) {
+              s2 = peg$parseUnicodeEscapeSequence();
+              if (s2 !== peg$FAILED) {
+                peg$savedPos = s0;
+                s0 = peg$f3(s2);
+              } else {
+                peg$currPos = s0;
+                s0 = peg$FAILED;
+              }
             } else {
               peg$currPos = s0;
               s0 = peg$FAILED;
             }
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
           }
         }
       }
@@ -1811,25 +1797,22 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$parseUnicodeCombiningMark();
       if (s0 === peg$FAILED) {
-        s0 = peg$parseNd();
+        s0 = peg$parsePc();
         if (s0 === peg$FAILED) {
-          s0 = peg$parsePc();
+          if (input.charCodeAt(peg$currPos) === 8204) {
+            s0 = peg$c17;
+            peg$currPos++;
+          } else {
+            s0 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$e23); }
+          }
           if (s0 === peg$FAILED) {
-            if (input.charCodeAt(peg$currPos) === 8204) {
-              s0 = peg$c17;
+            if (input.charCodeAt(peg$currPos) === 8205) {
+              s0 = peg$c18;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$e23); }
-            }
-            if (s0 === peg$FAILED) {
-              if (input.charCodeAt(peg$currPos) === 8205) {
-                s0 = peg$c18;
-                peg$currPos++;
-              } else {
-                s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$e24); }
-              }
+              if (peg$silentFails === 0) { peg$fail(peg$e24); }
             }
           }
         }

--- a/packages/concerto-cto/lib/parser.pegjs
+++ b/packages/concerto-cto/lib/parser.pegjs
@@ -140,7 +140,7 @@ SingleLineComment
   = "//" (!LineTerminator SourceCharacter)*
 
 Identifier
-  = !ReservedWord name:IdentifierName { return name; }
+  = name:IdentifierName { return name; }
 
 IdentifierName "identifier"
   = first:IdentifierStart rest:IdentifierPart* {
@@ -152,6 +152,7 @@ IdentifierName "identifier"
 
 IdentifierStart
   = UnicodeLetter
+  / UnicodeDigit
   / "$"
   / "_"
   / "\\" sequence:UnicodeEscapeSequence { return sequence; }
@@ -159,7 +160,6 @@ IdentifierStart
 IdentifierPart
   = IdentifierStart
   / UnicodeCombiningMark
-  / UnicodeDigit
   / UnicodeConnectorPunctuation
   / "\u200C"
   / "\u200D"


### PR DESCRIPTION
<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
<!--- Provide an overall summary of the pull request -->
Partially addresses Issue #572 

This PR relaxes the parsing and core API restrictions on identifier names. The following names are now permitted:
- `false`
- `true`
- `null`
- `1`
- `1abc`

### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
- Adds explicit test cases which give good coverage of valid & invalid identifiers
- Changes Parser rules to allow NullLiteral and BooleanLiterals as identifiers
- Changes Parser rules to allow identifiers to begin with UnicodeNumber values
- Removes the explicit reserved keyword check in the core API. This was only introduced recently to address a ReDOS limitation when generating sample JSON files regexes (negative lookahead was not supported). #484 

### Flags
<!--- Provide context or concerns a reviewer should be aware of -->
- I believe that this should be considered a non-breaking change, as it loosens the constraints on identifiers.

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [x] Merging to `main` from `fork:branchname`
