### PR TITLE
fix(metamodel): handle missing optional values in metamodel instance

### DIFF
--- a/packages/concerto-metamodel/lib/metamodelutil.js
+++ b/packages/concerto-metamodel/lib/metamodelutil.js
@@ -67,8 +67,7 @@ function createNameTable(priorModels, metaModel) {
     };
 
     // First list the imported names in order (overriding as we go along)
-    const imports = metaModel.imports;
-    imports.forEach((imp) => {
+    (metaModel.imports || []).forEach((imp) => {
         const namespace = imp.namespace;
         const modelFile = findNamespace(priorModels, namespace);
         if (imp.$class === `${MetaModelNamespace}.ImportType`) {
@@ -84,19 +83,16 @@ function createNameTable(priorModels, metaModel) {
                 table[type] = namespace;
             }
         } else {
-            const decls = modelFile.declarations;
-            decls.forEach((decl) => {
+            (modelFile.declarations || []).forEach((decl) => {
                 table[decl.name] = namespace;
             });
         }
     });
 
     // Then add the names local to this metaModel (overriding as we go along)
-    if (metaModel.declarations) {
-        metaModel.declarations.forEach((decl) => {
-            table[decl.name] = metaModel.namespace;
-        });
-    }
+    (metaModel.declarations || []).forEach((decl) => {
+        table[decl.name] = metaModel.namespace;
+    });
 
     return table;
 }
@@ -123,11 +119,9 @@ function resolveName(name, table) {
 function resolveTypeNames(metaModel, table) {
     switch (metaModel.$class) {
     case `${MetaModelNamespace}.Model`: {
-        if (metaModel.declarations) {
-            metaModel.declarations.forEach((decl) => {
-                resolveTypeNames(decl, table);
-            });
-        }
+        (metaModel.declarations || []).forEach((decl) => {
+            resolveTypeNames(decl, table);
+        });
     }
         break;
     case `${MetaModelNamespace}.AssetDeclaration`:
@@ -139,22 +133,18 @@ function resolveTypeNames(metaModel, table) {
             const name = metaModel.superType.name;
             metaModel.superType.namespace = resolveName(name, table);
         }
-        metaModel.properties.forEach((property) => {
+        (metaModel.properties || []).forEach((property) => {
             resolveTypeNames(property, table);
         });
-        if (metaModel.decorators) {
-            metaModel.decorators.forEach((decorator) => {
-                resolveTypeNames(decorator, table);
-            });
-        }
+        (metaModel.decorators || []).forEach((decorator) => {
+            resolveTypeNames(decorator, table);
+        });
     }
         break;
     case `${MetaModelNamespace}.EnumDeclaration`: {
-        if (metaModel.decorators) {
-            metaModel.decorators.forEach((decorator) => {
-                resolveTypeNames(decorator, table);
-            });
-        }
+        (metaModel.decorators || []).forEach((decorator) => {
+            resolveTypeNames(decorator, table);
+        });
     }
         break;
     case `${MetaModelNamespace}.EnumProperty`:
@@ -162,19 +152,15 @@ function resolveTypeNames(metaModel, table) {
     case `${MetaModelNamespace}.RelationshipProperty`: {
         const name = metaModel.type.name;
         metaModel.type.namespace = resolveName(name, table);
-        if (metaModel.decorators) {
-            metaModel.decorators.forEach((decorator) => {
-                resolveTypeNames(decorator, table);
-            });
-        }
+        (metaModel.decorators || []).forEach((decorator) => {
+            resolveTypeNames(decorator, table);
+        });
     }
         break;
     case `${MetaModelNamespace}.Decorator`: {
-        if (metaModel.arguments) {
-            metaModel.arguments.forEach((argument) => {
-                resolveTypeNames(argument, table);
-            });
-        }
+        (metaModel.arguments || []).forEach((argument) => {
+            resolveTypeNames(argument, table);
+        });
     }
         break;
     case `${MetaModelNamespace}.DecoratorTypeReference`: {

--- a/packages/concerto-metamodel/test/metamodelutil.js
+++ b/packages/concerto-metamodel/test/metamodelutil.js
@@ -50,6 +50,43 @@ describe('MetaModel (Empty)', () => {
     });
 });
 
+describe('MetaModel (Missing optional values)', () => {
+    const model = {
+        '$class': 'concerto.metamodel@1.0.0.Models',
+        'models': [
+            {
+                '$class': 'concerto.metamodel@1.0.0.Model',
+                'namespace': 'org.vehicle',
+            },
+            {
+                '$class': 'concerto.metamodel@1.0.0.Model',
+                'namespace': 'org.car',
+                'imports': [
+                    {
+                        '$class': 'concerto.metamodel@1.0.0.ImportAll',
+                        'namespace': 'org.vehicle'
+                    }
+                ],
+                'declarations': [
+                    {
+                        '$class': 'concerto.metamodel@1.0.0.ConceptDeclaration',
+                        'name': 'Car',
+                        'isAbstract': false,
+                        'properties': []
+                    }
+                ]
+            }
+        ]
+    };
+
+    describe('#toMetaModel', () => {
+        it('should convert a CTO model to its metamodel with name resolution', async () => {
+            const mm1r = MetaModelUtil.resolveLocalNames([], model);
+            mm1r.should.deep.equal(model);
+        });
+    });
+});
+
 describe('MetaModel (Car)', () => {
     const carModelPath = path.resolve(__dirname, './cto/car.json');
     const carModel = JSON.parse(fs.readFileSync(carModelPath, 'utf8'));


### PR DESCRIPTION
<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
<!--- Provide an overall summary of the pull request -->

Using `MetamodelUtil` with metamodel instances that don't include optional attributes would cause errors when attempting to read an undefined property, e.g. 
```
TypeError: Cannot read properties of undefined (reading 'forEach')
```

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [x] Merging to `main` from `fork:branchname`
