### PR TITLE
feat(map): Add Introspection for Map Type

### DIFF
--- a/packages/concerto-core/lib/basemodelmanager.js
+++ b/packages/concerto-core/lib/basemodelmanager.js
@@ -597,6 +597,16 @@ class BaseModelManager {
     }
 
     /**
+     * Get the MapDeclarations defined in this model manager
+     * @return {MapDeclaration[]} the MapDeclaration defined in the model manager
+     */
+    getMapDeclarations() {
+        return this.getModelFiles().reduce((prev, cur) => {
+            return prev.concat(cur.getMapDeclarations());
+        }, []);
+    }
+
+    /**
      * Get the EnumDeclarations defined in this model manager
      * @return {EnumDeclaration[]} the EnumDeclaration defined in the model manager
      */

--- a/packages/concerto-core/lib/introspect/mapdeclaration.js
+++ b/packages/concerto-core/lib/introspect/mapdeclaration.js
@@ -1,0 +1,249 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const Decorated = require('./decorated');
+const IllegalModelException = require('./illegalmodelexception');
+const MapPropertyType = require('./mapvaluetype');
+const MapKeyType = require('./mapkeytype');
+const ModelUtil = require('../modelutil');
+
+// Types needed for TypeScript generation.
+/* eslint-disable no-unused-vars */
+/* istanbul ignore next */
+if (global === undefined) {
+    const ModelFile = require('./modelfile');
+}
+
+/**
+ * MapDeclaration defines an MapType of Key & Value pair.
+ *
+ * @extends Decorated
+ * @see See {@link Decorated}
+ * @class
+ * @memberof module:concerto-core
+ */
+class MapDeclaration extends Decorated {
+    /**
+     * Create an MapDeclaration.
+     * @param {ModelFile} modelFile the ModelFile for this class
+     * @param {Object} ast - The AST created by the parser
+     * @throws {IllegalModelException}
+     */
+    constructor(modelFile, ast) {
+        super(ast);
+        this.modelFile = modelFile;
+        this.process();
+    }
+
+    /**
+     * Process the AST and build the model
+     *
+     * @throws {IllegalModelException}
+     * @private
+     */
+    process() {
+        super.process();
+
+        if (this.ast.properties.length !== 2) {
+            throw new IllegalModelException(`MapDeclaration must contain exactly two properties -  MapKeyType & MapyValueType ${this.ast.name}`, this.modelFile, this.ast.location);
+        }
+
+        const k = this.ast.properties.find(p => p.$class === 'concerto.metamodel@1.0.0.MapKeyType');
+        const v = this.ast.properties.find(p => p.$class === 'concerto.metamodel@1.0.0.AggregateValueType' || p.$class === 'concerto.metamodel@1.0.0.AggregateRelationshipValueType');
+
+        if (!k) {
+            throw new IllegalModelException(`MapDeclaration must contain MapKeyType  ${this.ast.name}`, this.modelFile, this.ast.location);
+        }
+
+        if (!v) {
+            throw new IllegalModelException(`MapDeclaration must contain AggregateValueType  ${this.ast.name}`, this.modelFile, this.ast.location);
+        }
+
+        this.name = this.ast.name;
+        this.key = new MapKeyType(this, k);
+        this.value = new MapPropertyType(this, v);
+        this.fqn = ModelUtil.getFullyQualifiedName(this.modelFile.getNamespace(), this.ast.name);
+    }
+
+    /**
+     * Semantic validation of the structure of this class.
+     *
+     * @throws {IllegalModelException}
+     * @protected
+     */
+    validate() {
+        super.validate();
+        this.key.validate();
+        this.value.validate();
+    }
+
+    /**
+     * Returns the fully qualified name of this class.
+     * The name will include the namespace if present.
+     *
+     * @return {string} the fully-qualified name of this class
+     */
+    getFullyQualifiedName() {
+        return this.fqn;
+    }
+
+    /**
+     * Returns the ModelFile that defines this class.
+     *
+     * @public
+     * @return {ModelFile} the owning ModelFile
+     */
+    getModelFile() {
+        return this.modelFile;
+    }
+
+    /**
+     * Returns the short name of a class. This name does not include the
+     * namespace from the owning ModelFile.
+     *
+     * @return {string} the short name of this class
+     */
+    getName() {
+        return this.name;
+    }
+
+    /**
+     * Returns the type of the Map key property.
+     *
+     * @return {string} the short name of this class
+     */
+    getKey() {
+        return this.key;
+    }
+
+    /**
+     * Returns the type of the Map Value property.
+     *
+     * @return {string} the short name of this class
+     */
+    getValue() {
+        return this.value;
+    }
+
+    /**
+     * Returns the MapDeclaration properties
+     *
+     * @return {array} the short name of this class
+     */
+    getProperties() {
+        return this.ast.properties;
+    }
+
+    /**
+     * Returns the string representation of this class
+     * @return {String} the string representation of the class
+     */
+    toString() {
+        return 'MapDeclaration {id=' + this.getFullyQualifiedName() + '}';
+    }
+
+    /**
+     * Returns the kind of declaration
+     *
+     * @return {string} what kind of declaration this is
+     */
+    declarationKind() {
+        return 'MapDeclaration';
+    }
+
+    /**
+     * Returns true if this class is abstract.
+     *
+     * @return {boolean} true if the class is abstract
+     */
+    isAbstract() {
+        return false;
+    }
+
+    /**
+     * Returns true if this class is the definition of an asset.
+     *
+     * @return {boolean} true if the class is an asset
+     */
+    isAsset() {
+        return false;
+    }
+
+    /**
+     * Returns true if this class is the definition of a participant.
+     *
+     * @return {boolean} true if the class is a participant
+     */
+    isParticipant() {
+        return false;
+    }
+
+    /**
+     * Returns true if this class is the definition of a transaction.
+     *
+     * @return {boolean} true if the class is a transaction
+     */
+    isTransaction() {
+        return false;
+    }
+
+    /**
+     * Returns true if this class is the definition of an event.
+     *
+     * @return {boolean} true if the class is an event
+     */
+    isEvent() {
+        return false;
+    }
+
+    /**
+     * Returns true if this class is the definition of a concept.
+     *
+     * @return {boolean} true if the class is a concept
+     */
+    isConcept() {
+        return false;
+    }
+
+    /**
+     * Returns true if this class is the definition of an enum.
+     *
+     * @return {boolean} true if the class is an enum
+     */
+    isEnum() {
+        return false;
+    }
+
+    /**
+     * Returns true if this class is the definition of a scalar declaration.
+     *
+     * @return {boolean} true if the class is a scalar
+     */
+    isScalarDeclaration() {
+        return false;
+    }
+
+    /**
+     * Returns true if this class is the definition of a class declaration.
+     *
+     * @return {boolean} true if the class is a class
+     */
+    isMapDeclaration() {
+        return true;
+    }
+}
+
+module.exports = MapDeclaration;

--- a/packages/concerto-core/lib/introspect/mapkeytype.js
+++ b/packages/concerto-core/lib/introspect/mapkeytype.js
@@ -1,0 +1,152 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const { MetaModelNamespace } = require('@accordproject/concerto-metamodel');
+
+const Decorated = require('./decorated');
+const IllegalModelException = require('./illegalmodelexception');
+const ModelUtil = require('../modelutil');
+
+// Types needed for TypeScript generation.
+/* eslint-disable no-unused-vars */
+/* istanbul ignore next */
+if (global === undefined) {
+    const ModelFile = require('./modelfile');
+}
+
+/**
+ * MapKeyType defines a Key type of an MapDeclaration.
+ *
+ * @extends Decorated
+ * @see See {@link Decorated}
+ * @class
+ * @memberof module:concerto-core
+ */
+class MapKeyType extends Decorated {
+    /**
+     * Create an MapKeyType.
+     * @param {MapDeclaration} parent - The owner of this property
+     * @param {Object} ast - The AST created by the parser
+     * @throws {IllegalModelException}
+     */
+    constructor(parent, ast) {
+        super(ast);
+        this.parent = parent;
+        this.name = null;
+        this.type = null;
+        this.fqn = null;
+        this.process();
+    }
+
+    /**
+     * Process the AST and build the model
+     *
+     * @throws {IllegalModelException}
+     * @private
+     */
+    process() {
+        super.process();
+        this.name = this.ast.name;
+        this.type = this.ast.name;
+        this.fqn = ModelUtil.getFullyQualifiedName(this.parent.getModelFile().getNamespace(), this.ast.name);
+    }
+
+    /**
+     * Semantic validation of the structure of this class.
+     *
+     * @throws {IllegalModelException}
+     * @protected
+     */
+    validate() {
+        const declaration = this.getModelFile().getAllDeclarations();
+        const key = declaration.find(decl => decl.name === this.name);
+
+        if (!key?.isConcept?.()           &&
+            !key?.isEnum?.()              &&
+            !key?.isScalarDeclaration?.() &&
+            !['String', 'Boolean', 'DateTime'].includes(this.type)) {
+            throw new IllegalModelException(`MapKeyType has invalid Type: ${this.type}`);
+        }
+
+        if (key?.isConcept?.()) {
+            if(!key.isIdentified()) {
+                throw new IllegalModelException(
+                    `ConceptDeclaration must be identified in context of MapKeyType: ${this.type}`
+                );
+            }
+        }
+
+        if (key?.isScalarDeclaration?.()) {
+            if (!(key?.ast.$class === `${MetaModelNamespace}.StringScalar`)  &&
+                !(key?.ast.$class === `${MetaModelNamespace}.BooleanScalar`) &&
+                !(key?.ast.$class === `${MetaModelNamespace}.DateTimeScalar` )) {
+                throw new IllegalModelException(
+                    `Scalar must be one of StringScalar, BooleanScalar, DateTimeScalar in context of MapKeyType. Invalid Scalar: ${this.name}`
+                );
+            }
+        }
+    }
+
+    /**
+     * Returns the fully qualified name of this class.
+     * The name will include the namespace if present.
+     *
+     * @return {string} the fully-qualified name of this class
+     */
+    getFullyQualifiedName() {
+        return this.fqn;
+    }
+
+    /**
+     * Returns the ModelFile that defines this class.
+     *
+     * @public
+     * @return {ModelFile} the owning ModelFile
+     */
+    getModelFile() {
+        return this.parent.getModelFile();
+    }
+
+    /**
+     * Returns the name of the MapKey. This name does not include the
+     * namespace from the owning ModelFile.
+     *
+     * @return {string} the short name of this class
+     */
+    getName() {
+        return this.ast.name;
+    }
+
+    /**
+     * Returns the Type of the MapKey. This name does not include the
+     * namespace from the owning ModelFile.
+     *
+     * @return {string} the short name of this class
+     */
+    getType() {
+        return this.ast.name;
+    }
+
+    /**
+     * Returns the string representation of this class
+     * @return {String} the string representation of the class
+     */
+    toString() {
+        return 'MapKeyType {id=' + this.getFullyQualifiedName() + '}';
+    }
+}
+
+module.exports = MapKeyType;

--- a/packages/concerto-core/lib/introspect/mapvaluetype.js
+++ b/packages/concerto-core/lib/introspect/mapvaluetype.js
@@ -1,0 +1,138 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const Decorated = require('./decorated');
+const IllegalModelException = require('./illegalmodelexception');
+const ModelUtil = require('../modelutil');
+
+// Types needed for TypeScript generation.
+/* eslint-disable no-unused-vars */
+/* istanbul ignore next */
+if (global === undefined) {
+    const ModelFile = require('./modelfile');
+}
+
+/**
+ * MapValueType defines a Value type of MapDeclaration.
+ *
+ * @extends Decorated
+ * @see See {@link Decorated}
+ * @class
+ * @memberof module:concerto-core
+ */
+class MapValueType extends Decorated {
+    /**
+     * Create an MapValueType.
+     * @param {MapDeclaration} parent - The owner of this property
+     * @param {Object} ast - The AST created by the parser
+     * @throws {IllegalModelException}
+     */
+    constructor(parent, ast) {
+        super(ast);
+        this.parent = parent;
+        this.name = null;
+        this.type = null;
+        this.fqn = null;
+        this.process();
+    }
+
+    /**
+     * Process the AST and build the model
+     *
+     * @throws {IllegalModelException}
+     * @private
+     */
+    process() {
+        super.process();
+        this.name = this.ast.name;
+        this.type = this.ast.name;
+        this.fqn = ModelUtil.getFullyQualifiedName(this.parent.getModelFile().getNamespace(), this.ast.name);
+    }
+
+    /**
+     * Semantic validation of the structure of this class.
+     *
+     * @throws {IllegalModelException}
+     * @protected
+     */
+    validate() {
+        const declarations = this.getModelFile().getAllDeclarations();
+
+        const value = declarations.find(decl => decl.name === this.name);
+
+        if (!value?.isConcept?.()           &&
+            !value?.isEnum?.()              &&
+            !value?.isEvent?.()             &&
+            !value?.isMapDeclaration?.()    &&
+            !value?.isScalarDeclaration?.() &&
+            !['String', 'Long', 'Integer', 'Double', 'Boolean', 'DateTime'].includes(this.type)) {
+            throw new IllegalModelException(
+                `MapPropertyType has invalid Type: ${this.type}` // TODO add useful error message
+            );
+        }
+    }
+
+    /**
+     * Returns the fully qualified name of this class.
+     * The name will include the namespace if present.
+     *
+     * @return {string} the fully-qualified name of this class
+     */
+    getFullyQualifiedName() {
+        return this.fqn;
+    }
+
+    /**
+     * Returns the ModelFile that defines this class.
+     *
+     * @public
+     * @return {ModelFile} the owning ModelFile
+     */
+    getModelFile() {
+        return this.parent.getModelFile();
+    }
+
+    /**
+     * Returns the name of the MapValue. This name does not include the
+     * namespace from the owning ModelFile.
+     *
+     * @return {string} the short name of this class
+     */
+    getName() {
+        return this.ast.name;
+    }
+
+    /**
+     * Returns the Type of the MapValue. This name does not include the
+     * namespace from the owning ModelFile.
+     *
+     * @return {string} the short name of this class
+     */
+    getType() {
+        return this.ast.name;
+    }
+
+    /**
+     * Returns the string representation of this class
+     * @return {String} the string representation of the class
+     */
+    toString() {
+        return 'MapValueType {id=' + this.getFullyQualifiedName() + '}';
+    }
+
+}
+
+module.exports = MapValueType;

--- a/packages/concerto-core/lib/introspect/modelfile.js
+++ b/packages/concerto-core/lib/introspect/modelfile.js
@@ -26,6 +26,7 @@ const ParticipantDeclaration = require('./participantdeclaration');
 const TransactionDeclaration = require('./transactiondeclaration');
 const EventDeclaration = require('./eventdeclaration');
 const IllegalModelException = require('./illegalmodelexception');
+const MapDeclaration = require('./mapdeclaration');
 const ModelUtil = require('../modelutil');
 const Globalize = require('../globalize');
 const Decorated = require('./decorated');
@@ -590,6 +591,14 @@ class ModelFile extends Decorated {
     }
 
     /**
+     * Get the MapDeclarations defined in this ModelFile
+     * @return {MapDeclaration[]} the MapDeclarations defined in the model file
+     */
+    getMapDeclarations() {
+        return this.getDeclarations(MapDeclaration);
+    }
+
+    /**
      * Get the ScalarDeclaration defined in this ModelFile
      * @return {ScalarDeclaration[]} the ScalarDeclaration defined in the model file
      */
@@ -779,6 +788,9 @@ class ModelFile extends Decorated {
             }
             else if(thing.$class === `${MetaModelNamespace}.EnumDeclaration`) {
                 this.declarations.push( new EnumDeclaration(this, thing) );
+            }
+            else if(thing.$class === `${MetaModelNamespace}.MapDeclaration`) {
+                this.declarations.push( new MapDeclaration(this, thing) );
             }
             else if(thing.$class === `${MetaModelNamespace}.ConceptDeclaration`) {
                 this.declarations.push( new ConceptDeclaration(this, thing) );

--- a/packages/concerto-core/test/data/parser/mapdeclaration/mapdeclaration.badkey.declaration.concept.cto
+++ b/packages/concerto-core/test/data/parser/mapdeclaration/mapdeclaration.badkey.declaration.concept.cto
@@ -1,0 +1,21 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+namespace com.testing@1.0.0
+
+concept NotIdentified {}
+
+map Dictionary {
+  o NotIdentified
+  o String
+}

--- a/packages/concerto-core/test/data/parser/mapdeclaration/mapdeclaration.badkey.declaration.enum.cto
+++ b/packages/concerto-core/test/data/parser/mapdeclaration/mapdeclaration.badkey.declaration.enum.cto
@@ -1,0 +1,19 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+namespace com.testing@1.0.0
+
+map Dictionary {
+  o NotDeclared
+  o String
+}

--- a/packages/concerto-core/test/data/parser/mapdeclaration/mapdeclaration.badkey.declaration.event.cto
+++ b/packages/concerto-core/test/data/parser/mapdeclaration/mapdeclaration.badkey.declaration.event.cto
@@ -1,0 +1,21 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+namespace com.testing@1.0.0
+
+event Activity {}
+
+map Dictionary {
+  o Activity
+  o String
+}

--- a/packages/concerto-core/test/data/parser/mapdeclaration/mapdeclaration.badkey.declaration.map.cto
+++ b/packages/concerto-core/test/data/parser/mapdeclaration/mapdeclaration.badkey.declaration.map.cto
@@ -1,0 +1,24 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+namespace com.testing@1.0.0
+
+map IllegalMapKey {
+  o String
+  o String
+}
+
+map Dictionary {
+  o IllegalMapKey
+  o String
+}

--- a/packages/concerto-core/test/data/parser/mapdeclaration/mapdeclaration.badkey.primitive.double.cto
+++ b/packages/concerto-core/test/data/parser/mapdeclaration/mapdeclaration.badkey.primitive.double.cto
@@ -1,0 +1,19 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+namespace com.testing@1.0.0
+
+map Dictionary {
+  o Double
+  o String
+}

--- a/packages/concerto-core/test/data/parser/mapdeclaration/mapdeclaration.badkey.primitive.integer.cto
+++ b/packages/concerto-core/test/data/parser/mapdeclaration/mapdeclaration.badkey.primitive.integer.cto
@@ -1,0 +1,19 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+namespace com.testing@1.0.0
+
+map Dictionary {
+  o Integer
+  o String
+}

--- a/packages/concerto-core/test/data/parser/mapdeclaration/mapdeclaration.badkey.primitive.long.cto
+++ b/packages/concerto-core/test/data/parser/mapdeclaration/mapdeclaration.badkey.primitive.long.cto
@@ -1,0 +1,19 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+namespace com.testing@1.0.0
+
+map Dictionary {
+  o Long
+  o String
+}

--- a/packages/concerto-core/test/data/parser/mapdeclaration/mapdeclaration.badkey.scalar.double.cto
+++ b/packages/concerto-core/test/data/parser/mapdeclaration/mapdeclaration.badkey.scalar.double.cto
@@ -1,0 +1,21 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you  may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+namespace com.testing@1.0.0
+
+scalar BAD extends Double
+
+map Dictionary {
+  o BAD
+  o String
+}

--- a/packages/concerto-core/test/data/parser/mapdeclaration/mapdeclaration.badkey.scalar.integer.cto
+++ b/packages/concerto-core/test/data/parser/mapdeclaration/mapdeclaration.badkey.scalar.integer.cto
@@ -1,0 +1,21 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+namespace com.testing@1.0.0
+
+scalar BAD extends Integer
+
+map Dictionary {
+  o BAD
+  o String
+}

--- a/packages/concerto-core/test/data/parser/mapdeclaration/mapdeclaration.badkey.scalar.long.cto
+++ b/packages/concerto-core/test/data/parser/mapdeclaration/mapdeclaration.badkey.scalar.long.cto
@@ -1,0 +1,21 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+namespace com.testing@1.0.0
+
+scalar BAD extends Long
+
+map Dictionary {
+  o BAD
+  o String
+}

--- a/packages/concerto-core/test/data/parser/mapdeclaration/mapdeclaration.goodkey.declaration.concept.cto
+++ b/packages/concerto-core/test/data/parser/mapdeclaration/mapdeclaration.goodkey.declaration.concept.cto
@@ -1,0 +1,22 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace com.testing@1.0.0 //todo makek sure namesapce is same for all test concepts
+
+concept Person identified {}
+
+map Dictionary {
+  o Person
+  o String
+}

--- a/packages/concerto-core/test/data/parser/mapdeclaration/mapdeclaration.goodkey.declaration.enum.cto
+++ b/packages/concerto-core/test/data/parser/mapdeclaration/mapdeclaration.goodkey.declaration.enum.cto
@@ -1,0 +1,24 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace com.acme@1.0.0
+
+enum Phase {
+  o ONE
+  o TWO
+}
+map Dictionary {
+  o Phase
+  o String
+}

--- a/packages/concerto-core/test/data/parser/mapdeclaration/mapdeclaration.goodkey.declaration.event.cto
+++ b/packages/concerto-core/test/data/parser/mapdeclaration/mapdeclaration.goodkey.declaration.event.cto
@@ -1,0 +1,22 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace com.acme@1.0.0
+
+event Activity {}
+
+map Dictionary {
+  o Activity
+  o String
+}

--- a/packages/concerto-core/test/data/parser/mapdeclaration/mapdeclaration.goodkey.primitive.boolean.cto
+++ b/packages/concerto-core/test/data/parser/mapdeclaration/mapdeclaration.goodkey.primitive.boolean.cto
@@ -1,0 +1,20 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace com.acme@1.0.0
+
+map Dictionary {
+  o Boolean
+  o String
+}

--- a/packages/concerto-core/test/data/parser/mapdeclaration/mapdeclaration.goodkey.primitive.datetime.cto
+++ b/packages/concerto-core/test/data/parser/mapdeclaration/mapdeclaration.goodkey.primitive.datetime.cto
@@ -1,0 +1,20 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace com.acme@1.0.0
+
+map Dictionary {
+  o DateTime
+  o String
+}

--- a/packages/concerto-core/test/data/parser/mapdeclaration/mapdeclaration.goodkey.primitive.string.cto
+++ b/packages/concerto-core/test/data/parser/mapdeclaration/mapdeclaration.goodkey.primitive.string.cto
@@ -1,0 +1,20 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace com.acme@1.0.0
+
+map Dictionary {
+  o String
+  o String
+}

--- a/packages/concerto-core/test/data/parser/mapdeclaration/mapdeclaration.goodkey.scalar.boolean.cto
+++ b/packages/concerto-core/test/data/parser/mapdeclaration/mapdeclaration.goodkey.scalar.boolean.cto
@@ -1,0 +1,22 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace com.acme@1.0.0
+
+scalar BOOL extends Boolean
+
+map Dictionary {
+  o BOOL
+  o String
+}

--- a/packages/concerto-core/test/data/parser/mapdeclaration/mapdeclaration.goodkey.scalar.datetime.cto
+++ b/packages/concerto-core/test/data/parser/mapdeclaration/mapdeclaration.goodkey.scalar.datetime.cto
@@ -1,0 +1,22 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace com.acme@1.0.0
+
+scalar DATE extends DateTime
+
+map Dictionary {
+  o DATE
+  o String
+}

--- a/packages/concerto-core/test/data/parser/mapdeclaration/mapdeclaration.goodkey.scalar.string.cto
+++ b/packages/concerto-core/test/data/parser/mapdeclaration/mapdeclaration.goodkey.scalar.string.cto
@@ -1,0 +1,22 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace com.acme@1.0.0
+
+scalar GUID extends String
+
+map Dictionary {
+  o GUID
+  o String
+}

--- a/packages/concerto-core/test/data/parser/mapdeclaration/mapdeclaration.goodvalue.declaration.concept.cto
+++ b/packages/concerto-core/test/data/parser/mapdeclaration/mapdeclaration.goodvalue.declaration.concept.cto
@@ -1,0 +1,21 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+namespace com.testing@1.0.0
+
+concept Person identified {}
+
+map Dictionary {
+  o String
+  o Person
+}

--- a/packages/concerto-core/test/data/parser/mapdeclaration/mapdeclaration.goodvalue.declaration.event.cto
+++ b/packages/concerto-core/test/data/parser/mapdeclaration/mapdeclaration.goodvalue.declaration.event.cto
@@ -1,0 +1,21 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+namespace com.testing@1.0.0
+
+event Activity {}
+
+map Dictionary {
+  o String
+  o Activity
+}

--- a/packages/concerto-core/test/data/parser/mapdeclaration/mapdeclaration.goodvalue.declaration.map.cto
+++ b/packages/concerto-core/test/data/parser/mapdeclaration/mapdeclaration.goodvalue.declaration.map.cto
@@ -1,0 +1,24 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+namespace com.testing@1.0.0
+
+map Dictionary {
+  o String
+  o String
+}
+
+map Dictionary {
+  o String
+  o Dictionary
+}

--- a/packages/concerto-core/test/data/parser/mapdeclaration/mapdeclaration.goodvalue.declaration.relationship.cto
+++ b/packages/concerto-core/test/data/parser/mapdeclaration/mapdeclaration.goodvalue.declaration.relationship.cto
@@ -1,0 +1,21 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+namespace com.testing@1.0.0
+
+concept Person identified {}
+
+map Dictionary {
+  o String
+  --> Person
+}

--- a/packages/concerto-core/test/data/parser/mapdeclaration/mapdeclaration.goodvalue.primitive.datetime.cto
+++ b/packages/concerto-core/test/data/parser/mapdeclaration/mapdeclaration.goodvalue.primitive.datetime.cto
@@ -1,0 +1,19 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+namespace com.testing@1.0.0
+
+map Dictionary {
+  o String
+  o DateTime
+}

--- a/packages/concerto-core/test/data/parser/mapdeclaration/mapdeclaration.goodvalue.primitive.double.cto
+++ b/packages/concerto-core/test/data/parser/mapdeclaration/mapdeclaration.goodvalue.primitive.double.cto
@@ -1,0 +1,19 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+namespace com.testing@1.0.0
+
+map Dictionary {
+  o String
+  o Double
+}

--- a/packages/concerto-core/test/data/parser/mapdeclaration/mapdeclaration.goodvalue.primitive.integer.cto
+++ b/packages/concerto-core/test/data/parser/mapdeclaration/mapdeclaration.goodvalue.primitive.integer.cto
@@ -1,0 +1,19 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+namespace com.testing@1.0.0
+
+map Dictionary {
+  o String
+  o Integer
+}

--- a/packages/concerto-core/test/data/parser/mapdeclaration/mapdeclaration.goodvalue.primitive.long.cto
+++ b/packages/concerto-core/test/data/parser/mapdeclaration/mapdeclaration.goodvalue.primitive.long.cto
@@ -1,0 +1,19 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+namespace com.testing@1.0.0
+
+map Dictionary {
+  o String
+  o Long
+}

--- a/packages/concerto-core/test/data/parser/mapdeclaration/mapdeclaration.goodvalue.primitive.string.cto
+++ b/packages/concerto-core/test/data/parser/mapdeclaration/mapdeclaration.goodvalue.primitive.string.cto
@@ -1,0 +1,19 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+namespace com.testing@1.0.0
+
+map Dictionary {
+  o String
+  o String
+}

--- a/packages/concerto-core/test/introspect/mapdeclaration.js
+++ b/packages/concerto-core/test/introspect/mapdeclaration.js
@@ -1,0 +1,375 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const IllegalModelException = require('../../lib/introspect/illegalmodelexception');
+
+const MapDeclaration = require('../../lib/introspect/mapdeclaration');
+const MapKeyType = require('../../lib/introspect/mapkeytype');
+const MapValueType = require('../../lib/introspect/mapvaluetype');
+
+const IntrospectUtils = require('./introspectutils');
+const ParserUtil = require('./parserutility');
+
+const ModelManager = require('../../lib/modelmanager');
+const Util = require('../composer/composermodelutility');
+
+const sinon = require('sinon');
+
+
+describe('MapDeclaration', () => {
+
+    let modelManager;
+    let modelFile;
+    let introspectUtils;
+
+    beforeEach(() => {
+        modelManager = new ModelManager();
+        Util.addComposerModel(modelManager);
+        introspectUtils = new IntrospectUtils(modelManager);
+        modelFile = ParserUtil.newModelFile(modelManager, 'namespace com.test', 'mapdeclaration.cto');
+    });
+
+    describe('#constructor', () => {
+
+        it('should throw if ast contains no MapKeyType', () => {
+            (() => {
+                new MapDeclaration(modelFile, {
+                    name: 'MapTest',
+                    properties: [
+                        {
+                            '$class': 'concerto.metamodel@1.0.0.MapKeyType',
+                            name: 'String'
+                        }
+                    ]
+                });
+            }).should.throw(IllegalModelException);
+        });
+
+        it('should throw if ast contains no MapValueType', () => {
+            (() => {
+                new MapDeclaration(modelFile, {
+                    name: 'MapTest',
+                    properties: [
+                        {
+                            '$class': 'concerto.metamodel@1.0.0.MapKeyType',
+                            name: 'Integer'
+                        }]
+                });
+            }).should.throw(IllegalModelException);
+        });
+
+        it('should throw if ast does not contain exactly two properties', () => {
+            (() => {
+                new MapDeclaration(modelFile, {
+                    name: 'MapTest',
+                    properties: [
+                        {
+                            '$class': 'concerto.metamodel@1.0.0.MapKeyType',
+                            name: 'String'
+                        },
+                        {
+                            '$class': 'concerto.metamodel@1.0.0.AggregateValueType',
+                            name: 'String'
+                        },
+                        {
+                            '$class': 'concerto.metamodel@1.0.0.StringProperty',
+                            name: 'String'
+                        }
+                    ]
+                });
+            }).should.throw(IllegalModelException);
+        });
+
+        it('should throw if ast contains properties other than MapKeyType, AggregateValueType & AggregateRelationshipValueType', () => {
+            (() => {
+                new MapDeclaration(modelFile, {
+                    name: 'MapTest',
+                    properties: [
+                        {
+                            '$class': 'concerto.metamodel@1.0.0.StringProperty',
+                            name: 'String'
+                        },
+                        {
+                            '$class': 'concerto.metamodel@1.0.0.StringProperty',
+                            name: 'String'
+                        }
+                    ]
+                });
+            }).should.throw(IllegalModelException);
+        });
+    });
+
+    describe('#validate success scenarios', () => {
+
+        it('should not throw when map key is an identified concept declaration', () => {
+            let asset = introspectUtils.loadLastDeclaration('test/data/parser/mapdeclaration/mapdeclaration.goodkey.declaration.concept.cto', MapDeclaration);
+            asset.validate();
+        });
+
+        it('should not throw when map key is an enum declaration', () => {
+            let asset = introspectUtils.loadLastDeclaration('test/data/parser/mapdeclaration/mapdeclaration.goodkey.declaration.enum.cto', MapDeclaration);
+            asset.validate();
+        });
+
+        it('should not throw when map key is primitive type boolean', () => {
+            let asset = introspectUtils.loadLastDeclaration('test/data/parser/mapdeclaration/mapdeclaration.goodkey.primitive.boolean.cto', MapDeclaration);
+            asset.validate();
+        });
+
+        it('should not throw when map key is primitive type datetime', () => {
+            let asset = introspectUtils.loadLastDeclaration('test/data/parser/mapdeclaration/mapdeclaration.goodkey.primitive.datetime.cto', MapDeclaration);
+            asset.validate();
+        });
+
+        it('should not throw when map key is primitive type string', () => {
+            let asset = introspectUtils.loadLastDeclaration('test/data/parser/mapdeclaration/mapdeclaration.goodkey.primitive.string.cto', MapDeclaration);
+            asset.validate();
+        });
+
+        it('should not throw when map key is primitive type scalar boolean', () => {
+            let asset = introspectUtils.loadLastDeclaration('test/data/parser/mapdeclaration/mapdeclaration.goodkey.scalar.boolean.cto', MapDeclaration);
+            asset.validate();
+        });
+
+        it('should not throw when map key is primitive type string datetime', () => {
+            let asset = introspectUtils.loadLastDeclaration('test/data/parser/mapdeclaration/mapdeclaration.goodkey.scalar.datetime.cto', MapDeclaration);
+            asset.validate();
+        });
+
+        it('should not throw when map key is primitive type scalar string', () => {
+            let asset = introspectUtils.loadLastDeclaration('test/data/parser/mapdeclaration/mapdeclaration.goodkey.scalar.string.cto', MapDeclaration);
+            asset.validate();
+        });
+
+        it('should not throw when map value is an identified concept declaration', () => {
+            let asset = introspectUtils.loadLastDeclaration('test/data/parser/mapdeclaration/mapdeclaration.goodvalue.declaration.concept.cto', MapDeclaration);
+            asset.validate();
+        });
+
+        it('should not throw when map value is an event declaration', () => {
+            let asset = introspectUtils.loadLastDeclaration('test/data/parser/mapdeclaration/mapdeclaration.goodvalue.declaration.event.cto', MapDeclaration);
+            asset.validate();
+        });
+
+        it('should not throw when map value is a map declaration', () => {
+            let asset = introspectUtils.loadLastDeclaration('test/data/parser/mapdeclaration/mapdeclaration.goodvalue.declaration.map.cto', MapDeclaration);
+            asset.validate();
+        });
+
+        it('should not throw when map value is a relationship', () => {
+            let asset = introspectUtils.loadLastDeclaration('test/data/parser/mapdeclaration/mapdeclaration.goodvalue.declaration.relationship.cto', MapDeclaration);
+            asset.validate();
+        });
+
+        it('should not throw when map value is a primitive string', () => {
+            let asset = introspectUtils.loadLastDeclaration('test/data/parser/mapdeclaration/mapdeclaration.goodvalue.primitive.string.cto', MapDeclaration);
+            asset.validate();
+        });
+
+        it('should not throw when map value is a primitive datetime', () => {
+            let asset = introspectUtils.loadLastDeclaration('test/data/parser/mapdeclaration/mapdeclaration.goodvalue.primitive.datetime.cto', MapDeclaration);
+            asset.validate();
+        });
+
+        it('should not throw when map value is a primitive double', () => {
+            let asset = introspectUtils.loadLastDeclaration('test/data/parser/mapdeclaration/mapdeclaration.goodvalue.primitive.double.cto', MapDeclaration);
+            asset.validate();
+        });
+
+        it('should not throw when map value is a primitive integer', () => {
+            let asset = introspectUtils.loadLastDeclaration('test/data/parser/mapdeclaration/mapdeclaration.goodvalue.primitive.integer.cto', MapDeclaration);
+            asset.validate();
+        });
+
+        it('should not throw when map value is a primitive long', () => {
+            let asset = introspectUtils.loadLastDeclaration('test/data/parser/mapdeclaration/mapdeclaration.goodvalue.primitive.long.cto', MapDeclaration);
+            asset.validate();
+        });
+
+    });
+
+    describe('#validate failure scenarios', () => {
+        it('should throw validating with a non-identified concept declaration as key', function() {
+            (() => {
+                let asset = introspectUtils.loadLastDeclaration('test/data/parser/mapdeclaration/mapdeclaration.badkey.declaration.concept.cto', MapDeclaration);
+                asset.validate();
+            }).should.throw(/ConceptDeclaration must be identified in context of MapKeyType: NotIdentified/);
+        });
+
+        it('should throw when an enum key declaration missing', function() {
+            (() => {
+                let asset = introspectUtils.loadLastDeclaration('test/data/parser/mapdeclaration/mapdeclaration.badkey.declaration.enum.cto', MapDeclaration);
+                asset.validate();
+            }).should.throw(/MapKeyType has invalid Type: NotDeclared/);
+        });
+
+        it('should throw when map key is an event declaration', function() {
+            (() => {
+                let asset = introspectUtils.loadLastDeclaration('test/data/parser/mapdeclaration/mapdeclaration.badkey.declaration.event.cto', MapDeclaration);
+                asset.validate();
+            }).should.throw(/MapKeyType has invalid Type: Activity/);
+        });
+
+        it('should throw when map key is of type MapDeclaration', function() {
+            (() => {
+                let asset = introspectUtils.loadLastDeclaration('test/data/parser/mapdeclaration/mapdeclaration.badkey.declaration.map.cto', MapDeclaration);
+                asset.validate();
+            }).should.throw(/MapKeyType has invalid Type: IllegalMapKey/);
+        });
+
+        it('should throw when map key is of primitive type Double', function() {
+            (() => {
+                let asset = introspectUtils.loadLastDeclaration('test/data/parser/mapdeclaration/mapdeclaration.badkey.primitive.double.cto', MapDeclaration);
+                asset.validate();
+            }).should.throw(/MapKeyType has invalid Type: Double/);
+        });
+
+        it('should throw when map key is of primitive type Integer', function() {
+            (() => {
+                let asset = introspectUtils.loadLastDeclaration('test/data/parser/mapdeclaration/mapdeclaration.badkey.primitive.integer.cto', MapDeclaration);
+                asset.validate();
+            }).should.throw(/MapKeyType has invalid Type: Integer/);
+        });
+
+        it('should throw when map key is of primitive type Long', function() {
+            (() => {
+                let asset = introspectUtils.loadLastDeclaration('test/data/parser/mapdeclaration/mapdeclaration.badkey.primitive.long.cto', MapDeclaration);
+                asset.validate();
+            }).should.throw(/MapKeyType has invalid Type: Long/);
+        });
+
+        it('should throw when map key is of scalar type Double', function() {
+            (() => {
+                let asset = introspectUtils.loadLastDeclaration('test/data/parser/mapdeclaration/mapdeclaration.badkey.scalar.double.cto', MapDeclaration);
+                asset.validate();
+            }).should.throw(/Scalar must be one of StringScalar, BooleanScalar, DateTimeScalar in context of MapKeyType. Invalid Scalar: BAD/);
+        });
+
+        it('should throw when map key is of scalar type Integer', function() {
+            (() => {
+                let asset = introspectUtils.loadLastDeclaration('test/data/parser/mapdeclaration/mapdeclaration.badkey.scalar.integer.cto', MapDeclaration);
+                asset.validate();
+            }).should.throw(/Scalar must be one of StringScalar, BooleanScalar, DateTimeScalar in context of MapKeyType. Invalid Scalar: BAD/);
+        });
+
+        it('should throw when map key is of scalar type Long', function() {
+            (() => {
+                let asset = introspectUtils.loadLastDeclaration('test/data/parser/mapdeclaration/mapdeclaration.badkey.scalar.long.cto', MapDeclaration);
+                asset.validate();
+            }).should.throw(/Scalar must be one of StringScalar, BooleanScalar, DateTimeScalar in context of MapKeyType. Invalid Scalar: BAD/);
+        });
+    });
+
+    describe('#accept', () => {
+        it('should call the visitor', () => {
+            let clz = new MapDeclaration(modelFile, {
+                name: 'MapTest',
+                properties: [
+                    {
+                        '$class': 'concerto.metamodel@1.0.0.MapKeyType',
+                        name: 'String'
+                    },
+                    {
+                        '$class': 'concerto.metamodel@1.0.0.AggregateValueType',
+                        name: 'String'
+                    }
+                ]
+            });
+            let visitor = {
+                visit: sinon.stub()
+            };
+            clz.accept(visitor, ['some', 'args']);
+            sinon.assert.calledOnce(visitor.visit);
+            sinon.assert.calledWith(visitor.visit, clz, ['some', 'args']);
+        });
+
+    });
+
+    describe('#getKey', () => {
+        it('should return the map key property', () => {
+            let clz = new MapDeclaration(modelFile, {
+                name: 'MapTest',
+                properties: [
+                    {
+                        '$class': 'concerto.metamodel@1.0.0.MapKeyType',
+                        name: 'DateTime'
+                    },
+                    {
+                        '$class': 'concerto.metamodel@1.0.0.AggregateValueType',
+                        name: 'String'
+                    }
+                ]
+            });
+            (clz.getKey() instanceof MapKeyType).should.be.equal(true);
+            clz.getKey().ast.$class.should.equal('concerto.metamodel@1.0.0.MapKeyType');
+            clz.getKey().ast.name.should.equal('DateTime');
+        });
+    });
+
+    describe('#getValue', () => {
+        it('should return the map value property', () => {
+            let clz = new MapDeclaration(modelFile, {
+                name: 'MapTest',
+                properties: [
+                    {
+                        '$class': 'concerto.metamodel@1.0.0.MapKeyType',
+                        name: 'DateTime'
+                    },
+                    {
+                        '$class': 'concerto.metamodel@1.0.0.AggregateValueType',
+                        name: 'String'
+                    }
+                ]
+            });
+            (clz.getValue() instanceof MapValueType).should.be.equal(true);
+            clz.getValue().ast.$class.should.equal('concerto.metamodel@1.0.0.AggregateValueType');
+            clz.getValue().ast.name.should.equal('String');
+        });
+    });
+
+    describe('#getProperties', () => {
+        it('should return the map properties', () => {
+            let clz = new MapDeclaration(modelFile, {
+                name: 'MapTest',
+                properties: [
+                    {
+                        '$class': 'concerto.metamodel@1.0.0.MapKeyType',
+                        'name': 'String'
+                    },
+                    {
+                        '$class': 'concerto.metamodel@1.0.0.AggregateValueType',
+                        'name': 'String'
+                    }
+                ]
+            });
+            clz.getProperties().length.should.be.equal(2);
+        });
+    });
+
+    describe('#declarationKind', () => {
+        it('should return that declaration kind - MapDeclaration', () => {
+            let declaration = introspectUtils.loadLastDeclaration('test/data/parser/mapdeclaration/mapdeclaration.goodkey.declaration.concept.cto', MapDeclaration);
+            (declaration.declarationKind()).should.equal('MapDeclaration');
+        });
+    });
+
+    describe('#toString', () => {
+        it('should give the correct value for Map Declaration', () => {
+            let declaration = introspectUtils.loadLastDeclaration('test/data/parser/mapdeclaration/mapdeclaration.goodkey.declaration.concept.cto', MapDeclaration);
+            declaration.toString().should.equal('MapDeclaration {id=com.testing@1.0.0.Dictionary}');
+        });
+    });
+});

--- a/packages/concerto-core/types/lib/basemodelmanager.d.ts
+++ b/packages/concerto-core/types/lib/basemodelmanager.d.ts
@@ -241,6 +241,11 @@ declare class BaseModelManager {
      */
     getParticipantDeclarations(): ParticipantDeclaration[];
     /**
+     * Get the MapDeclarations defined in this model manager
+     * @return {MapDeclaration[]} the MapDeclaration defined in the model manager
+     */
+    getMapDeclarations(): MapDeclaration[];
+    /**
      * Get the EnumDeclarations defined in this model manager
      * @return {EnumDeclaration[]} the EnumDeclaration defined in the model manager
      */

--- a/packages/concerto-core/types/lib/introspect/mapdeclaration.d.ts
+++ b/packages/concerto-core/types/lib/introspect/mapdeclaration.d.ts
@@ -1,0 +1,126 @@
+export = MapDeclaration;
+/**
+ * MapDeclaration defines an MapType of Key & Value pair.
+ *
+ * @extends Decorated
+ * @see See {@link Decorated}
+ * @class
+ * @memberof module:concerto-core
+ */
+declare class MapDeclaration extends Decorated {
+    /**
+     * Create an MapDeclaration.
+     * @param {ModelFile} modelFile the ModelFile for this class
+     * @param {Object} ast - The AST created by the parser
+     * @throws {IllegalModelException}
+     */
+    constructor(modelFile: ModelFile, ast: any);
+    modelFile: ModelFile;
+    name: any;
+    key: MapKeyType;
+    value: MapPropertyType;
+    fqn: string;
+    /**
+     * Semantic validation of the structure of this class.
+     *
+     * @throws {IllegalModelException}
+     * @protected
+     */
+    protected validate(): void;
+    /**
+     * Returns the fully qualified name of this class.
+     * The name will include the namespace if present.
+     *
+     * @return {string} the fully-qualified name of this class
+     */
+    getFullyQualifiedName(): string;
+    /**
+     * Returns the short name of a class. This name does not include the
+     * namespace from the owning ModelFile.
+     *
+     * @return {string} the short name of this class
+     */
+    getName(): string;
+    /**
+     * Returns the type of the Map key property.
+     *
+     * @return {string} the short name of this class
+     */
+    getKey(): string;
+    /**
+     * Returns the type of the Map Value property.
+     *
+     * @return {string} the short name of this class
+     */
+    getValue(): string;
+    /**
+     * Returns the MapDeclaration properties
+     *
+     * @return {array} the short name of this class
+     */
+    getProperties(): any[];
+    /**
+     * Returns the kind of declaration
+     *
+     * @return {string} what kind of declaration this is
+     */
+    declarationKind(): string;
+    /**
+     * Returns true if this class is abstract.
+     *
+     * @return {boolean} true if the class is abstract
+     */
+    isAbstract(): boolean;
+    /**
+     * Returns true if this class is the definition of an asset.
+     *
+     * @return {boolean} true if the class is an asset
+     */
+    isAsset(): boolean;
+    /**
+     * Returns true if this class is the definition of a participant.
+     *
+     * @return {boolean} true if the class is a participant
+     */
+    isParticipant(): boolean;
+    /**
+     * Returns true if this class is the definition of a transaction.
+     *
+     * @return {boolean} true if the class is a transaction
+     */
+    isTransaction(): boolean;
+    /**
+     * Returns true if this class is the definition of an event.
+     *
+     * @return {boolean} true if the class is an event
+     */
+    isEvent(): boolean;
+    /**
+     * Returns true if this class is the definition of a concept.
+     *
+     * @return {boolean} true if the class is a concept
+     */
+    isConcept(): boolean;
+    /**
+     * Returns true if this class is the definition of an enum.
+     *
+     * @return {boolean} true if the class is an enum
+     */
+    isEnum(): boolean;
+    /**
+     * Returns true if this class is the definition of a scalar declaration.
+     *
+     * @return {boolean} true if the class is a scalar
+     */
+    isScalarDeclaration(): boolean;
+    /**
+     * Returns true if this class is the definition of a class declaration.
+     *
+     * @return {boolean} true if the class is a class
+     */
+    isMapDeclaration(): boolean;
+}
+import Decorated = require("./decorated");
+import ModelFile = require("./modelfile");
+import MapKeyType = require("./mapkeytype");
+import MapPropertyType = require("./mapvaluetype");

--- a/packages/concerto-core/types/lib/introspect/mapkeytype.d.ts
+++ b/packages/concerto-core/types/lib/introspect/mapkeytype.d.ts
@@ -1,0 +1,51 @@
+export = MapKeyType;
+/**
+ * MapKeyType defines a Key type of an MapDeclaration.
+ *
+ * @extends Decorated
+ * @see See {@link Decorated}
+ * @class
+ * @memberof module:concerto-core
+ */
+declare class MapKeyType extends Decorated {
+    /**
+     * Create an MapKeyType.
+     * @param {MapDeclaration} parent - The owner of this property
+     * @param {Object} ast - The AST created by the parser
+     * @throws {IllegalModelException}
+     */
+    constructor(parent: MapDeclaration, ast: any);
+    parent: MapDeclaration;
+    name: any;
+    type: any;
+    fqn: string;
+    /**
+     * Semantic validation of the structure of this class.
+     *
+     * @throws {IllegalModelException}
+     * @protected
+     */
+    protected validate(): void;
+    /**
+     * Returns the fully qualified name of this class.
+     * The name will include the namespace if present.
+     *
+     * @return {string} the fully-qualified name of this class
+     */
+    getFullyQualifiedName(): string;
+    /**
+     * Returns the name of the MapKey. This name does not include the
+     * namespace from the owning ModelFile.
+     *
+     * @return {string} the short name of this class
+     */
+    getName(): string;
+    /**
+     * Returns the Type of the MapKey. This name does not include the
+     * namespace from the owning ModelFile.
+     *
+     * @return {string} the short name of this class
+     */
+    getType(): string;
+}
+import Decorated = require("./decorated");

--- a/packages/concerto-core/types/lib/introspect/mapvaluetype.d.ts
+++ b/packages/concerto-core/types/lib/introspect/mapvaluetype.d.ts
@@ -1,0 +1,51 @@
+export = MapValueType;
+/**
+ * MapValueType defines a Value type of MapDeclaration.
+ *
+ * @extends Decorated
+ * @see See {@link Decorated}
+ * @class
+ * @memberof module:concerto-core
+ */
+declare class MapValueType extends Decorated {
+    /**
+     * Create an MapValueType.
+     * @param {MapDeclaration} parent - The owner of this property
+     * @param {Object} ast - The AST created by the parser
+     * @throws {IllegalModelException}
+     */
+    constructor(parent: MapDeclaration, ast: any);
+    parent: MapDeclaration;
+    name: any;
+    type: any;
+    fqn: string;
+    /**
+     * Semantic validation of the structure of this class.
+     *
+     * @throws {IllegalModelException}
+     * @protected
+     */
+    protected validate(): void;
+    /**
+     * Returns the fully qualified name of this class.
+     * The name will include the namespace if present.
+     *
+     * @return {string} the fully-qualified name of this class
+     */
+    getFullyQualifiedName(): string;
+    /**
+     * Returns the name of the MapValue. This name does not include the
+     * namespace from the owning ModelFile.
+     *
+     * @return {string} the short name of this class
+     */
+    getName(): string;
+    /**
+     * Returns the Type of the MapValue. This name does not include the
+     * namespace from the owning ModelFile.
+     *
+     * @return {string} the short name of this class
+     */
+    getType(): string;
+}
+import Decorated = require("./decorated");

--- a/packages/concerto-core/types/lib/introspect/modelfile.d.ts
+++ b/packages/concerto-core/types/lib/introspect/modelfile.d.ts
@@ -212,6 +212,11 @@ declare class ModelFile extends Decorated {
      */
     getEnumDeclarations(): EnumDeclaration[];
     /**
+     * Get the MapDeclarations defined in this ModelFile
+     * @return {MapDeclaration[]} the MapDeclarations defined in the model file
+     */
+    getMapDeclarations(): MapDeclaration[];
+    /**
      * Get the ScalarDeclaration defined in this ModelFile
      * @return {ScalarDeclaration[]} the ScalarDeclaration defined in the model file
      */
@@ -287,4 +292,5 @@ import EventDeclaration = require("./eventdeclaration");
 import ParticipantDeclaration = require("./participantdeclaration");
 import ConceptDeclaration = require("./conceptdeclaration");
 import EnumDeclaration = require("./enumdeclaration");
+import MapDeclaration = require("./mapdeclaration");
 import ScalarDeclaration = require("./scalardeclaration");


### PR DESCRIPTION
<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #<CORRESPONDING ISSUE NUMBER>
<!--- Provide an overall summary of the pull request -->

This change adds the specified classes for runtime introspection of a MapType - `MapDeclaration`,`MapKeyType` and a general `AggregateValueType`. Each class is responsible for processing of an AST representation of a MapDeclaration before instantiation, exposing various functionality, as well as correct validation for each of its parts.

For more information on the design specification see [here](https://github.com/accordproject/concerto/wiki/Aggregate-Types-Design)

### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
- <ONE> Added classes for `MapDeclaration`,`MapKeyType` and `AggregateValueType`
- <TWO> Added test coverage
- <THREE> Added type definitions

### Related Issues
- Issue #447 

### Author Checklist
- [X] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [X] Vital features and changes captured in unit and/or integration tests
- [X] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ ] Merging to `main` from `fork:branchname`
