### PR TITLE
fix(core): enforce identifier validation on AST JSON

### DIFF
--- a/packages/concerto-core/lib/introspect/classdeclaration.js
+++ b/packages/concerto-core/lib/introspect/classdeclaration.js
@@ -79,6 +79,12 @@ class ClassDeclaration extends Decorated {
     process() {
         super.process();
 
+        if (!ModelUtil.isValidIdentifier(this.ast.name)){
+            throw new IllegalModelException(`Invalid class name '${this.ast.name}'`, this.modelFile, this.ast.location);
+        }
+
+        const reservedProperties = ['$class', '$identifier', '$timestamp'];
+
         this.name = this.ast.name;
         this.properties = [];
         this.superType = null;
@@ -111,8 +117,8 @@ class ClassDeclaration extends Decorated {
         for (let n = 0; n < this.ast.properties.length; n++) {
             let thing = this.ast.properties[n];
 
-            if(thing.name && thing.name.startsWith('$')) {
-                throw new IllegalModelException(`Invalid field name ${thing.name}`, this.modelFile, this.ast.location);
+            if(reservedProperties.includes(thing.name)) {
+                throw new IllegalModelException(`Invalid field name '${thing.name}'`, this.modelFile, this.ast.location);
             }
 
             if (thing.$class === `${MetaModelNamespace}.RelationshipProperty`) {

--- a/packages/concerto-core/lib/introspect/modelfile.js
+++ b/packages/concerto-core/lib/introspect/modelfile.js
@@ -679,6 +679,14 @@ class ModelFile extends Decorated {
      */
     fromAst(ast) {
         const nsInfo = ModelUtil.parseNamespace(ast.namespace);
+
+        const namespaceParts = nsInfo.name.split('.');
+        namespaceParts.forEach(part => {
+            if (!ModelUtil.isValidIdentifier(part)){
+                throw new IllegalModelException(`Invalid namespace part '${part}'`, this.modelFile, this.ast.location);
+            }
+        });
+
         this.namespace = ast.namespace;
         this.version = nsInfo.version;
 

--- a/packages/concerto-core/lib/introspect/property.js
+++ b/packages/concerto-core/lib/introspect/property.js
@@ -17,6 +17,7 @@
 const { MetaModelNamespace } = require('@accordproject/concerto-metamodel');
 
 const ModelUtil = require('../modelutil');
+const IllegalModelException = require('./illegalmodelexception');
 const Decorated = require('./decorated');
 
 // Types needed for TypeScript generation.
@@ -74,6 +75,10 @@ class Property extends Decorated {
      */
     process() {
         super.process();
+
+        if (!ModelUtil.isValidIdentifier(this.ast.name)){
+            throw new IllegalModelException(`Invalid property name '${this.ast.name}'`, this.modelFile, this.ast.location);
+        }
 
         this.name = this.ast.name;
         this.decorator = null;

--- a/packages/concerto-core/lib/modelutil.js
+++ b/packages/concerto-core/lib/modelutil.js
@@ -18,6 +18,8 @@ const { MetaModelUtil } = require('@accordproject/concerto-metamodel');
 const semver = require('semver');
 const Globalize = require('./globalize');
 
+const ID_REGEX = /^(\p{Lu}|\p{Ll}|\p{Lt}|\p{Lm}|\p{Lo}|\p{Nl}|\$|_|\\u[0-9A-Fa-f]{4})(?:\p{Lu}|\p{Ll}|\p{Lt}|\p{Lm}|\p{Lo}|\p{Nl}|\$|_|\\u[0-9A-Fa-f]{4}|\p{Mn}|\p{Mc}|\p{Nd}|\p{Pc}|\u200C|\u200D)*$/u;
+
 /**
  * Internal Model Utility Class
  * <p><a href="./diagrams-private/modelutil.svg"><img src="./diagrams-private/modelutil.svg" style="height:100%;"/></a></p>
@@ -32,14 +34,12 @@ class ModelUtil {
      * @return {string} - the string after the last dot
      */
     static getShortName(fqn) {
-        //console.log('toShortName ' + name );
         let result = fqn;
         let dotIndex = fqn.lastIndexOf('.');
         if (dotIndex > -1) {
             result = fqn.substr(dotIndex + 1);
         }
 
-        //console.log('result ' + result );
         return result;
     }
 
@@ -182,6 +182,15 @@ class ModelUtil {
         const modelFile = scalar.getParent().getModelFile();
         const declaration = modelFile.getType(scalar.getType());
         return (declaration !== null && declaration.isScalarDeclaration?.());
+    }
+
+    /**
+     * Return true if the name is a valid Concerto identifier
+     * @param {string} name - the name of the identifier to test.
+     * @returns {boolean} true if the identifier is valid.
+     */
+    static isValidIdentifier(name) {
+        return ID_REGEX.test(name);
     }
 
     /**

--- a/packages/concerto-core/test/introspect/classdeclaration.js
+++ b/packages/concerto-core/test/introspect/classdeclaration.js
@@ -58,6 +58,15 @@ describe('ClassDeclaration', () => {
             }).should.throw(/Unrecognised model element/);
         });
 
+        it('should throw for a bad identifier', () => {
+            (() => {
+                new ClassDeclaration(modelFile, {
+                    name: '2nd',
+                    properties: []
+                });
+            }).should.throw(/Invalid class name '2nd'/);
+        });
+
     });
 
     describe('#validate', () => {

--- a/packages/concerto-core/test/introspect/identifieddeclaration.js
+++ b/packages/concerto-core/test/introspect/identifieddeclaration.js
@@ -182,7 +182,22 @@ asset Order identified by sku {
                 asset Order {
                     o String $identifier
                 }`, 'test.cto');
-            }).should.throw(/Invalid field name \$identifier/);
+            }).should.throw(/Invalid field name '\$identifier'/);
+        });
+
+        it('should allow field called $foo', () => {
+            const mm = new ModelManager();
+
+            mm.addCTOModel( `
+                namespace test
+
+                asset Order {
+                    o String $foo
+                }`, 'test.cto');
+
+            const order = mm.getType('test.Order');
+            order.should.not.be.null;
+            order.getProperties().length.should.equal(2); // XXX Assets always have an identifier
         });
 
         it('should allow abstract assets without an identifier', () => {

--- a/packages/concerto-core/test/introspect/modelfile.js
+++ b/packages/concerto-core/test/introspect/modelfile.js
@@ -136,6 +136,20 @@ describe('ModelFile', () => {
             (mf.getImportURI('org.doge.Foo') === null).should.be.true;
         });
 
+        it('should throw for a bad namespace part', () => {
+            const ast = {
+                $class: `${MetaModelNamespace}.Model`,
+                namespace: 'org.foo-bar',
+                imports: [],
+                declarations: [ ]
+            };
+            sandbox.stub(Parser, 'parse').returns(ast);
+
+            (() => {
+                ParserUtil.newModelFile(modelManager, 'fake definitions');
+            }).should.throw(/Invalid namespace part 'foo-bar'/);
+        });
+
         it('should throw for a wildcard import when strict is true', () => {
             const strictModelManager = new ModelManager({ strict: true });
 

--- a/packages/concerto-core/test/introspect/property.js
+++ b/packages/concerto-core/test/introspect/property.js
@@ -96,7 +96,7 @@ describe('Property', () => {
                     $class: `${MetaModelNamespace}.StringProperty`,
                     name: '1st',
                 });
-            }).should.throw(/Invalid property name '1st'/)
+            }).should.throw(/Invalid property name '1st'/);
         });
 
     });

--- a/packages/concerto-core/test/introspect/property.js
+++ b/packages/concerto-core/test/introspect/property.js
@@ -90,6 +90,15 @@ describe('Property', () => {
             p.array.should.equal(true);
         });
 
+        it('should throw for a bad property identifier', () => {
+            (() => {
+                new Property(mockClassDeclaration, {
+                    $class: `${MetaModelNamespace}.StringProperty`,
+                    name: '1st',
+                });
+            }).should.throw(/Invalid property name '1st'/)
+        });
+
     });
 
     describe('#hasInstance', () => {

--- a/packages/concerto-core/types/lib/modelutil.d.ts
+++ b/packages/concerto-core/types/lib/modelutil.d.ts
@@ -99,6 +99,12 @@ declare class ModelUtil {
      */
     private static isScalar;
     /**
+     * Return true if the name is a valid Concerto identifier
+     * @param {string} name - the name of the identifier to test.
+     * @returns {boolean} true if the identifier is valid.
+     */
+    static isValidIdentifier(name: string): boolean;
+    /**
      * Get the fully qualified name of a type.
      * @param {string} namespace - namespace of the type.
      * @param {string} type - short name of the type.


### PR DESCRIPTION
<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
Related to #581 

### Changes
- Modifies the Core API to validate identifiers for Class Declarations, Properties, Enum values, and Namespace parts.
- Also, loosens a restriction in the code that prevented all user-defined properties beginning with a `$`. This now aligns with the metamodel.

### Flags
- This is a bug fix, to address a gap in previously released code, however, it has the potential to break clients who relied upon the previous behaviour.
- The ID_REGEX is duplicated between the metamodel and the API, ideally, we should reuse the same definition. One solution is to validate the JSON AST against the metamodel using Concerto. However, for simplicity I've followed the existing pattern of implementing semantic checks in the introspection API.

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [x] Merging to `main` from `fork:branchname`
