### PR TITLE
fix(identifiers): add comma to list of whitespace and jointers to be turned into a lower dash

### DIFF
--- a/packages/concerto-util/lib/identifiers.js
+++ b/packages/concerto-util/lib/identifiers.js
@@ -47,7 +47,7 @@ function normalizeIdentifier(identifier, truncateLength = -1) {
         .replace(/^\p{Nd}/u, '_$&')
 
     // 2. Substitute Whitespace, and joiners
-        .replace(/[-‐−@#:;><|/\\\u200c\u200d]/g, '_')
+        .replace(/[-‐−@#:;,><|/\\\u200c\u200d]/g, '_')
         .replace(/\s/g, '_')
 
     // 3a. Replace Invalid Characters


### PR DESCRIPTION
# Closes #655 
Adds comma (`,`) to list of whitespace and jointers to be turned into a lower dash (`_`) when normalising.

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [x] Extend the documentation, if necessary
- [x] Merging to `main` from `fork:branchname`
