### PR TITLE
fix(core): disallow reserved fields in JSON serialization

### DIFF
--- a/packages/concerto-core/lib/introspect/classdeclaration.js
+++ b/packages/concerto-core/lib/introspect/classdeclaration.js
@@ -536,9 +536,10 @@ class ClassDeclaration extends Declaration {
             }
 
             // go get the fields from the super type
+            // Note: this allows addition of an $identifier field from a supertype
+            // even if this type is explicitly identified.
+            // We allow this because it allows normalization of identifier lookup without the model present
             result = result.concat(classDecl.getProperties());
-        } else {
-            // console.log('No super type for ' + this.getName() );
         }
 
         return result;

--- a/packages/concerto-core/lib/introspect/classdeclaration.js
+++ b/packages/concerto-core/lib/introspect/classdeclaration.js
@@ -23,6 +23,7 @@ const Globalize = require('../globalize');
 const IllegalModelException = require('./illegalmodelexception');
 const Introspector = require('./introspector');
 const RelationshipDeclaration = require('./relationshipdeclaration');
+const ModelUtil = require('../modelutil');
 
 // Types needed for TypeScript generation.
 /* eslint-disable no-unused-vars */
@@ -52,8 +53,6 @@ class ClassDeclaration extends Declaration {
      */
     process() {
         super.process();
-
-        const reservedProperties = ['$class', '$identifier', '$timestamp'];
 
         this.properties = [];
         this.superType = null;
@@ -86,7 +85,7 @@ class ClassDeclaration extends Declaration {
         for (let n = 0; n < this.ast.properties.length; n++) {
             let thing = this.ast.properties[n];
 
-            if(reservedProperties.includes(thing.name)) {
+            if(ModelUtil.isSystemProperty(thing.name)) {
                 throw new IllegalModelException(`Invalid field name '${thing.name}'`, this.modelFile, this.ast.location);
             }
 

--- a/packages/concerto-core/lib/model/identifiable.js
+++ b/packages/concerto-core/lib/model/identifiable.js
@@ -44,7 +44,8 @@ class Identifiable extends Typed {
      */
     constructor(modelManager, classDeclaration, ns, type, id, timestamp) {
         super(modelManager, classDeclaration, ns, type);
-        this.$identifier = id;
+        this.setIdentifierFieldName();
+        this.setIdentifier(id);
         this.$timestamp = timestamp;
     }
 
@@ -61,7 +62,7 @@ class Identifiable extends Typed {
      * @return {string} The identifier for this object
      */
     getIdentifier() {
-        return this.$identifier;
+        return this[this.$identifierFieldName];
     }
 
     /**
@@ -70,10 +71,7 @@ class Identifiable extends Typed {
      */
     setIdentifier(id) {
         this.$identifier = id;
-        const modelFile = this.$modelManager.getModelFile(this.getNamespace());
-        const typeDeclaration = modelFile.getType(this.getFullyQualifiedType());
-        const idField = typeDeclaration.getIdentifierFieldName();
-        this[idField] = id;
+        this[this.$identifierFieldName] = id;
     }
 
     /**
@@ -82,10 +80,22 @@ class Identifiable extends Typed {
      * @return {string} the fully qualified identifier of this instance
      */
     getFullyQualifiedIdentifier() {
-        if (this.$identifier) {
-            return this.getFullyQualifiedType() + '#' + this.$identifier;
+        if (this.getIdentifier()) {
+            return this.getFullyQualifiedType() + '#' + this.getIdentifier();
         }
         return this.getFullyQualifiedType();
+    }
+
+    /**
+     * Returns the name of the identifying field for this class.
+     * @private
+     */
+    setIdentifierFieldName() {
+        if (!this.$identifierFieldName){
+            const modelFile = this.$modelManager.getModelFile(this.getNamespace());
+            const typeDeclaration = modelFile?.getType(this.getFullyQualifiedType());
+            this.$identifierFieldName = typeDeclaration?.getIdentifierFieldName() || '$identifier';
+        }
     }
 
     /**
@@ -121,7 +131,6 @@ class Identifiable extends Typed {
     toURI() {
         const resourceId = new ResourceId(this.getNamespace(), this.getType(), this.getIdentifier());
         const result = resourceId.toURI();
-        //console.log( '***** URI for ' + this.toString() + ' is ' + result );
         return result;
     }
 }

--- a/packages/concerto-core/lib/model/identifiable.js
+++ b/packages/concerto-core/lib/model/identifiable.js
@@ -44,7 +44,12 @@ class Identifiable extends Typed {
      */
     constructor(modelManager, classDeclaration, ns, type, id, timestamp) {
         super(modelManager, classDeclaration, ns, type);
-        this.setIdentifierFieldName();
+
+        // Cache the identifier field name
+        const modelFile = this.$modelManager.getModelFile(this.getNamespace());
+        const typeDeclaration = modelFile?.getType(this.getFullyQualifiedType());
+        this.$identifierFieldName = typeDeclaration?.getIdentifierFieldName() || '$identifier';
+
         this.setIdentifier(id);
         this.$timestamp = timestamp;
     }
@@ -84,18 +89,6 @@ class Identifiable extends Typed {
             return this.getFullyQualifiedType() + '#' + this.getIdentifier();
         }
         return this.getFullyQualifiedType();
-    }
-
-    /**
-     * Returns the name of the identifying field for this class.
-     * @private
-     */
-    setIdentifierFieldName() {
-        if (!this.$identifierFieldName){
-            const modelFile = this.$modelManager.getModelFile(this.getNamespace());
-            const typeDeclaration = modelFile?.getType(this.getFullyQualifiedType());
-            this.$identifierFieldName = typeDeclaration?.getIdentifierFieldName() || '$identifier';
-        }
     }
 
     /**

--- a/packages/concerto-core/lib/modelutil.js
+++ b/packages/concerto-core/lib/modelutil.js
@@ -21,20 +21,31 @@ const Globalize = require('./globalize');
 const ID_REGEX = /^(\p{Lu}|\p{Ll}|\p{Lt}|\p{Lm}|\p{Lo}|\p{Nl}|\$|_|\\u[0-9A-Fa-f]{4})(?:\p{Lu}|\p{Ll}|\p{Lt}|\p{Lm}|\p{Lo}|\p{Nl}|\$|_|\\u[0-9A-Fa-f]{4}|\p{Mn}|\p{Mc}|\p{Nd}|\p{Pc}|\u200C|\u200D)*$/u;
 
 const privateReservedProperties = [
-    '$classDeclaration',
-    '$namespace',
-    '$type',
-    '$modelManager',
-    '$validator',
+    // Internal use only
+    '$classDeclaration',    // Used to cache a reference to theClass Declaration instance
+    '$namespace',           // Used to cache the namespace for a type
+    '$type',                // Used to cache the type for a type
+    '$modelManager',        // Used to cache a reference to the ModelManager instance
+    '$validator',           // Used to cache a reference to the ResourceValidator instance
+    '$identifierFieldName', // Used for caching the identifier field name
+
+    '$imports',             // Reserved for future use
+    '$superTypes',          // Reserved for future use
+
+    // Included in serialization
+    '$id',                  // Used for URI identifier
 ];
 
 const assignableReservedProperties = [
-    '$identifier',
-    '$timestamp'
+    // Included in serialization
+    '$identifier',          // Used for shadowing the identifier field, or where a system identifier is required
+    '$timestamp'            // Used in Event and Transaction prototype classes
 ];
 
 const reservedProperties = [
-    '$class',
+    // Included in serialization
+    '$class',               // Used for discriminating between instances of different classes
+
     ...assignableReservedProperties,
     ...privateReservedProperties
 ];

--- a/packages/concerto-core/lib/modelutil.js
+++ b/packages/concerto-core/lib/modelutil.js
@@ -20,6 +20,25 @@ const Globalize = require('./globalize');
 
 const ID_REGEX = /^(\p{Lu}|\p{Ll}|\p{Lt}|\p{Lm}|\p{Lo}|\p{Nl}|\$|_|\\u[0-9A-Fa-f]{4})(?:\p{Lu}|\p{Ll}|\p{Lt}|\p{Lm}|\p{Lo}|\p{Nl}|\$|_|\\u[0-9A-Fa-f]{4}|\p{Mn}|\p{Mc}|\p{Nd}|\p{Pc}|\u200C|\u200D)*$/u;
 
+const privateReservedProperties = [
+    '$classDeclaration',
+    '$namespace',
+    '$type',
+    '$modelManager',
+    '$validator',
+];
+
+const assignableReservedProperties = [
+    '$identifier',
+    '$timestamp'
+];
+
+const reservedProperties = [
+    '$class',
+    ...assignableReservedProperties,
+    ...privateReservedProperties
+];
+
 /**
  * Internal Model Utility Class
  * <p><a href="./diagrams-private/modelutil.svg"><img src="./diagrams-private/modelutil.svg" style="height:100%;"/></a></p>
@@ -221,6 +240,28 @@ class ModelUtil {
         const { name: namespace } = ModelUtil.parseNamespace(ns);
         const typeName = ModelUtil.getShortName(fqn);
         return ModelUtil.getFullyQualifiedName(namespace, typeName);
+    }
+
+    /**
+     * Returns true if the property is a system property.
+     * System properties are not declared in the model.
+     * @param {String} propertyName - the name of the property
+     * @return {Boolean} true if the property is a system property
+     * @private
+     */
+    static isSystemProperty(propertyName) {
+        return reservedProperties.includes(propertyName);
+    }
+
+    /**
+     * Returns true if the property is an system property that can be set in serialized JSON.
+     * System properties are not declared in the model.
+     * @param {String} propertyName - the name of the property
+     * @return {Boolean} true if the property is a system property
+     * @private
+     */
+    static isPrivateSystemProperty(propertyName) {
+        return privateReservedProperties.includes(propertyName);
     }
 }
 

--- a/packages/concerto-core/lib/serializer/jsonpopulator.js
+++ b/packages/concerto-core/lib/serializer/jsonpopulator.js
@@ -71,15 +71,6 @@ function validateProperties(properties, classDeclaration) {
 
     const invalidProperties = properties.filter((property) => !expectedProperties.includes(property));
     if (invalidProperties.length > 0) {
-
-        // Allow shadowing of the $identifer field to normalize lookup of the identifying field.
-        if (invalidProperties.includes('$identifier') &&
-            classDeclaration.isIdentified() &&
-            classDeclaration.getIdentifierFieldName() !== '$identifier'
-        ) {
-            return;
-        }
-
         const errorText = `Unexpected properties for type ${classDeclaration.getFullyQualifiedName()}: ` +
             invalidProperties.join(', ');
         throw new ValidationException(errorText);

--- a/packages/concerto-core/lib/serializer/resourcevalidator.js
+++ b/packages/concerto-core/lib/serializer/resourcevalidator.js
@@ -138,7 +138,7 @@ class ResourceValidator {
         let props = Object.getOwnPropertyNames(obj);
         for (let n = 0; n < props.length; n++) {
             let propName = props[n];
-            if(!this.isSystemProperty(propName)) {
+            if(!ModelUtil.isSystemProperty(propName)) {
                 const field = toBeAssignedClassDeclaration.getProperty(propName);
                 if (!field) {
                     if(classDeclaration.isIdentified()) {
@@ -178,17 +178,6 @@ class ResourceValidator {
             }
         }
         return null;
-    }
-
-    /**
-     * Returns true if the property is a system property.
-     * System properties are not declared in the model.
-     * @param {String} propertyName - the name of the property
-     * @return {Boolean} true if the property is a system property
-     * @private
-     */
-    isSystemProperty(propertyName) {
-        return propertyName.charAt(0) === '$';
     }
 
     /**

--- a/packages/concerto-core/lib/serializer/resourcevalidator.js
+++ b/packages/concerto-core/lib/serializer/resourcevalidator.js
@@ -126,6 +126,7 @@ class ResourceValidator {
 
         const toBeAssignedClassDeclaration = parameters.modelManager.getType(obj.getFullyQualifiedType());
         const toBeAssignedClassDecName = toBeAssignedClassDeclaration.getFullyQualifiedName();
+        const identifierFieldName = toBeAssignedClassDeclaration.getIdentifierFieldName();
 
         // is the type we are assigning to abstract?
         // the only way this can happen is if the type is non-abstract
@@ -141,7 +142,10 @@ class ResourceValidator {
             if(!ModelUtil.isSystemProperty(propName)) {
                 const field = toBeAssignedClassDeclaration.getProperty(propName);
                 if (!field) {
-                    if(classDeclaration.isIdentified()) {
+                    if(classDeclaration.isIdentified() &&
+                        // Allow shadowing of the $identifer field to normalize lookup of the identifying field.
+                        propName !== '$identifier'
+                    ){
                         ResourceValidator.reportUndeclaredField(obj.getIdentifier(), propName, toBeAssignedClassDecName);
                     }
                     else {
@@ -159,6 +163,12 @@ class ResourceValidator {
                 ResourceValidator.reportEmptyIdentifier(parameters.rootResourceIdentifier);
             }
 
+            // Enforce that shadowed $identifier fields have the same value as the explicit identifying field.
+            // The value of the explicit identified field takes precedence.
+            if (identifierFieldName !== '$identifier'){
+                obj.$identifier = id;
+            }
+
             parameters.currentIdentifier = obj.getFullyQualifiedIdentifier();
         }
 
@@ -173,6 +183,11 @@ class ResourceValidator {
             }
             else {
                 if(!property.isOptional()) {
+                    // Allow shadowing of the $identifer field to normalize lookup of the identifying field.
+                    if (property.getName() === '$identifier' && identifierFieldName !== '$identifier'
+                    ) {
+                        continue;
+                    }
                     ResourceValidator.reportMissingRequiredProperty( parameters.rootResourceIdentifier, property);
                 }
             }

--- a/packages/concerto-core/test/models/animaltracking.js
+++ b/packages/concerto-core/test/models/animaltracking.js
@@ -16,7 +16,6 @@
 
 //const assert = require('assert');
 require('chai').should();
-const Logger = require('@accordproject/concerto-util').Logger;
 const Factory = require('../../lib/factory');
 const ModelManager = require('../../lib/modelmanager');
 const Relationship = require('../../lib/model/relationship');
@@ -41,8 +40,6 @@ describe('animaltracking Model', function(){
         animaltrackingModel = fs.readFileSync('./test/data/model/animaltracking.cto', 'utf8');
         animaltrackingModel.should.not.be.null;
         modelManager.addCTOModel(animaltrackingModel, 'animaltracking.cto');
-        Logger.info('no###');
-        Logger.info(modelManager.getNamespaces());
 
         modelFile = modelManager.getModelFile('com.hyperledger.composer.animaltracking');
         modelFile.should.not.be.null;

--- a/packages/concerto-core/test/models/model.js
+++ b/packages/concerto-core/test/models/model.js
@@ -83,75 +83,75 @@ describe('Model Tests', function(){
             // o String stringProperty
             resource.setPropertyValue('stringProperty', 'string');
             resource.stringProperty.should.equal('string');
-            assert.throws( function() {resource.setPropertyValue('stringProperty', 1);}, /ValidationException: Model violation in the "org.acme.base.BaseAsset#123" instance. The field "stringProperty" has a value of "1" \(type of value: "number"\). Expected type of value: "String"./);
+            assert.throws( function() {resource.setPropertyValue('stringProperty', 1);}, /ValidationException: Model violation in the "org.acme.base.BaseAsset#string" instance. The field "stringProperty" has a value of "1" \(type of value: "number"\). Expected type of value: "String"./);
 
             // o Integer integerProperty
             resource.setPropertyValue('integerProperty', 999);
             resource.integerProperty.should.equal(999);
-            assert.throws( function() {resource.setPropertyValue('integerProperty', 'Foo');}, /ValidationException: Model violation in the "org.acme.base.BaseAsset#123" instance. The field "integerProperty" has a value of ""Foo"" \(type of value: "string"\). Expected type of value: "Integer"./);
+            assert.throws( function() {resource.setPropertyValue('integerProperty', 'Foo');}, /ValidationException: Model violation in the "org.acme.base.BaseAsset#string" instance. The field "integerProperty" has a value of ""Foo"" \(type of value: "string"\). Expected type of value: "Integer"./);
 
             // o Double doubleProperty
             resource.setPropertyValue('doubleProperty', 10.0);
             resource.doubleProperty.should.equal(10.0);
-            assert.throws( function() {resource.setPropertyValue('doubleProperty', 'Foo');}, /ValidationException: Model violation in the "org.acme.base.BaseAsset#123" instance. The field "doubleProperty" has a value of ""Foo"" \(type of value: "string"\). Expected type of value: "Double"./);
+            assert.throws( function() {resource.setPropertyValue('doubleProperty', 'Foo');}, /ValidationException: Model violation in the "org.acme.base.BaseAsset#string" instance. The field "doubleProperty" has a value of ""Foo"" \(type of value: "string"\). Expected type of value: "Double"./);
 
             // o Boolean booleanProperty
             resource.setPropertyValue('booleanProperty', true );
             resource.booleanProperty.should.equal(true);
-            assert.throws( function() {resource.setPropertyValue('booleanProperty', 'Foo');}, /ValidationException: Model violation in the "org.acme.base.BaseAsset#123" instance. The field "booleanProperty" has a value of ""Foo"" \(type of value: "string"\). Expected type of value: "Boolean"./);
+            assert.throws( function() {resource.setPropertyValue('booleanProperty', 'Foo');}, /ValidationException: Model violation in the "org.acme.base.BaseAsset#string" instance. The field "booleanProperty" has a value of ""Foo"" \(type of value: "string"\). Expected type of value: "Boolean"./);
 
             // o DateTime dateTimeProperty
             const dateTime = dayjs.utc('2016-10-11T02:30:26.262Z');
             resource.setPropertyValue('dateTimeProperty', dateTime );
             resource.dateTimeProperty.should.equal(dateTime);
-            assert.throws( function() {resource.setPropertyValue('dateTimeProperty', 'Foo');}, /ValidationException: Model violation in the "org.acme.base.BaseAsset#123" instance. The field "dateTimeProperty" has a value of ""Foo"" \(type of value: "string"\). Expected type of value: "DateTime"./);
+            assert.throws( function() {resource.setPropertyValue('dateTimeProperty', 'Foo');}, /ValidationException: Model violation in the "org.acme.base.BaseAsset#string" instance. The field "dateTimeProperty" has a value of ""Foo"" \(type of value: "string"\). Expected type of value: "DateTime"./);
 
             // o Long longProperty
             resource.setPropertyValue('longProperty', 100 );
             resource.longProperty.should.equal(100);
-            assert.throws( function() {resource.setPropertyValue('longProperty', 'Foo');}, /ValidationException: Model violation in the "org.acme.base.BaseAsset#123" instance. The field "longProperty" has a value of ""Foo"" \(type of value: "string"\). Expected type of value: "Long"./);
+            assert.throws( function() {resource.setPropertyValue('longProperty', 'Foo');}, /ValidationException: Model violation in the "org.acme.base.BaseAsset#string" instance. The field "longProperty" has a value of ""Foo"" \(type of value: "string"\). Expected type of value: "Long"./);
 
             // o State stateProperty
             resource.setPropertyValue('stateProperty', 'GOLD' );
             resource.stateProperty.should.equal('GOLD');
-            assert.throws( function() {resource.setPropertyValue('stateProperty', 'Foo');}, /ValidationException: Model violation in the "org.acme.base.BaseAsset#123" instance. Invalid enum value of "Foo" for the field "State"./);
-            assert.throws( function() {resource.setPropertyValue('stateProperty', 1);}, /ValidationException: Model violation in the "org.acme.base.BaseAsset#123" instance. Invalid enum value of "1" for the field "State"./);
+            assert.throws( function() {resource.setPropertyValue('stateProperty', 'Foo');}, /ValidationException: Model violation in the "org.acme.base.BaseAsset#string" instance. Invalid enum value of "Foo" for the field "State"./);
+            assert.throws( function() {resource.setPropertyValue('stateProperty', 1);}, /ValidationException: Model violation in the "org.acme.base.BaseAsset#string" instance. Invalid enum value of "1" for the field "State"./);
 
             // o String[] stringArrayProperty
             resource.setPropertyValue('stringArrayProperty', ['string'] );
             resource.stringArrayProperty.should.contain('string');
-            assert.throws( function() {resource.setPropertyValue('stringArrayProperty', 1);}, /ValidationException: Model violation in the "org.acme.base.BaseAsset#123" instance. The field "stringArrayProperty" has a value of "1" \(type of value: "number"\). Expected type of value: "String\[\]"./);
+            assert.throws( function() {resource.setPropertyValue('stringArrayProperty', 1);}, /ValidationException: Model violation in the "org.acme.base.BaseAsset#string" instance. The field "stringArrayProperty" has a value of "1" \(type of value: "number"\). Expected type of value: "String\[\]"./);
 
             // o Integer[] integerArrayProperty
             resource.setPropertyValue('integerArrayProperty', [999] );
             resource.integerArrayProperty.should.contain(999);
-            assert.throws( function() {resource.setPropertyValue('integerArrayProperty', 'Foo');}, /ValidationException: Model violation in the "org.acme.base.BaseAsset#123" instance. The field "integerArrayProperty" has a value of ""Foo"" \(type of value: "string"\). Expected type of value: "Integer\[\]"./);
+            assert.throws( function() {resource.setPropertyValue('integerArrayProperty', 'Foo');}, /ValidationException: Model violation in the "org.acme.base.BaseAsset#string" instance. The field "integerArrayProperty" has a value of ""Foo"" \(type of value: "string"\). Expected type of value: "Integer\[\]"./);
 
             // o Double[] doubleArrayProperty
             resource.setPropertyValue('doubleArrayProperty', [999.0] );
             resource.doubleArrayProperty.should.contain(999.0);
-            assert.throws( function() {resource.setPropertyValue('doubleArrayProperty', 'Foo');}, /ValidationException: Model violation in the "org.acme.base.BaseAsset#123" instance. The field "doubleArrayProperty" has a value of ""Foo"" \(type of value: "string"\). Expected type of value: "Double\[\]"./);
+            assert.throws( function() {resource.setPropertyValue('doubleArrayProperty', 'Foo');}, /ValidationException: Model violation in the "org.acme.base.BaseAsset#string" instance. The field "doubleArrayProperty" has a value of ""Foo"" \(type of value: "string"\). Expected type of value: "Double\[\]"./);
 
             // o Boolean[] booleanArrayProperty
             resource.setPropertyValue('booleanArrayProperty', [true, false] );
             resource.booleanArrayProperty.should.contain(true);
-            assert.throws( function() {resource.setPropertyValue('booleanArrayProperty', 'Foo');}, /ValidationException: Model violation in the "org.acme.base.BaseAsset#123" instance. The field "booleanArrayProperty" has a value of ""Foo"" \(type of value: "string"\). Expected type of value: "Boolean\[\]"./);
+            assert.throws( function() {resource.setPropertyValue('booleanArrayProperty', 'Foo');}, /ValidationException: Model violation in the "org.acme.base.BaseAsset#string" instance. The field "booleanArrayProperty" has a value of ""Foo"" \(type of value: "string"\). Expected type of value: "Boolean\[\]"./);
 
             // o DateTime[] dateTimeArrayProperty
             resource.setPropertyValue('dateTimeArrayProperty', [dateTime] );
             resource.dateTimeArrayProperty.should.contain(dateTime);
-            assert.throws( function() {resource.setPropertyValue('dateTimeArrayProperty', 'Foo');}, /ValidationException: Model violation in the "org.acme.base.BaseAsset#123" instance. The field "dateTimeArrayProperty" has a value of ""Foo"" \(type of value: "string"\). Expected type of value: "DateTime\[\]"./);
+            assert.throws( function() {resource.setPropertyValue('dateTimeArrayProperty', 'Foo');}, /ValidationException: Model violation in the "org.acme.base.BaseAsset#string" instance. The field "dateTimeArrayProperty" has a value of ""Foo"" \(type of value: "string"\). Expected type of value: "DateTime\[\]"./);
 
             // o Long[] longArrayProperty
             resource.setPropertyValue('longArrayProperty', [1,2,3] );
             resource.longArrayProperty.should.contain(3);
-            assert.throws( function() {resource.setPropertyValue('longArrayProperty', 'Foo');}, /ValidationException: Model violation in the "org.acme.base.BaseAsset#123" instance. The field "longArrayProperty" has a value of ""Foo"" \(type of value: "string"\). Expected type of value: "Long\[\]"./);
+            assert.throws( function() {resource.setPropertyValue('longArrayProperty', 'Foo');}, /ValidationException: Model violation in the "org.acme.base.BaseAsset#string" instance. The field "longArrayProperty" has a value of ""Foo"" \(type of value: "string"\). Expected type of value: "Long\[\]"./);
 
             // o State[] stateArrayProperty
             resource.setPropertyValue('stateArrayProperty', ['GOLD', 'SILVER'] );
             resource.stateArrayProperty.should.contain('SILVER');
-            assert.throws( function() {resource.setPropertyValue('stateArrayProperty', ['GOLD', 'Foo']);}, 'ValidationException: Model violation in the "org.acme.base.BaseAsset#123" instance. Invalid enum value of "Foo" for the field "State".');
-            assert.throws( function() {resource.setPropertyValue('stateArrayProperty', 'GOLD');}, /ValidationException: Model violation in the "org.acme.base.BaseAsset#123" instance. The field "stateArrayProperty" has a value of ""GOLD"" \(type of value: "string"\). Expected type of value: "State\[\]"./);
+            assert.throws( function() {resource.setPropertyValue('stateArrayProperty', ['GOLD', 'Foo']);}, 'ValidationException: Model violation in the "org.acme.base.BaseAsset#string" instance. Invalid enum value of "Foo" for the field "State".');
+            assert.throws( function() {resource.setPropertyValue('stateArrayProperty', 'GOLD');}, /ValidationException: Model violation in the "org.acme.base.BaseAsset#string" instance. The field "stateArrayProperty" has a value of ""GOLD"" \(type of value: "string"\). Expected type of value: "State\[\]"./);
 
             // set the relationships
             const personRelationship = factory.newRelationship('org.acme.base', 'Person', 'DAN' );
@@ -160,7 +160,7 @@ describe('Model Tests', function(){
 
             // set an invalid relationship
             const blokeRelationship = factory.newRelationship('org.acme.base', 'Bloke', 'DAN' );
-            assert.throws( function() {resource.setPropertyValue('singlePerson', blokeRelationship );}, /ValidationException: Instance "org.acme.base.BaseAsset#123" has a property "singlePerson" with type "org.acme.base.Bloke" that is not derived from "org.acme.base.Person"./);
+            assert.throws( function() {resource.setPropertyValue('singlePerson', blokeRelationship );}, /ValidationException: Instance "org.acme.base.BaseAsset#string" has a property "singlePerson" with type "org.acme.base.Bloke" that is not derived from "org.acme.base.Person"./);
 
             // create a Person
             const person = factory.newResource('org.acme.base', 'Person', 'P1' );
@@ -182,12 +182,12 @@ describe('Model Tests', function(){
 
             resource.myPeople = [person,person];
 
-            assert.throws( function() {resource.validate();}, /ValidationException: Instance "org.acme.base.BaseAsset#123" has a property "myPerson" with type "org.acme.base.Bloke" that is not derived from "org.acme.base.Person"./);
+            assert.throws( function() {resource.validate();}, /ValidationException: Instance "org.acme.base.BaseAsset#string" has a property "myPerson" with type "org.acme.base.Bloke" that is not derived from "org.acme.base.Person"./);
             resource.myPerson = person;
 
             // set an extra property
             resource.blotto = 'Yes!';
-            assert.throws( function() {resource.validate();}, /ValidationException: Instance "123" has a property named "blotto", which is not declared in "org.acme.base.BaseAsset"./);
+            assert.throws( function() {resource.validate();}, /ValidationException: Instance "string" has a property named "blotto", which is not declared in "org.acme.base.BaseAsset"./);
             delete resource.blotto;
 
             // set a missing property
@@ -203,7 +203,7 @@ describe('Model Tests', function(){
             let json = serializer.toJSON(resource, { utcOffset: 0 });
 
             // assert on the entire format of the JSON serialization
-            JSON.stringify(json).should.be.equal('{"$class":"org.acme.base.BaseAsset","stringProperty":"string","integerProperty":999,"doubleProperty":10,"booleanProperty":true,"dateTimeProperty":"2016-10-11T02:30:26.262Z","longProperty":100,"stateProperty":"GOLD","stringArrayProperty":["string"],"integerArrayProperty":[999],"doubleArrayProperty":[999],"booleanArrayProperty":[true,false],"dateTimeArrayProperty":["2016-10-11T02:30:26.262Z"],"longArrayProperty":[1,2,3],"stateArrayProperty":["GOLD","SILVER"],"singlePerson":"resource:org.acme.base.Person#DAN","personArray":["resource:org.acme.base.Person#DAN","resource:org.acme.base.Person#DAN"],"myPerson":{"$class":"org.acme.base.Person","stringProperty":"P1","address":{"$class":"org.acme.base.UnitedStatesAddress","zipcode":"CA","street":"Test","city":"Winchester","country":"UK"},"$identifier":"P1"},"myPeople":[{"$class":"org.acme.base.Person","stringProperty":"P1","address":{"$class":"org.acme.base.UnitedStatesAddress","zipcode":"CA","street":"Test","city":"Winchester","country":"UK"},"$identifier":"P1"},{"$class":"org.acme.base.Person","stringProperty":"P1","address":{"$class":"org.acme.base.UnitedStatesAddress","zipcode":"CA","street":"Test","city":"Winchester","country":"UK"},"$identifier":"P1"}],"$identifier":"123"}');
+            JSON.stringify(json).should.be.equal('{"$class":"org.acme.base.BaseAsset","stringProperty":"string","integerProperty":999,"doubleProperty":10,"booleanProperty":true,"dateTimeProperty":"2016-10-11T02:30:26.262Z","longProperty":100,"stateProperty":"GOLD","stringArrayProperty":["string"],"integerArrayProperty":[999],"doubleArrayProperty":[999],"booleanArrayProperty":[true,false],"dateTimeArrayProperty":["2016-10-11T02:30:26.262Z"],"longArrayProperty":[1,2,3],"stateArrayProperty":["GOLD","SILVER"],"singlePerson":"resource:org.acme.base.Person#DAN","personArray":["resource:org.acme.base.Person#DAN","resource:org.acme.base.Person#DAN"],"myPerson":{"$class":"org.acme.base.Person","stringProperty":"P1","address":{"$class":"org.acme.base.UnitedStatesAddress","zipcode":"CA","street":"Test","city":"Winchester","country":"UK"},"$identifier":"P1"},"myPeople":[{"$class":"org.acme.base.Person","stringProperty":"P1","address":{"$class":"org.acme.base.UnitedStatesAddress","zipcode":"CA","street":"Test","city":"Winchester","country":"UK"},"$identifier":"P1"},{"$class":"org.acme.base.Person","stringProperty":"P1","address":{"$class":"org.acme.base.UnitedStatesAddress","zipcode":"CA","street":"Test","city":"Winchester","country":"UK"},"$identifier":"P1"}],"$identifier":"string"}');
 
             // check we can convert back to an object
             const newResource = serializer.fromJSON(json);

--- a/packages/concerto-core/test/serializer.js
+++ b/packages/concerto-core/test/serializer.js
@@ -433,6 +433,47 @@ describe('Serializer', () => {
             ).should.throw(/Unexpected reserved properties for type org.acme.sample.SampleParticipant: \$validator/);
         });
 
+        it('should error on unexpected $timestamp property when the model doesn\'t require them', () => {
+            const json = {
+                $class: 'org.acme.sample.Address',
+                country: 'UK',
+                elevation: 3.14,
+                city: 'Winchester',
+                postcode: 'SO21 2JN',
+                $timestamp: 'now',
+            };
+            (() =>
+                serializer.fromJSON(json)
+            ).should.throw(/Unexpected property for type org.acme.sample.Address: \$timestamp/);
+        });
+
+        it('should not error on unexpected $identifier property when the model doesn\'t require them', () => {
+            const json = {
+                $class: 'org.acme.sample.SampleEvent',
+                eventId: '111',
+                asset: 'resource:org.acme.sample.SampleAsset#1',
+                newValue: 'the value',
+                $timestamp: '2022-11-28T01:02:03.987Z',
+                $identifier: '111',
+            };
+            const result = serializer.fromJSON(json);
+            result.should.be.an.instanceOf(Resource);
+        });
+
+        it('should not error when shadowed $identifier does not match explicit identifier value', () => {
+            const json = {
+                $class: 'org.acme.sample.SampleEvent',
+                eventId: '111',
+                asset: 'resource:org.acme.sample.SampleAsset#1',
+                newValue: 'the value',
+                $timestamp: '2022-11-28T01:02:03.987Z',
+                $identifier: '222',
+            };
+            const result = serializer.fromJSON(json);
+            result.should.be.an.instanceOf(Resource);
+            result.$identifier = '111';
+        });
+
         it('should not error on unexpected properties if their value is undefined', () => {
             const json = {
                 $class: 'org.acme.sample.SampleParticipant',

--- a/packages/concerto-core/test/serializer.js
+++ b/packages/concerto-core/test/serializer.js
@@ -407,6 +407,32 @@ describe('Serializer', () => {
                 .should.throw(/WRONG/);
         });
 
+        it('should error on unexpected properties that start with $', () => {
+            const json = {
+                $class: 'org.acme.sample.SampleParticipant',
+                participantId: 'alphablock',
+                firstName: 'Block',
+                lastName: 'Norris',
+                $WRONG: 'blah',
+            };
+            (() =>
+                serializer.fromJSON(json)
+            ).should.throw(/Unexpected properties for type org.acme.sample.SampleParticipant: \$WRONG/);
+        });
+
+        it('should error on unexpected properties that start with reserved keywords', () => {
+            const json = {
+                $class: 'org.acme.sample.SampleParticipant',
+                participantId: 'alphablock',
+                firstName: 'Block',
+                lastName: 'Norris',
+                $validator: 'blah',
+            };
+            (() =>
+                serializer.fromJSON(json)
+            ).should.throw(/Unexpected reserved properties for type org.acme.sample.SampleParticipant: \$validator/);
+        });
+
         it('should not error on unexpected properties if their value is undefined', () => {
             const json = {
                 $class: 'org.acme.sample.SampleParticipant',

--- a/packages/concerto-core/test/serializer/objectvalidator.js
+++ b/packages/concerto-core/test/serializer/objectvalidator.js
@@ -339,7 +339,7 @@ describe('ObjectValidator', function () {
                 $class: 'test.Person',
                 email: 'matt@example',
             };
-            const field = concerto.getTypeDeclaration(data).getProperties()[1];
+            const field = concerto.getTypeDeclaration(data).getProperties()[0];
             (function () {
                 ObjectValidator.reportFieldTypeViolation('123', 'name', data, field, concerto);
             }).should.throw('Model violation in the "123" instance. The field "name" has a value of "matt@example" (type of value: "Person"). Expected type of value: "String"');

--- a/packages/concerto-core/test/serializer/objectvalidator.js
+++ b/packages/concerto-core/test/serializer/objectvalidator.js
@@ -233,6 +233,19 @@ describe('ObjectValidator', function () {
                 objectValidator.visit(concerto.getTypeDeclaration(data), parameters);
             }).should.throw('Type "Missing" is not defined in namespace "test".');
         });
+
+        it('should fail for an undeclared field', () => {
+            const data = {
+                $class : 'test.Vehicle',
+                manufacturer: 'Ford',
+            };
+            const parameters = {};
+            parameters.stack = new TypedStack(data);
+
+            (function () {
+                objectValidator.visit(concerto.getTypeDeclaration(data), parameters);
+            }).should.throw('Instance "undefined" has a property named "manufacturer", which is not declared in "test.Vehicle"');
+        });
     });
 
     describe('#visitRelationshipDeclaration', () => {

--- a/packages/concerto-core/test/serializer/resourcevalidator.js
+++ b/packages/concerto-core/test/serializer/resourcevalidator.js
@@ -405,6 +405,21 @@ describe('ResourceValidator', function () {
             }).should.throw('Instance "ABC" has a property named "foo", which is not declared in "org.acme.l3.Car".');
         });
 
+        it('should detect an empty identifier', function () {
+            const vehicle = factory.newResource('org.acme.l3', 'Car', 'foo');
+            vehicle.setIdentifier('');
+            vehicle.model = 'Ford';
+            vehicle.numberOfWheels = 4;
+            vehicle.milage = 3.14;
+            const typedStack = new TypedStack(vehicle);
+            const assetDeclaration = modelManager.getType('org.acme.l3.Car');
+            const parameters = { stack : typedStack, 'modelManager' : modelManager, rootResourceIdentifier : 'ABC' };
+
+            (function () {
+                assetDeclaration.accept(resourceValidator,parameters );
+            }).should.throw(/has an empty identifier/);
+        });
+
         it('should normalize a shadowed identifier to the value from the indentified field', function () {
             const vehicle = factory.newResource('org.acme.l3', 'Car', 'foo');
             vehicle.$identifier = ''; // empty the identifier

--- a/packages/concerto-core/test/serializer/resourcevalidator.js
+++ b/packages/concerto-core/test/serializer/resourcevalidator.js
@@ -395,7 +395,7 @@ describe('ResourceValidator', function () {
 
         it('should detect additional field', function () {
             const vehicle = factory.newResource('org.acme.l3', 'Car', 'ABC');
-            vehicle.foo = 'Baz';
+            vehicle.foo = 'Baz'; // additional field
             const typedStack = new TypedStack(vehicle);
             const assetDeclaration = modelManager.getType('org.acme.l2.Vehicle');
             const parameters = { stack : typedStack, 'modelManager' : modelManager, rootResourceIdentifier : 'ABC' };
@@ -405,7 +405,7 @@ describe('ResourceValidator', function () {
             }).should.throw('Instance "ABC" has a property named "foo", which is not declared in "org.acme.l3.Car".');
         });
 
-        it('should detect an empty identifier', function () {
+        it('should normalize a shadowed identifier to the value from the indentified field', function () {
             const vehicle = factory.newResource('org.acme.l3', 'Car', 'foo');
             vehicle.$identifier = ''; // empty the identifier
             vehicle.model = 'Ford';
@@ -415,9 +415,8 @@ describe('ResourceValidator', function () {
             const assetDeclaration = modelManager.getType('org.acme.l3.Car');
             const parameters = { stack : typedStack, 'modelManager' : modelManager, rootResourceIdentifier : 'ABC' };
 
-            (function () {
-                assetDeclaration.accept(resourceValidator,parameters );
-            }).should.throw(/has an empty identifier/);
+            assetDeclaration.accept(resourceValidator, parameters);
+            vehicle.$identifier.should.equal('foo');
         });
 
         it('should reject a Double which is not finite', function () {
@@ -432,7 +431,7 @@ describe('ResourceValidator', function () {
 
             (() => {
                 assetDeclaration.accept(resourceValidator,parameters);
-            }).should.throw('Model violation in the "org.acme.l3.Car#42" instance. The field "milage" has a value of "NaN" (type of value: "number"). Expected type of value: "Double".');
+            }).should.throw('Model violation in the "org.acme.l3.Car#foo" instance. The field "milage" has a value of "NaN" (type of value: "number"). Expected type of value: "Double".');
         });
 
         it('should report undeclared field if not identifiable', () => {

--- a/packages/concerto-core/test/serializer/resourcevalidator.js
+++ b/packages/concerto-core/test/serializer/resourcevalidator.js
@@ -447,6 +447,19 @@ describe('ResourceValidator', function () {
                 resourceValidator.visitClassDeclaration(conceptDeclaration,parameters);
             }).should.throw('Instance "undefined" has a property named "numberOfWipers", which is not declared in "org.acme.l1.Data".');
         });
+
+        it('should report undeclared field with a $ prefix', () => {
+            const data = factory.newConcept('org.acme.l1', 'Data');
+            data.name = 'name';
+            data.$numberOfWipers = 2;
+            const typedStack = new TypedStack(data);
+            const conceptDeclaration = modelManager.getType('org.acme.l1.Data');
+            const parameters = { stack : typedStack, 'modelManager' : modelManager, rootResourceIdentifier : 'ABC' };
+
+            (() => {
+                resourceValidator.visitClassDeclaration(conceptDeclaration,parameters);
+            }).should.throw('Instance "undefined" has a property named "$numberOfWipers", which is not declared in "org.acme.l1.Data".');
+        });
     });
 
     describe('#reportFieldTypeViolation', () => {


### PR DESCRIPTION
<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
<!--- Provide an overall summary of the pull request -->
Better aligns the introspection API with the parser for fields that begin with a `$`.

Also, note that the existing behaviour is to add an additional field `$identifier` which shadows the value of any user-provided identifier field. This is by design because it allows client applications to resolve the identifier value without introspecting the model (which may not be available client-side). 

For example,
```cs
namespace test@1.0.0

concept test identified by name
{      o String name    }
```

The following payload is considered valid
```json
{    "$class": "test@1.0.0.test",     "name": "test",    "$identifier" : "test" }
```

### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
- When a concept is identified by an explicitly named field (e.g. `concept p identified by x {...}`), we give the value of that field primacy.
- We explicitly list reserved fields, rather than assuming that anything that starts with `$` is a system field.

### Flags
<!--- Provide context or concerns a reviewer should be aware of -->
- This changes the behaviour of the operation `.getIdentifier()` when the user has explicitly set `$identifier` but hasn't changed the value of the explicitly named identifier field. See the test changes for `ValidatedResource`
- The list of private reserved keywords now includes `$superTypes`, and `$imports`. These are reserved for future use, where we may want to resolve or cache these values in serializations to improve performance.

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [x] Merging to `main` from `fork:branchname`
