### PR TITLE
fix(performance): refactoring inefficient duplication checking nested for loops

### DIFF
--- a/packages/concerto-core/lib/introspect/decorated.js
+++ b/packages/concerto-core/lib/introspect/decorated.js
@@ -110,17 +110,28 @@ class Decorated {
      * @protected
      */
     validate(...args) {
-        for(let n=0; n < this.decorators.length; n++) {
-            let decorator = this.decorators[n];
-            decorator.validate();
+        if (this.decorators && this.decorators.length > 0) {
+            for(let n=0; n < this.decorators.length; n++) {
+                this.decorators[n].validate();
+            }
 
             // check we don't have this decorator twice
-            for(let i=n+1; i < this.decorators.length; i++) {
-                let otherDecorator = this.decorators[i];
-                if(decorator.getName() === otherDecorator.getName()) {
-                    let modelFile = this.getModelFile();
-                    throw new IllegalModelException(`Duplicate decorator ${decorator.getName()}`,modelFile, this.ast.location);
-                }
+            const decoratorNames = this.decorators.map(
+                d => d.getName()
+            );
+            const uniqueDecoratorNames = new Set(decoratorNames);
+
+            if (uniqueDecoratorNames.size !== this.decorators.length) {
+                const duplicateElements = decoratorNames
+                    .filter(
+                        (item, index) => decoratorNames.indexOf(item) !== index
+                    );
+                const modelFile = this.getModelFile();
+                throw new IllegalModelException(
+                    `Duplicate decorator ${duplicateElements[0]}`,
+                    modelFile,
+                    this.ast.location,
+                );
             }
         }
     }

--- a/packages/concerto-core/lib/introspect/scalardeclaration.js
+++ b/packages/concerto-core/lib/introspect/scalardeclaration.js
@@ -136,16 +136,18 @@ class ScalarDeclaration extends Decorated {
         super.validate();
 
         const declarations = this.getModelFile().getAllDeclarations();
-        for (let n = 0; n < declarations.length; n++) {
-            let declaration = declarations[n];
+        const declarationNames = declarations.map(
+            d => d.getFullyQualifiedName()
+        );
+        const uniqueNames = new Set(declarationNames);
 
-            // check we don't have an asset with the same name
-            for (let i = n + 1; i < declarations.length; i++) {
-                let otherDeclaration = declarations[i];
-                if (declaration.getFullyQualifiedName() === otherDeclaration.getFullyQualifiedName()) {
-                    throw new IllegalModelException(`Duplicate class name ${declaration.getName()}`);
-                }
-            }
+        if (uniqueNames.size !== declarations.length) {
+            const duplicateElements = declarationNames.filter(
+                (item, index) => declarationNames.indexOf(item) !== index
+            );
+            throw new IllegalModelException(
+                `Duplicate class name ${duplicateElements[0]}`
+            );
         }
     }
 


### PR DESCRIPTION
Refactoring inefficient duplicate-checking nested `for` loops. The refactoring methodology follows @mttrbrts's (https://github.com/accordproject/concerto/pull/582) in replacing the nested `for` loops with ES6's `Set` structures.

Inefficiency discovery methodology: inspecting all loops in codebase.

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [x] Merging to `main` from `fork:branchname`
