### PR TITLE
fix: improve how plantuml namespaces are rendered

### DIFF
--- a/packages/concerto-tools/lib/codegen/fromcto/plantuml/plantumlvisitor.js
+++ b/packages/concerto-tools/lib/codegen/fromcto/plantuml/plantumlvisitor.js
@@ -145,7 +145,12 @@ class PlantUMLVisitor extends DiagramVisitor {
             const typeName = ModelUtil.getShortName(input);
             const ns = ModelUtil.getNamespace(input);
             const {name,version} = ModelUtil.parseNamespace(ns);
-            return `${name}_${version.replace(/\./g, '_')}.${typeName}`;
+            if(version) {
+                return `${name}_${version.replace(/\./g, '_')}.${typeName}`;
+            }
+            else {
+                return `${name}.${typeName}`;
+            }
         }
         else {
             return input;

--- a/packages/concerto-tools/lib/codegen/fromcto/plantuml/plantumlvisitor.js
+++ b/packages/concerto-tools/lib/codegen/fromcto/plantuml/plantumlvisitor.js
@@ -14,6 +14,7 @@
 
 'use strict';
 
+const { ModelUtil } = require('@accordproject/concerto-core');
 const DiagramVisitor = require('../../../common/diagramvisitor');
 
 /**
@@ -131,13 +132,24 @@ class PlantUMLVisitor extends DiagramVisitor {
     }
 
     /**
-     * Escape versions and periods.
-     * @param {String} string - the object being visited
+     * Escape fully qualified names. We preserve the dots in the
+     * package name, remove the '@' symbol because it is invalid
+     * and remove the dots in the version (because otherwise packages get created)
+     * @param {String} input - the object being visited
      * @return {String} string  - the parameter
      * @protected
      */
-    escapeString(string) {
-        return string.replace('@', '_');
+    escapeString(input) {
+        const hasNamespace = ModelUtil.getNamespace(input) !== '';
+        if(hasNamespace) {
+            const typeName = ModelUtil.getShortName(input);
+            const ns = ModelUtil.getNamespace(input);
+            const {name,version} = ModelUtil.parseNamespace(ns);
+            return `${name}_${version.replace(/\./g, '_')}.${typeName}`;
+        }
+        else {
+            return input;
+        }
     }
 }
 

--- a/packages/concerto-tools/test/codegen/__snapshots__/codegen.js.snap
+++ b/packages/concerto-tools/test/codegen/__snapshots__/codegen.js.snap
@@ -3139,7 +3139,7 @@ class org.acme.hr.State << (E,grey) >> {
    + IL
    + CA
 }
-org.acme.hr.State --|> concerto_1.0.0.Concept
+org.acme.hr.State --|> concerto_1_0_0.Concept
 class org.acme.hr.Address {
    + String street
    + String city
@@ -3147,12 +3147,12 @@ class org.acme.hr.Address {
    + String zipCode
    + String country
 }
-org.acme.hr.Address --|> concerto_1.0.0.Concept
+org.acme.hr.Address --|> concerto_1_0_0.Concept
 class org.acme.hr.Company {
    + String name
    + Address headquarters
 }
-org.acme.hr.Company --|> concerto_1.0.0.Concept
+org.acme.hr.Company --|> concerto_1_0_0.Concept
 class org.acme.hr.Department << (E,grey) >> {
    + Sales
    + Marketing
@@ -3161,16 +3161,16 @@ class org.acme.hr.Department << (E,grey) >> {
    + Engineering
    + Design
 }
-org.acme.hr.Department --|> concerto_1.0.0.Concept
+org.acme.hr.Department --|> concerto_1_0_0.Concept
 class org.acme.hr.Equipment << (A,green) >> {
    + String serialNumber
 }
-org.acme.hr.Equipment --|> concerto_1.0.0.Asset
+org.acme.hr.Equipment --|> concerto_1_0_0.Asset
 class org.acme.hr.LaptopMake << (E,grey) >> {
    + Apple
    + Microsoft
 }
-org.acme.hr.LaptopMake --|> concerto_1.0.0.Concept
+org.acme.hr.LaptopMake --|> concerto_1_0_0.Concept
 class org.acme.hr.Laptop << (A,green) >> {
    + LaptopMake make
 }
@@ -3185,7 +3185,7 @@ class org.acme.hr.Person << (P,lightblue) >> {
    + Double height
    + DateTime dob
 }
-org.acme.hr.Person --|> concerto_1.0.0.Participant
+org.acme.hr.Person --|> concerto_1_0_0.Participant
 class org.acme.hr.Employee << (P,lightblue) >> {
    + String employeeId
    + Long salary
@@ -3211,7 +3211,7 @@ org.acme.hr.Manager "1" o-- "*" org.acme.hr.Person : reports
 org.acme.hr.Manager --|> org.acme.hr.Employee
 class org.acme.hr.CompanyEvent {
 }
-org.acme.hr.CompanyEvent --|> concerto_1.0.0.Event
+org.acme.hr.CompanyEvent --|> concerto_1_0_0.Event
 class org.acme.hr.Onboarded {
    + Employee employee
 }
@@ -3222,7 +3222,7 @@ class org.acme.hr.ChangeOfAddress << (T,yellow) >> {
    + Address newAddress
 }
 org.acme.hr.ChangeOfAddress "1" o-- "1" org.acme.hr.Person : Person
-org.acme.hr.ChangeOfAddress --|> concerto_1.0.0.Transaction
+org.acme.hr.ChangeOfAddress --|> concerto_1_0_0.Transaction
 @enduml
 ",
 }
@@ -4016,7 +4016,7 @@ exports[`codegen #formats check we can convert all formats from namespace versio
 title
 Model
 endtitle
-class org.acme.hr_1.0.0.State << (E,grey) >> {
+class org.acme.hr_1_0_0.State << (E,grey) >> {
    + MA
    + NY
    + CO
@@ -4024,7 +4024,7 @@ class org.acme.hr_1.0.0.State << (E,grey) >> {
    + IL
    + CA
 }
-class org.acme.hr_1.0.0.Address {
+class org.acme.hr_1_0_0.Address {
    + String street
    + String city
    + State state
@@ -4032,12 +4032,12 @@ class org.acme.hr_1.0.0.Address {
    + String country
 }
 org.acme.hr@1.0.0.Address "1" *-- "1" org.acme.hr@1.0.0.State : state
-class org.acme.hr_1.0.0.Company {
+class org.acme.hr_1_0_0.Company {
    + String name
    + Address headquarters
 }
 org.acme.hr@1.0.0.Company "1" *-- "1" org.acme.hr@1.0.0.Address : headquarters
-class org.acme.hr_1.0.0.Department << (E,grey) >> {
+class org.acme.hr_1_0_0.Department << (E,grey) >> {
    + Sales
    + Marketing
    + Finance
@@ -4045,19 +4045,19 @@ class org.acme.hr_1.0.0.Department << (E,grey) >> {
    + Engineering
    + Design
 }
-class org.acme.hr_1.0.0.Equipment << (A,green) >> {
+class org.acme.hr_1_0_0.Equipment << (A,green) >> {
    + String serialNumber
 }
-class org.acme.hr_1.0.0.LaptopMake << (E,grey) >> {
+class org.acme.hr_1_0_0.LaptopMake << (E,grey) >> {
    + Apple
    + Microsoft
 }
-class org.acme.hr_1.0.0.Laptop << (A,green) >> {
+class org.acme.hr_1_0_0.Laptop << (A,green) >> {
    + LaptopMake make
 }
 org.acme.hr@1.0.0.Laptop "1" *-- "1" org.acme.hr@1.0.0.LaptopMake : make
-org.acme.hr_1.0.0.Laptop --|> org.acme.hr_1.0.0.Equipment
-class org.acme.hr_1.0.0.Person << (P,lightblue) >> {
+org.acme.hr_1_0_0.Laptop --|> org.acme.hr_1_0_0.Equipment
+class org.acme.hr_1_0_0.Person << (P,lightblue) >> {
    + String email
    + String firstName
    + String lastName
@@ -4069,7 +4069,7 @@ class org.acme.hr_1.0.0.Person << (P,lightblue) >> {
 }
 org.acme.hr@1.0.0.Person "1" *-- "1" org.acme.hr@1.0.0.Address : homeAddress
 org.acme.hr@1.0.0.Person "1" *-- "1" org.acme.hr@1.0.0.SSN : ssn
-class org.acme.hr_1.0.0.Employee << (P,lightblue) >> {
+class org.acme.hr_1_0_0.Employee << (P,lightblue) >> {
    + String employeeId
    + Long salary
    + Integer numDependents
@@ -4083,27 +4083,27 @@ org.acme.hr@1.0.0.Employee "1" *-- "1" org.acme.hr@1.0.0.Department : department
 org.acme.hr@1.0.0.Employee "1" *-- "1" org.acme.hr@1.0.0.Address : officeAddress
 org.acme.hr@1.0.0.Employee "1" *-- "*" org.acme.hr@1.0.0.Equipment : companyAssets
 org.acme.hr@1.0.0.Employee "1" o-- "1" org.acme.hr@1.0.0.Manager : manager
-org.acme.hr_1.0.0.Employee --|> org.acme.hr_1.0.0.Person
-class org.acme.hr_1.0.0.Contractor << (P,lightblue) >> {
+org.acme.hr_1_0_0.Employee --|> org.acme.hr_1_0_0.Person
+class org.acme.hr_1_0_0.Contractor << (P,lightblue) >> {
    + Company company
    + Manager manager
 }
 org.acme.hr@1.0.0.Contractor "1" *-- "1" org.acme.hr@1.0.0.Company : company
 org.acme.hr@1.0.0.Contractor "1" o-- "1" org.acme.hr@1.0.0.Manager : manager
-org.acme.hr_1.0.0.Contractor --|> org.acme.hr_1.0.0.Person
-class org.acme.hr_1.0.0.Manager << (P,lightblue) >> {
+org.acme.hr_1_0_0.Contractor --|> org.acme.hr_1_0_0.Person
+class org.acme.hr_1_0_0.Manager << (P,lightblue) >> {
    + Person[] reports
 }
 org.acme.hr@1.0.0.Manager "1" o-- "*" org.acme.hr@1.0.0.Person : reports
-org.acme.hr_1.0.0.Manager --|> org.acme.hr_1.0.0.Employee
-class org.acme.hr_1.0.0.CompanyEvent {
+org.acme.hr_1_0_0.Manager --|> org.acme.hr_1_0_0.Employee
+class org.acme.hr_1_0_0.CompanyEvent {
 }
-class org.acme.hr_1.0.0.Onboarded {
+class org.acme.hr_1_0_0.Onboarded {
    + Employee employee
 }
 org.acme.hr@1.0.0.Onboarded "1" o-- "1" org.acme.hr@1.0.0.Employee : employee
-org.acme.hr_1.0.0.Onboarded --|> org.acme.hr_1.0.0.CompanyEvent
-class org.acme.hr_1.0.0.ChangeOfAddress << (T,yellow) >> {
+org.acme.hr_1_0_0.Onboarded --|> org.acme.hr_1_0_0.CompanyEvent
+class org.acme.hr_1_0_0.ChangeOfAddress << (T,yellow) >> {
    + Person Person
    + Address newAddress
 }
@@ -7255,7 +7255,7 @@ exports[`codegen #formats check we can convert all formats from namespace versio
 title
 Model
 endtitle
-class org.acme.hr_1.0.0.State << (E,grey) >> {
+class org.acme.hr_1_0_0.State << (E,grey) >> {
    + MA
    + NY
    + CO
@@ -7263,8 +7263,8 @@ class org.acme.hr_1.0.0.State << (E,grey) >> {
    + IL
    + CA
 }
-org.acme.hr_1.0.0.State --|> concerto_1.0.0.Concept
-class org.acme.hr_1.0.0.Address {
+org.acme.hr_1_0_0.State --|> concerto_1_0_0.Concept
+class org.acme.hr_1_0_0.Address {
    + String street
    + String city
    + State state
@@ -7272,14 +7272,14 @@ class org.acme.hr_1.0.0.Address {
    + String country
 }
 org.acme.hr@1.0.0.Address "1" *-- "1" org.acme.hr@1.0.0.State : state
-org.acme.hr_1.0.0.Address --|> concerto_1.0.0.Concept
-class org.acme.hr_1.0.0.Company {
+org.acme.hr_1_0_0.Address --|> concerto_1_0_0.Concept
+class org.acme.hr_1_0_0.Company {
    + String name
    + Address headquarters
 }
 org.acme.hr@1.0.0.Company "1" *-- "1" org.acme.hr@1.0.0.Address : headquarters
-org.acme.hr_1.0.0.Company --|> concerto_1.0.0.Concept
-class org.acme.hr_1.0.0.Department << (E,grey) >> {
+org.acme.hr_1_0_0.Company --|> concerto_1_0_0.Concept
+class org.acme.hr_1_0_0.Department << (E,grey) >> {
    + Sales
    + Marketing
    + Finance
@@ -7287,22 +7287,22 @@ class org.acme.hr_1.0.0.Department << (E,grey) >> {
    + Engineering
    + Design
 }
-org.acme.hr_1.0.0.Department --|> concerto_1.0.0.Concept
-class org.acme.hr_1.0.0.Equipment << (A,green) >> {
+org.acme.hr_1_0_0.Department --|> concerto_1_0_0.Concept
+class org.acme.hr_1_0_0.Equipment << (A,green) >> {
    + String serialNumber
 }
-org.acme.hr_1.0.0.Equipment --|> concerto_1.0.0.Asset
-class org.acme.hr_1.0.0.LaptopMake << (E,grey) >> {
+org.acme.hr_1_0_0.Equipment --|> concerto_1_0_0.Asset
+class org.acme.hr_1_0_0.LaptopMake << (E,grey) >> {
    + Apple
    + Microsoft
 }
-org.acme.hr_1.0.0.LaptopMake --|> concerto_1.0.0.Concept
-class org.acme.hr_1.0.0.Laptop << (A,green) >> {
+org.acme.hr_1_0_0.LaptopMake --|> concerto_1_0_0.Concept
+class org.acme.hr_1_0_0.Laptop << (A,green) >> {
    + LaptopMake make
 }
 org.acme.hr@1.0.0.Laptop "1" *-- "1" org.acme.hr@1.0.0.LaptopMake : make
-org.acme.hr_1.0.0.Laptop --|> org.acme.hr_1.0.0.Equipment
-class org.acme.hr_1.0.0.Person << (P,lightblue) >> {
+org.acme.hr_1_0_0.Laptop --|> org.acme.hr_1_0_0.Equipment
+class org.acme.hr_1_0_0.Person << (P,lightblue) >> {
    + String email
    + String firstName
    + String lastName
@@ -7314,8 +7314,8 @@ class org.acme.hr_1.0.0.Person << (P,lightblue) >> {
 }
 org.acme.hr@1.0.0.Person "1" *-- "1" org.acme.hr@1.0.0.Address : homeAddress
 org.acme.hr@1.0.0.Person "1" *-- "1" org.acme.hr@1.0.0.SSN : ssn
-org.acme.hr_1.0.0.Person --|> concerto_1.0.0.Participant
-class org.acme.hr_1.0.0.Employee << (P,lightblue) >> {
+org.acme.hr_1_0_0.Person --|> concerto_1_0_0.Participant
+class org.acme.hr_1_0_0.Employee << (P,lightblue) >> {
    + String employeeId
    + Long salary
    + Integer numDependents
@@ -7329,34 +7329,34 @@ org.acme.hr@1.0.0.Employee "1" *-- "1" org.acme.hr@1.0.0.Department : department
 org.acme.hr@1.0.0.Employee "1" *-- "1" org.acme.hr@1.0.0.Address : officeAddress
 org.acme.hr@1.0.0.Employee "1" *-- "*" org.acme.hr@1.0.0.Equipment : companyAssets
 org.acme.hr@1.0.0.Employee "1" o-- "1" org.acme.hr@1.0.0.Manager : manager
-org.acme.hr_1.0.0.Employee --|> org.acme.hr_1.0.0.Person
-class org.acme.hr_1.0.0.Contractor << (P,lightblue) >> {
+org.acme.hr_1_0_0.Employee --|> org.acme.hr_1_0_0.Person
+class org.acme.hr_1_0_0.Contractor << (P,lightblue) >> {
    + Company company
    + Manager manager
 }
 org.acme.hr@1.0.0.Contractor "1" *-- "1" org.acme.hr@1.0.0.Company : company
 org.acme.hr@1.0.0.Contractor "1" o-- "1" org.acme.hr@1.0.0.Manager : manager
-org.acme.hr_1.0.0.Contractor --|> org.acme.hr_1.0.0.Person
-class org.acme.hr_1.0.0.Manager << (P,lightblue) >> {
+org.acme.hr_1_0_0.Contractor --|> org.acme.hr_1_0_0.Person
+class org.acme.hr_1_0_0.Manager << (P,lightblue) >> {
    + Person[] reports
 }
 org.acme.hr@1.0.0.Manager "1" o-- "*" org.acme.hr@1.0.0.Person : reports
-org.acme.hr_1.0.0.Manager --|> org.acme.hr_1.0.0.Employee
-class org.acme.hr_1.0.0.CompanyEvent {
+org.acme.hr_1_0_0.Manager --|> org.acme.hr_1_0_0.Employee
+class org.acme.hr_1_0_0.CompanyEvent {
 }
-org.acme.hr_1.0.0.CompanyEvent --|> concerto_1.0.0.Event
-class org.acme.hr_1.0.0.Onboarded {
+org.acme.hr_1_0_0.CompanyEvent --|> concerto_1_0_0.Event
+class org.acme.hr_1_0_0.Onboarded {
    + Employee employee
 }
 org.acme.hr@1.0.0.Onboarded "1" o-- "1" org.acme.hr@1.0.0.Employee : employee
-org.acme.hr_1.0.0.Onboarded --|> org.acme.hr_1.0.0.CompanyEvent
-class org.acme.hr_1.0.0.ChangeOfAddress << (T,yellow) >> {
+org.acme.hr_1_0_0.Onboarded --|> org.acme.hr_1_0_0.CompanyEvent
+class org.acme.hr_1_0_0.ChangeOfAddress << (T,yellow) >> {
    + Person Person
    + Address newAddress
 }
 org.acme.hr@1.0.0.ChangeOfAddress "1" o-- "1" org.acme.hr@1.0.0.Person : Person
 org.acme.hr@1.0.0.ChangeOfAddress "1" *-- "1" org.acme.hr@1.0.0.Address : newAddress
-org.acme.hr_1.0.0.ChangeOfAddress --|> concerto_1.0.0.Transaction
+org.acme.hr_1_0_0.ChangeOfAddress --|> concerto_1_0_0.Transaction
 @enduml
 ",
 }


### PR DESCRIPTION
Today the PlantUML diagram is messy because PlantUML interprets all dots in fully-qualified names as packages names, and renders a box for the contained elements.

### Changes
- Changes the string escaping function for PlantUML to escape the dots that appear in versioned namespaces to underscores

### Screenshots or Video

Note that boxes have been drawn for the `org` and `acme` and `test` namespaces, but not for the version of the `test@1.0.0` namespace.

<img width="1038" alt="image" src="https://user-images.githubusercontent.com/623108/223748028-94c0f50f-9937-4925-b383-6446f08f222c.png">

### Related Issues
- Issue #<NUMBER>
- Pull Request #<NUMBER>

### Author Checklist
- [ ] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [ ] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ ] Merging to `main` from `fork:branchname`
