### PR TITLE
feat(tools): csharp codegen uuid support

### DIFF
--- a/packages/concerto-core/types/index.d.ts
+++ b/packages/concerto-core/types/index.d.ts
@@ -5,7 +5,6 @@ import Decorator = require("./lib/introspect/decorator");
 import DecoratorFactory = require("./lib/introspect/decoratorfactory");
 import DecoratorManager = require("./lib/decoratormanager");
 import ClassDeclaration = require("./lib/introspect/classdeclaration");
-import ScalarDeclaration = require("./lib/introspect/scalardeclaration");
 import IdentifiedDeclaration = require("./lib/introspect/identifieddeclaration");
 import AssetDeclaration = require("./lib/introspect/assetdeclaration");
 import ConceptDeclaration = require("./lib/introspect/conceptdeclaration");
@@ -40,4 +39,4 @@ export const version: {
     name: string;
     version: string;
 };
-export { SecurityException, IllegalModelException, TypeNotFoundException, Decorator, DecoratorFactory, DecoratorManager, ClassDeclaration, IdentifiedDeclaration, AssetDeclaration, ConceptDeclaration, EnumValueDeclaration, EventDeclaration, ParticipantDeclaration, TransactionDeclaration, Property, Field, EnumDeclaration, RelationshipDeclaration, Validator, NumberValidator, StringValidator, Typed, Identifiable, Relationship, Resource, Factory, Globalize, Introspector, ModelFile, ModelManager, Serializer, ModelUtil, ModelLoader, DateTimeUtil, Concerto, MetaModel, ScalarDeclaration };
+export { SecurityException, IllegalModelException, TypeNotFoundException, Decorator, DecoratorFactory, DecoratorManager, ClassDeclaration, IdentifiedDeclaration, AssetDeclaration, ConceptDeclaration, EnumValueDeclaration, EventDeclaration, ParticipantDeclaration, TransactionDeclaration, Property, Field, EnumDeclaration, RelationshipDeclaration, Validator, NumberValidator, StringValidator, Typed, Identifiable, Relationship, Resource, Factory, Globalize, Introspector, ModelFile, ModelManager, Serializer, ModelUtil, ModelLoader, DateTimeUtil, Concerto, MetaModel };

--- a/packages/concerto-core/types/index.d.ts
+++ b/packages/concerto-core/types/index.d.ts
@@ -5,6 +5,7 @@ import Decorator = require("./lib/introspect/decorator");
 import DecoratorFactory = require("./lib/introspect/decoratorfactory");
 import DecoratorManager = require("./lib/decoratormanager");
 import ClassDeclaration = require("./lib/introspect/classdeclaration");
+import ScalarDeclaration = require("./lib/introspect/scalardeclaration");
 import IdentifiedDeclaration = require("./lib/introspect/identifieddeclaration");
 import AssetDeclaration = require("./lib/introspect/assetdeclaration");
 import ConceptDeclaration = require("./lib/introspect/conceptdeclaration");
@@ -39,4 +40,4 @@ export const version: {
     name: string;
     version: string;
 };
-export { SecurityException, IllegalModelException, TypeNotFoundException, Decorator, DecoratorFactory, DecoratorManager, ClassDeclaration, IdentifiedDeclaration, AssetDeclaration, ConceptDeclaration, EnumValueDeclaration, EventDeclaration, ParticipantDeclaration, TransactionDeclaration, Property, Field, EnumDeclaration, RelationshipDeclaration, Validator, NumberValidator, StringValidator, Typed, Identifiable, Relationship, Resource, Factory, Globalize, Introspector, ModelFile, ModelManager, Serializer, ModelUtil, ModelLoader, DateTimeUtil, Concerto, MetaModel };
+export { SecurityException, IllegalModelException, TypeNotFoundException, Decorator, DecoratorFactory, DecoratorManager, ClassDeclaration, IdentifiedDeclaration, AssetDeclaration, ConceptDeclaration, EnumValueDeclaration, EventDeclaration, ParticipantDeclaration, TransactionDeclaration, Property, Field, EnumDeclaration, RelationshipDeclaration, Validator, NumberValidator, StringValidator, Typed, Identifiable, Relationship, Resource, Factory, Globalize, Introspector, ModelFile, ModelManager, Serializer, ModelUtil, ModelLoader, DateTimeUtil, Concerto, MetaModel, ScalarDeclaration };

--- a/packages/concerto-tools/lib/codegen/fromcto/csharp/csharpvisitor.js
+++ b/packages/concerto-tools/lib/codegen/fromcto/csharp/csharpvisitor.js
@@ -59,7 +59,7 @@ class CSharpVisitor {
         } else if (thing.isClassDeclaration?.()) {
             return this.visitClassDeclaration(thing, parameters);
         } else if (thing.isTypeScalar?.()) {
-            return this.visitField(thing.getScalarField(), parameters);
+            return this.visitScalarField(thing, parameters);
         } else if (thing.isField?.()) {
             return this.visitField(thing, parameters);
         } else if (thing.isRelationship?.()) {
@@ -235,7 +235,38 @@ class CSharpVisitor {
      * @return {Object} the result of visiting or null
      * @private
      */
+    visitScalarField(field, parameters) {
+        let fieldType;
+        let scalarField = field.getScalarField();
+        if (scalarField.getType() === 'String') {
+            const type = field.getParent().getModelFile().getType(field.getType());
+            if (type.getName() === 'UUID' && type.getNamespace().startsWith('concerto.scalar')) {
+                fieldType = 'UUID';
+            }
+        }
+        return this.writeField(field.getScalarField(), parameters, fieldType);
+    }
+
+    /**
+     * Visitor design pattern
+     * @param {Field} field - the object being visited
+     * @param {Object} parameters  - the parameter
+     * @return {Object} the result of visiting or null
+     * @private
+     */
     visitField(field, parameters) {
+        return this.writeField(field, parameters);
+    }
+
+    /**
+     * Write a field
+     * @param {Field} field - the object being visited
+     * @param {Object} parameters  - the parameter
+     * @param {string} [externalFieldType] - the external field type like UUID (optional)
+     * @return {Object} the result of visiting or null
+     * @private
+     */
+    writeField(field, parameters, externalFieldType) {
         // If no serlialization library is specified we default to the .NET one.
         // However, we also allow both options to be specified
         if (!parameters.useSystemTextJson && !parameters.useNewtonsoftJson){
@@ -258,11 +289,13 @@ class CSharpVisitor {
             parameters.fileWriter.writeLine(1, '[AccordProject.Concerto.Identifier()]');
         }
 
+        let fieldType = externalFieldType ? externalFieldType : field.getType();
+
         const lines = this.toCSharpProperty(
             'public',
             field.getParent()?.getName(),
             field.getName(),
-            field.getType()+nullableType,
+            fieldType+nullableType,
             array,
             '{ get; set; }',
             parameters
@@ -434,6 +467,8 @@ class CSharpVisitor {
             return 'long';
         case 'Integer':
             return 'int';
+        case 'UUID':
+            return 'Guid';
         default:
             return this.toCSharpIdentifier(undefined, type, parameters);
         }

--- a/packages/concerto-tools/lib/codegen/fromcto/csharp/csharpvisitor.js
+++ b/packages/concerto-tools/lib/codegen/fromcto/csharp/csharpvisitor.js
@@ -239,9 +239,8 @@ class CSharpVisitor {
         let fieldType;
         let scalarField = field.getScalarField();
         if (scalarField.getType() === 'String') {
-            const type = field.getParent().getModelFile().getType(field.getType());
-            if (type.getName() === 'UUID' && type.getNamespace().startsWith('concerto.scalar')) {
-                fieldType = 'UUID';
+            if(ModelUtil.removeNamespaceVersionFromFullyQualifiedName(field.getFullyQualifiedTypeName()) === 'concerto.scalar.UUID') {
+                fieldType = 'concerto.scalar.UUID';
             }
         }
         return this.writeField(field.getScalarField(), parameters, fieldType);
@@ -467,7 +466,7 @@ class CSharpVisitor {
             return 'long';
         case 'Integer':
             return 'int';
-        case 'UUID':
+        case 'concerto.scalar.UUID':
             return 'Guid';
         default:
             return this.toCSharpIdentifier(undefined, type, parameters);

--- a/packages/concerto-tools/lib/codegen/fromcto/csharp/csharpvisitor.js
+++ b/packages/concerto-tools/lib/codegen/fromcto/csharp/csharpvisitor.js
@@ -236,14 +236,8 @@ class CSharpVisitor {
      * @private
      */
     visitScalarField(field, parameters) {
-        let fieldType;
-        let scalarField = field.getScalarField();
-        if (scalarField.getType() === 'String') {
-            if(ModelUtil.removeNamespaceVersionFromFullyQualifiedName(field.getFullyQualifiedTypeName()) === 'concerto.scalar.UUID') {
-                fieldType = 'concerto.scalar.UUID';
-            }
-        }
-        return this.writeField(field.getScalarField(), parameters, fieldType);
+        const fieldType = ModelUtil.removeNamespaceVersionFromFullyQualifiedName(field.getFullyQualifiedTypeName());
+        return this.writeField(field.getScalarField(), parameters, fieldType === 'concerto.scalar.UUID' ? fieldType : null );
     }
 
     /**

--- a/packages/concerto-tools/test/codegen/fromcto/csharp/csharpvisitor.js
+++ b/packages/concerto-tools/test/codegen/fromcto/csharp/csharpvisitor.js
@@ -29,7 +29,6 @@ const ModelFile = require('@accordproject/concerto-core').ModelFile;
 const ModelManager = require('@accordproject/concerto-core').ModelManager;
 const RelationshipDeclaration = require('@accordproject/concerto-core').RelationshipDeclaration;
 const FileWriter = require('@accordproject/concerto-util').FileWriter;
-const ScalarDeclaration = require('@accordproject/concerto-core').ScalarDeclaration;
 
 describe('CSharpVisitor', function () {
     let csharpVisitor;
@@ -271,6 +270,54 @@ describe('CSharpVisitor', function () {
             file1.should.match(/namespace org.acme;/);
             file1.should.match(/class Thing/);
             file1.should.match(/public Guid ThingId/);
+        });
+
+        it('should use string for scalar type UUID but with different namespace than concerto.scalar ', () => {
+            const modelManager = new ModelManager({ strict: true });
+            modelManager.addCTOModel(`
+            namespace org.specific.scalar@1.0.0
+
+            scalar UUID extends String default="00000000-0000-0000-0000-000000000000" regex=/^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$/
+            `);
+            modelManager.addCTOModel(`
+            namespace org.acme@1.2.3
+
+            import org.specific.scalar@1.0.0.{ UUID }
+
+            concept Thing {
+                o UUID ThingId
+            }
+            `);
+            csharpVisitor.visit(modelManager, { fileWriter });
+            const files = fileWriter.getFilesInMemory();
+            const file1 = files.get('org.acme@1.2.3.cs');
+            file1.should.match(/namespace org.acme;/);
+            file1.should.match(/class Thing/);
+            file1.should.match(/public string ThingId/);
+        });
+
+        it('should use string for scalar type non UUID', () => {
+            const modelManager = new ModelManager({ strict: true });
+            modelManager.addCTOModel(`
+            namespace concerto.scalar@1.0.0
+
+            scalar SSN extends String
+            `);
+            modelManager.addCTOModel(`
+            namespace org.acme@1.2.3
+
+            import concerto.scalar@1.0.0.{ SSN }
+
+            concept Thing {
+                o SSN ThingId
+            }
+            `);
+            csharpVisitor.visit(modelManager, { fileWriter });
+            const files = fileWriter.getFilesInMemory();
+            const file1 = files.get('org.acme@1.2.3.cs');
+            file1.should.match(/namespace org.acme;/);
+            file1.should.match(/class Thing/);
+            file1.should.match(/public string ThingId/);
         });
     });
 
@@ -856,23 +903,51 @@ describe('CSharpVisitor', function () {
             mockField.getType.returns('UUID');
             mockField.isArray.returns(false);
             mockField.isTypeScalar.returns(true);
+            mockField.getFullyQualifiedTypeName.returns('concerto.scalar@1.0.0.UUID');
 
             const mockScalarField = sinon.createStubInstance(Field);
             mockScalarField.getType.returns('String');
+            mockScalarField.getName.returns('someId');
             mockField.getScalarField.returns(mockScalarField);
 
-            const mockModelManager = sinon.createStubInstance(ModelManager);
-            const mockModelFile = sinon.createStubInstance(ModelFile);
-            const mockScalarDeclaration = sinon.createStubInstance(ScalarDeclaration);
-
-            mockModelManager.getType.returns(mockScalarDeclaration);
-            mockScalarDeclaration.getName.returns('UUID');
-            mockScalarDeclaration.getNamespace.returns('concerto.scalar@1.2.3');
-            mockModelFile.getModelManager.returns(mockModelManager);
-            mockScalarDeclaration.getModelFile.returns(mockModelFile);
-            mockField.getParent.returns(mockScalarDeclaration);
-            csharpVisitor.visitField(mockField, param);
+            csharpVisitor.visitScalarField(mockField, param);
             param.fileWriter.writeLine.withArgs(1, 'public Guid someId { get; set; }').calledOnce.should.be.ok;
+        });
+
+        it('should write a line for scalar field of type UUID from org specific namespce with dotnet type string', () => {
+            const mockField = sinon.createStubInstance(Field);
+            mockField.isPrimitive.returns(false);
+            mockField.getName.returns('someId');
+            mockField.getType.returns('UUID');
+            mockField.isArray.returns(false);
+            mockField.isTypeScalar.returns(true);
+            mockField.getFullyQualifiedTypeName.returns('org.acme.scalar@1.0.0.UUID');
+
+            const mockScalarField = sinon.createStubInstance(Field);
+            mockScalarField.getType.returns('String');
+            mockScalarField.getName.returns('someId');
+            mockField.getScalarField.returns(mockScalarField);
+
+            csharpVisitor.visitScalarField(mockField, param);
+            param.fileWriter.writeLine.withArgs(1, 'public string someId { get; set; }').calledOnce.should.be.ok;
+        });
+
+        it('should write a line for scalar field of non UUID type', () => {
+            const mockField = sinon.createStubInstance(Field);
+            mockField.isPrimitive.returns(false);
+            mockField.getName.returns('someId');
+            mockField.getType.returns('SSN');
+            mockField.isArray.returns(false);
+            mockField.isTypeScalar.returns(true);
+            mockField.getFullyQualifiedTypeName.returns('org.arg@1.2.3.SSN');
+
+            const mockScalarField = sinon.createStubInstance(Field);
+            mockScalarField.getType.returns('String');
+            mockScalarField.getName.returns('someId');
+            mockField.getScalarField.returns(mockScalarField);
+
+            csharpVisitor.visitScalarField(mockField, param);
+            param.fileWriter.writeLine.withArgs(1, 'public string someId { get; set; }').calledOnce.should.be.ok;
         });
     });
 
@@ -1000,7 +1075,7 @@ describe('CSharpVisitor', function () {
             csharpVisitor.toCSharpType('Integer').should.deep.equal('int');
         });
         it('should return Guid for Scalar type UUID', () => {
-            csharpVisitor.toCSharpType('UUID').should.deep.equal('Guid');
+            csharpVisitor.toCSharpType('concerto.scalar.UUID').should.deep.equal('Guid');
         });
         it('should return passed in type by default', () => {
             csharpVisitor.toCSharpType('Penguin').should.deep.equal('Penguin');


### PR DESCRIPTION
<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #<CORRESPONDING ISSUE NUMBER>
 

### Changes
UUID support for csharp codegen.  Since UUID's are not supported globally by concerto, added a scalar type UUID with regex validation in `concerto.scalar` namespace.

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [ ] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ ] Merging to `main` from `fork:branchname`
