### PR TITLE
fix: JSON Schema generation improvements for base types #592

### DIFF
--- a/packages/concerto-tools/test/codegen/__snapshots__/codegen.js.snap
+++ b/packages/concerto-tools/test/codegen/__snapshots__/codegen.js.snap
@@ -390,7 +390,14 @@ exports[`codegen #formats check we can convert all formats from namespace unvers
         "companyAssets": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/org.acme.hr.Equipment"
+            "anyOf": [
+              {
+                "$ref": "#/definitions/org.acme.hr.Equipment"
+              },
+              {
+                "$ref": "#/definitions/org.acme.hr.Laptop"
+              }
+            ]
           }
         },
         "manager": {
@@ -542,7 +549,14 @@ exports[`codegen #formats check we can convert all formats from namespace unvers
         "companyAssets": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/org.acme.hr.Equipment"
+            "anyOf": [
+              {
+                "$ref": "#/definitions/org.acme.hr.Equipment"
+              },
+              {
+                "$ref": "#/definitions/org.acme.hr.Laptop"
+              }
+            ]
           }
         },
         "manager": {
@@ -3109,7 +3123,14 @@ exports[`codegen #formats check we can convert all formats from namespace unvers
           "companyAssets": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/org.acme.hr.Equipment"
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/org.acme.hr.Equipment"
+                },
+                {
+                  "$ref": "#/components/schemas/org.acme.hr.Laptop"
+                }
+              ]
             }
           },
           "manager": {
@@ -3261,7 +3282,14 @@ exports[`codegen #formats check we can convert all formats from namespace unvers
           "companyAssets": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/org.acme.hr.Equipment"
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/org.acme.hr.Equipment"
+                },
+                {
+                  "$ref": "#/components/schemas/org.acme.hr.Laptop"
+                }
+              ]
             }
           },
           "manager": {
@@ -4227,7 +4255,14 @@ exports[`codegen #formats check we can convert all formats from namespace versio
         "companyAssets": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/org.acme.hr@1.0.0.Equipment"
+            "anyOf": [
+              {
+                "$ref": "#/definitions/org.acme.hr@1.0.0.Equipment"
+              },
+              {
+                "$ref": "#/definitions/org.acme.hr@1.0.0.Laptop"
+              }
+            ]
           }
         },
         "manager": {
@@ -4379,7 +4414,14 @@ exports[`codegen #formats check we can convert all formats from namespace versio
         "companyAssets": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/org.acme.hr@1.0.0.Equipment"
+            "anyOf": [
+              {
+                "$ref": "#/definitions/org.acme.hr@1.0.0.Equipment"
+              },
+              {
+                "$ref": "#/definitions/org.acme.hr@1.0.0.Laptop"
+              }
+            ]
           }
         },
         "manager": {
@@ -6946,7 +6988,14 @@ exports[`codegen #formats check we can convert all formats from namespace versio
           "companyAssets": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/org.acme.hr@1.0.0.Equipment"
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/org.acme.hr@1.0.0.Equipment"
+                },
+                {
+                  "$ref": "#/components/schemas/org.acme.hr@1.0.0.Laptop"
+                }
+              ]
             }
           },
           "manager": {
@@ -7098,7 +7147,14 @@ exports[`codegen #formats check we can convert all formats from namespace versio
           "companyAssets": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/org.acme.hr@1.0.0.Equipment"
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/org.acme.hr@1.0.0.Equipment"
+                },
+                {
+                  "$ref": "#/components/schemas/org.acme.hr@1.0.0.Laptop"
+                }
+              ]
             }
           },
           "manager": {


### PR DESCRIPTION
Signed-off-by: Dan Selman <danscode@selman.org>

# Closes #592

Updates the JSON Schema visitor to include an `anyOf` for polymorphic types.

### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
- <ONE>
- <TWO>

### Flags
<!--- Provide context or concerns a reviewer should be aware of -->
- <ONE>
- <TWO>

### Screenshots or Video
<!--- Provide an easily accessible demonstration of the changes, if applicable -->

### Related Issues
- Issue #<NUMBER>
- Pull Request #<NUMBER>

### Author Checklist
- [ ] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [ ] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ ] Merging to `main` from `fork:branchname`
