### PR TITLE
feat(map): add serialisation for map<string, string>

### DIFF
--- a/packages/concerto-core/lib/modelutil.js
+++ b/packages/concerto-core/lib/modelutil.js
@@ -191,7 +191,7 @@ class ModelUtil {
     }
 
     /**
-     * Returns the true if the given field is an enumerated type
+     * Returns true if the given field is an enumerated type
      * @param {Field} field - the string
      * @return {boolean} true if the field is declared as an enumeration
      * @private
@@ -203,7 +203,7 @@ class ModelUtil {
     }
 
     /**
-     * Returns the true if the given field is an map type
+     * Returns true if the given field is an map type
      * @param {Field} field - the string
      * @return {boolean} true if the field is declared as an map
      * @private
@@ -215,7 +215,7 @@ class ModelUtil {
     }
 
     /**
-     * Returns the true if the given field is a Scalar type
+     * Returns true if the given field is a Scalar type
      * @param {Field} field - the Field to test
      * @return {boolean} true if the field is declared as an scalar
      * @private

--- a/packages/concerto-core/lib/modelutil.js
+++ b/packages/concerto-core/lib/modelutil.js
@@ -199,7 +199,7 @@ class ModelUtil {
     static isEnum(field) {
         const modelFile = field.getParent().getModelFile();
         const typeDeclaration = modelFile.getType(field.getType());
-        return (typeDeclaration !== null && typeDeclaration.isEnum());
+        return typeDeclaration?.isEnum();
     }
 
     /**
@@ -211,7 +211,7 @@ class ModelUtil {
     static isMap(field) {
         const modelFile = field.getParent().getModelFile();
         const typeDeclaration = modelFile.getType(field.getType());
-        return (typeDeclaration !== null && typeDeclaration?.isMapDeclaration?.());
+        return typeDeclaration?.isMapDeclaration?.();
     }
 
     /**
@@ -223,7 +223,7 @@ class ModelUtil {
     static isScalar(field) {
         const modelFile = field.getParent().getModelFile();
         const declaration = modelFile.getType(field.getType());
-        return (declaration !== null && declaration.isScalarDeclaration?.());
+        return declaration?.isScalarDeclaration?.();
     }
 
     /**

--- a/packages/concerto-core/lib/modelutil.js
+++ b/packages/concerto-core/lib/modelutil.js
@@ -211,7 +211,7 @@ class ModelUtil {
     static isMap(field) {
         const modelFile = field.getParent().getModelFile();
         const typeDeclaration = modelFile.getType(field.getType());
-        return (typeDeclaration !== null && typeDeclaration?.isMapDeclaration());
+        return (typeDeclaration !== null && typeDeclaration?.isMapDeclaration?.());
     }
 
     /**

--- a/packages/concerto-core/lib/modelutil.js
+++ b/packages/concerto-core/lib/modelutil.js
@@ -203,6 +203,18 @@ class ModelUtil {
     }
 
     /**
+     * Returns the true if the given field is an map type
+     * @param {Field} field - the string
+     * @return {boolean} true if the field is declared as an map
+     * @private
+     */
+    static isMap(field) {
+        const modelFile = field.getParent().getModelFile();
+        const typeDeclaration = modelFile.getType(field.getType());
+        return (typeDeclaration !== null && typeDeclaration?.isMapDeclaration());
+    }
+
+    /**
      * Returns the true if the given field is a Scalar type
      * @param {Field} field - the Field to test
      * @return {boolean} true if the field is declared as an scalar

--- a/packages/concerto-core/lib/serializer.js
+++ b/packages/concerto-core/lib/serializer.js
@@ -174,7 +174,7 @@ class Serializer {
                 classDeclaration.getName(),
                 jsonObject[classDeclaration.getIdentifierFieldName()] );
         } else if (classDeclaration.isMapDeclaration?.()) {
-            throw new Error('Attempting to create an Map declaration is not supported.');
+            throw new Error('Attempting to create a Map declaration is not supported.');
         } else if (classDeclaration.isEnum()) {
             throw new Error('Attempting to create an ENUM declaration is not supported.');
         } else {

--- a/packages/concerto-core/lib/serializer.js
+++ b/packages/concerto-core/lib/serializer.js
@@ -173,6 +173,8 @@ class Serializer {
             resource = this.factory.newConcept(classDeclaration.getNamespace(),
                 classDeclaration.getName(),
                 jsonObject[classDeclaration.getIdentifierFieldName()] );
+        } else if (classDeclaration.isMapDeclaration()) {
+            throw new Error('Attempting to create an Map declaration is not supported.');
         } else if (classDeclaration.isEnum()) {
             throw new Error('Attempting to create an ENUM declaration is not supported.');
         } else {

--- a/packages/concerto-core/lib/serializer.js
+++ b/packages/concerto-core/lib/serializer.js
@@ -161,19 +161,19 @@ class Serializer {
 
         // create a new instance, using the identifier field name as the ID.
         let resource;
-        if (classDeclaration.isTransaction()) {
+        if (classDeclaration.isTransaction?.()) {
             resource = this.factory.newTransaction(classDeclaration.getNamespace(),
                 classDeclaration.getName(),
                 jsonObject[classDeclaration.getIdentifierFieldName()] );
-        } else if (classDeclaration.isEvent()) {
+        } else if (classDeclaration.isEvent?.()) {
             resource = this.factory.newEvent(classDeclaration.getNamespace(),
                 classDeclaration.getName(),
                 jsonObject[classDeclaration.getIdentifierFieldName()] );
-        } else if (classDeclaration.isConcept()) {
+        } else if (classDeclaration.isConcept?.()) {
             resource = this.factory.newConcept(classDeclaration.getNamespace(),
                 classDeclaration.getName(),
                 jsonObject[classDeclaration.getIdentifierFieldName()] );
-        } else if (classDeclaration.isMapDeclaration()) {
+        } else if (classDeclaration.isMapDeclaration?.()) {
             throw new Error('Attempting to create an Map declaration is not supported.');
         } else if (classDeclaration.isEnum()) {
             throw new Error('Attempting to create an ENUM declaration is not supported.');

--- a/packages/concerto-core/lib/serializer/instancegenerator.js
+++ b/packages/concerto-core/lib/serializer/instancegenerator.js
@@ -194,7 +194,7 @@ class InstanceGenerator {
      * @throws {Error} if no concrete subclasses exist.
      */
     findConcreteSubclass(declaration) {
-        if (!declaration.isAbstract?.()) {
+        if (declaration.isMapDeclaration?.() || !declaration.isAbstract()) {
             return declaration;
         }
 

--- a/packages/concerto-core/lib/serializer/instancegenerator.js
+++ b/packages/concerto-core/lib/serializer/instancegenerator.js
@@ -37,6 +37,8 @@ class InstanceGenerator {
     visit(thing, parameters) {
         if (thing.isClassDeclaration?.()) {
             return this.visitClassDeclaration(thing, parameters);
+        } else if (thing.isMapDeclaration?.()) {
+            return this.visitMapDeclaration(thing, parameters);
         } else if (thing.isRelationship?.()) {
             return this.visitRelationshipDeclaration(thing, parameters);
         } else if (thing.isTypeScalar?.()) {
@@ -152,31 +154,33 @@ class InstanceGenerator {
             }
         }
 
-        let classDeclaration = parameters.modelManager.getType(type);
+        let declaration = parameters.modelManager.getType(type);
 
-        if (classDeclaration.isEnum()) {
-            let enumValues = classDeclaration.getOwnProperties();
+        if (declaration.isEnum()) {
+            let enumValues = declaration.getOwnProperties();
             return parameters.valueGenerator.getEnum(enumValues).getName();
         }
 
-        classDeclaration = this.findConcreteSubclass(classDeclaration);
+        declaration = this.findConcreteSubclass(declaration);
 
-        let id = null;
-        if (classDeclaration.isIdentified()) {
-            let idFieldName = classDeclaration.getIdentifierFieldName();
-            let idField = classDeclaration.getProperty(idFieldName);
-            if (idField?.isTypeScalar?.()){
-                idField = idField.getScalarField();
+        if (!declaration.isMapDeclaration?.()) {
+            let id = null;
+            if (declaration.isIdentified()) {
+                let idFieldName = declaration.getIdentifierFieldName();
+                let idField = declaration.getProperty(idFieldName);
+                if (idField?.isTypeScalar?.()){
+                    idField = idField.getScalarField();
+                }
+                if(idField?.validator?.regex){
+                    id = parameters.valueGenerator.getRegex(fieldOrScalarDeclaration.validator.regex);
+                } else {
+                    id = this.generateRandomId(declaration);
+                }
             }
-            if(idField?.validator?.regex){
-                id = parameters.valueGenerator.getRegex(fieldOrScalarDeclaration.validator.regex);
-            } else {
-                id = this.generateRandomId(classDeclaration);
-            }
+            let resource = parameters.factory.newResource(declaration.getNamespace(), declaration.getName(), id);
+            parameters.stack.push(resource);
         }
-        let resource = parameters.factory.newResource(classDeclaration.getNamespace(), classDeclaration.getName(), id);
-        parameters.stack.push(resource);
-        return classDeclaration.accept(this, parameters);
+        return declaration.accept(this, parameters);
     }
 
     /**
@@ -190,7 +194,7 @@ class InstanceGenerator {
      * @throws {Error} if no concrete subclasses exist.
      */
     findConcreteSubclass(declaration) {
-        if (!declaration.isAbstract()) {
+        if (!declaration.isAbstract?.()) {
             return declaration;
         }
 
@@ -227,6 +231,17 @@ class InstanceGenerator {
         } else {
             return valueSupplier();
         }
+    }
+
+    /**
+     * Visitor design pattern
+     * @param {MapDeclaration} mapDeclaration - the object being visited
+     * @param {Object} parameters  - the parameter
+     * @return {Object} the result of visiting or null
+     * @private
+     */
+    visitMapDeclaration(mapDeclaration, parameters) {
+        return parameters.valueGenerator.getMap();
     }
 
     /**

--- a/packages/concerto-core/lib/serializer/jsongenerator.js
+++ b/packages/concerto-core/lib/serializer/jsongenerator.js
@@ -65,6 +65,8 @@ class JSONGenerator {
             return this.visitClassDeclaration(thing, parameters);
         } else if (thing.isRelationship?.()) {
             return this.visitRelationshipDeclaration(thing, parameters);
+        }else if (thing.isMapDeclaration?.()) {
+            return this.visitMapDeclaration(thing, parameters);
         } else if (thing.isTypeScalar?.()) {
             return this.visitField(thing.getScalarField(), parameters);
         } else if (thing.isField?.()) {
@@ -72,6 +74,21 @@ class JSONGenerator {
         } else {
             throw new Error('Unrecognised ' + JSON.stringify(thing));
         }
+    }
+
+    /**
+     * Visitor design pattern
+     * @param {MapDeclaration} mapDeclaration - the object being visited
+     * @param {Object} parameters  - the parameter
+     * @return {Object} the result of visiting or null
+     * @private
+     */
+    visitMapDeclaration(mapDeclaration, parameters) {
+        const obj = parameters.stack.pop();
+        if (!((obj instanceof Map))) {
+            throw new Error('Expected a Map, but found ' + obj);
+        }
+        return Object.fromEntries(obj);
     }
 
     /**
@@ -148,7 +165,12 @@ class JSONGenerator {
             result = this.convertToJSON(field, obj);
         } else if (ModelUtil.isEnum(field)) {
             result = this.convertToJSON(field, obj);
-        } else {
+        } else if (obj instanceof Map) {
+            parameters.stack.push(obj);
+            const mapDeclaration = parameters.modelManager.getType(field.getFullyQualifiedTypeName());
+            result = mapDeclaration.accept(this, parameters);
+        }
+        else {
             parameters.stack.push(obj);
             const classDeclaration = parameters.modelManager.getType(obj.getFullyQualifiedType());
             result = classDeclaration.accept(this, parameters);

--- a/packages/concerto-core/lib/serializer/jsongenerator.js
+++ b/packages/concerto-core/lib/serializer/jsongenerator.js
@@ -85,9 +85,6 @@ class JSONGenerator {
      */
     visitMapDeclaration(mapDeclaration, parameters) {
         const obj = parameters.stack.pop();
-        if (!((obj instanceof Map))) {
-            throw new Error('Expected a Map, but found ' + obj);
-        }
         return Object.fromEntries(obj);
     }
 

--- a/packages/concerto-core/lib/serializer/jsongenerator.js
+++ b/packages/concerto-core/lib/serializer/jsongenerator.js
@@ -85,7 +85,7 @@ class JSONGenerator {
      */
     visitMapDeclaration(mapDeclaration, parameters) {
         const obj = parameters.stack.pop();
-        return Object.fromEntries(obj);
+        return { $class: obj.$class, value: Object.fromEntries(obj.value)};
     }
 
     /**
@@ -162,7 +162,7 @@ class JSONGenerator {
             result = this.convertToJSON(field, obj);
         } else if (ModelUtil.isEnum(field)) {
             result = this.convertToJSON(field, obj);
-        } else if (obj instanceof Map) {
+        } else if (ModelUtil.isMap(field)) {
             parameters.stack.push(obj);
             const mapDeclaration = parameters.modelManager.getType(field.getFullyQualifiedTypeName());
             result = mapDeclaration.accept(this, parameters);

--- a/packages/concerto-core/lib/serializer/jsonpopulator.js
+++ b/packages/concerto-core/lib/serializer/jsonpopulator.js
@@ -121,6 +121,8 @@ class JSONPopulator {
 
         if (thing.isClassDeclaration?.()) {
             return this.visitClassDeclaration(thing, parameters);
+        } else if (thing.isMapDeclaration?.()) {
+            return this.visitMapDeclaration(thing, parameters);
         } else if (thing.isRelationship?.()) {
             return this.visitRelationshipDeclaration(thing, parameters);
         } else if (thing.isTypeScalar?.()) {
@@ -162,6 +164,18 @@ class JSONPopulator {
 
     /**
      * Visitor design pattern
+     * @param {MapDeclaration} mapDeclaration - the object being visited
+     * @param {Object} parameters  - the parameter
+     * @return {Object} the result of visiting or null
+     * @private
+     */
+    visitMapDeclaration(mapDeclaration, parameters) {
+        const jsonObj = parameters.jsonStack.pop();
+        return new Map(Object.entries(jsonObj));
+    }
+
+    /**
+     * Visitor design pattern
      * @param {Field} field - the object being visited
      * @param {Object} parameters  - the parameter
      * @return {Object} the result of visiting or null
@@ -197,7 +211,7 @@ class JSONPopulator {
     convertItem(field, jsonItem, parameters) {
         let result = null;
 
-        if(!field.isPrimitive() && !field.isTypeEnum()) {
+        if(!field.isPrimitive?.() && !field.isTypeEnum?.()) {
             let typeName = jsonItem.$class;
             if(!typeName) {
                 // If the type name is not specified in the data, then use the
@@ -207,26 +221,26 @@ class JSONPopulator {
             }
 
             // This throws if the type does not exist.
-            const classDeclaration = parameters.modelManager.getType(typeName);
+            const declaration = parameters.modelManager.getType(typeName);
 
-            // create a new instance, using the identifier field name as the ID.
-            let subResource = null;
+            if (!declaration.isMapDeclaration?.()) {
 
-            // if this is identifiable, then we create a resource
-            if(classDeclaration.isIdentified()) {
-                subResource = parameters.factory.newResource(classDeclaration.getNamespace(),
-                    classDeclaration.getName(), jsonItem[classDeclaration.getIdentifierFieldName()] );
+                // create a new instance, using the identifier field name as the ID.
+                let subResource = null;
+
+                // if this is identifiable, then we create a resource
+                if (declaration.isIdentified()) {
+                    subResource = parameters.factory.newResource(declaration.getNamespace(),
+                        declaration.getName(), jsonItem[declaration.getIdentifierFieldName()] );
+                } else {
+                    // otherwise we create a concept
+                    subResource = parameters.factory.newConcept(declaration.getNamespace(),
+                        declaration.getName());
+                }
+                parameters.resourceStack.push(subResource);
             }
-            else {
-                // otherwise we create a concept
-                subResource = parameters.factory.newConcept(classDeclaration.getNamespace(),
-                    classDeclaration.getName() );
-            }
-
-            result = subResource;
-            parameters.resourceStack.push(subResource);
             parameters.jsonStack.push(jsonItem);
-            classDeclaration.accept(this, parameters);
+            result = declaration.accept(this, parameters);
         }
         else {
             result = this.convertToObject(field, jsonItem, parameters);

--- a/packages/concerto-core/lib/serializer/jsonpopulator.js
+++ b/packages/concerto-core/lib/serializer/jsonpopulator.js
@@ -171,7 +171,7 @@ class JSONPopulator {
      */
     visitMapDeclaration(mapDeclaration, parameters) {
         const jsonObj = parameters.jsonStack.pop();
-        return new Map(Object.entries(jsonObj));
+        return { $class: jsonObj.$class, value: new Map(Object.entries(jsonObj)) };
     }
 
     /**

--- a/packages/concerto-core/lib/serializer/jsonpopulator.js
+++ b/packages/concerto-core/lib/serializer/jsonpopulator.js
@@ -171,7 +171,18 @@ class JSONPopulator {
      */
     visitMapDeclaration(mapDeclaration, parameters) {
         const jsonObj = parameters.jsonStack.pop();
-        return { $class: jsonObj.$class, value: new Map(Object.entries(jsonObj)) };
+        parameters.path ?? (parameters.path = new TypedStack('$'));
+        const path = parameters.path.stack.join('');
+
+        if(!jsonObj.$class) {
+            throw new Error(`Invalid JSON data at "${path}". Map value does not contain a $class type identifier.`);
+        }
+
+        if(!jsonObj.value) {
+            throw new Error(`Invalid JSON data at "${path}". Map value does not contain a value property.`);
+        }
+
+        return { $class: jsonObj.$class, value: new Map(Object.entries(jsonObj.value)) };
     }
 
     /**

--- a/packages/concerto-core/lib/serializer/resourcevalidator.js
+++ b/packages/concerto-core/lib/serializer/resourcevalidator.js
@@ -114,19 +114,19 @@ class ResourceValidator {
      * @private
      */
     visitMapDeclaration(mapDeclaration, parameters) {
-        const obj = parameters.stack.pop();
-        let m = new Map(Object.entries(obj));
-        const keys = m.keys();
-        const values = m.values();
 
-        for (let i= 0; i < m.size; i++) {
-            if ((typeof keys.next().value) !== 'string') {
-                ResourceValidator.reportInvalidMap(parameters.rootResourceIdentifier, mapDeclaration, obj );
+        const obj = parameters.stack.pop();
+
+        obj.forEach((key,value) => {
+            if(!ModelUtil.isSystemProperty(key)) {
+                if (typeof key !== 'string') {
+                    ResourceValidator.reportInvalidMap(parameters.rootResourceIdentifier, mapDeclaration, obj );
+                }
+                if (typeof value !== 'string') {
+                    ResourceValidator.reportInvalidMap(parameters.rootResourceIdentifier, mapDeclaration, obj );
+                }
             }
-            if ((typeof values.next().value) !== 'string') {
-                ResourceValidator.reportInvalidMap(parameters.rootResourceIdentifier, mapDeclaration, obj );
-            }
-        }
+        });
     }
 
     /**

--- a/packages/concerto-core/lib/serializer/resourcevalidator.js
+++ b/packages/concerto-core/lib/serializer/resourcevalidator.js
@@ -114,20 +114,23 @@ class ResourceValidator {
      * @private
      */
     visitMapDeclaration(mapDeclaration, parameters) {
-
         const obj = parameters.stack.pop();
 
-        if (!((obj instanceof Map))) {
-            throw new Error('Expected a Map, but found ' + obj);
+        if (!((obj.value instanceof Map))) {
+            throw new Error('Expected a Map, but found ' + JSON.stringify(obj));
         }
 
-        obj.forEach((key,value) => {
+        if (obj.$class !== mapDeclaration.getFullyQualifiedName()) {
+            throw new Error(`$class value must match ${mapDeclaration.getFullyQualifiedName()}`);
+        }
+
+        obj.value.forEach((key,value) => {
             if(!ModelUtil.isSystemProperty(key)) {
                 if (typeof key !== 'string') {
-                    ResourceValidator.reportInvalidMap(parameters.rootResourceIdentifier, mapDeclaration, obj );
+                    ResourceValidator.reportInvalidMap(parameters.rootResourceIdentifier, mapDeclaration, obj);
                 }
                 if (typeof value !== 'string') {
-                    ResourceValidator.reportInvalidMap(parameters.rootResourceIdentifier, mapDeclaration, obj );
+                    ResourceValidator.reportInvalidMap(parameters.rootResourceIdentifier, mapDeclaration, obj);
                 }
             }
         });

--- a/packages/concerto-core/lib/serializer/resourcevalidator.js
+++ b/packages/concerto-core/lib/serializer/resourcevalidator.js
@@ -124,7 +124,7 @@ class ResourceValidator {
             throw new Error(`$class value must match ${mapDeclaration.getFullyQualifiedName()}`);
         }
 
-        obj.value.forEach((key,value) => {
+        obj.value.forEach((value, key) => {
             if(!ModelUtil.isSystemProperty(key)) {
                 if (typeof key !== 'string') {
                     ResourceValidator.reportInvalidMap(parameters.rootResourceIdentifier, mapDeclaration, obj);

--- a/packages/concerto-core/lib/serializer/resourcevalidator.js
+++ b/packages/concerto-core/lib/serializer/resourcevalidator.js
@@ -117,6 +117,10 @@ class ResourceValidator {
 
         const obj = parameters.stack.pop();
 
+        if (!((obj instanceof Map))) {
+            throw new Error('Expected a Map, but found ' + obj);
+        }
+
         obj.forEach((key,value) => {
             if(!ModelUtil.isSystemProperty(key)) {
                 if (typeof key !== 'string') {

--- a/packages/concerto-core/lib/serializer/resourcevalidator.js
+++ b/packages/concerto-core/lib/serializer/resourcevalidator.js
@@ -67,7 +67,9 @@ class ResourceValidator {
             return this.visitEnumDeclaration(thing, parameters);
         } else if (thing.isClassDeclaration?.()) {
             return this.visitClassDeclaration(thing, parameters);
-        } else if (thing.isRelationship?.()) {
+        } else if (thing.isMapDeclaration?.()) {
+            return this.visitMapDeclaration(thing, parameters);
+        }else if (thing.isRelationship?.()) {
             return this.visitRelationshipDeclaration(thing, parameters);
         } else if (thing.isTypeScalar?.()) {
             return this.visitField(thing.getScalarField(), parameters);
@@ -102,6 +104,29 @@ class ResourceValidator {
         }
 
         return null;
+    }
+
+    /**
+     * Visitor design pattern
+     *
+     * @param {MapDeclaration} mapDeclaration - the object being visited
+     * @param {Object} parameters  - the parameter
+     * @private
+     */
+    visitMapDeclaration(mapDeclaration, parameters) {
+        const obj = parameters.stack.pop();
+        let m = new Map(Object.entries(obj));
+        const keys = m.keys();
+        const values = m.values();
+
+        for (let i= 0; i < m.size; i++) {
+            if ((typeof keys.next().value) !== 'string') {
+                ResourceValidator.reportInvalidMap(parameters.rootResourceIdentifier, mapDeclaration, obj );
+            }
+            if ((typeof values.next().value) !== 'string') {
+                ResourceValidator.reportInvalidMap(parameters.rootResourceIdentifier, mapDeclaration, obj );
+            }
+        }
     }
 
     /**
@@ -450,7 +475,7 @@ class ResourceValidator {
     /**
      * Throw a new error for a model violation.
      * @param {string} id - the identifier of this instance.
-     * @param {classDeclaration} classDeclaration - the declaration of the classs
+     * @param {ClassDeclaration} classDeclaration - the declaration of the class
      * @param {Object} value - the value of the field.
      * @private
      */
@@ -466,7 +491,23 @@ class ResourceValidator {
     /**
      * Throw a new error for a model violation.
      * @param {string} id - the identifier of this instance.
-     * @param {RelationshipDeclaration} relationshipDeclaration - the declaration of the classs
+     * @param {MapDeclaration} mapDeclaration - the declaration of the map
+     * @param {Object} value - the value of the field.
+     * @private
+     */
+    static reportInvalidMap(id, mapDeclaration, value) {
+        let formatter = Globalize.messageFormatter('resourcevalidator-invalidmap');
+        throw new ValidationException(formatter({
+            resourceId: id,
+            classFQN: mapDeclaration.getFullyQualifiedName(),
+            invalidValue: value.toString()
+        }));
+    }
+
+    /**
+     * Throw a new error for a model violation.
+     * @param {string} id - the identifier of this instance.
+     * @param {RelationshipDeclaration} relationshipDeclaration - the declaration of the class
      * @param {Object} value - the value of the field.
      * @private
      */

--- a/packages/concerto-core/lib/serializer/valuegenerator.js
+++ b/packages/concerto-core/lib/serializer/valuegenerator.js
@@ -231,7 +231,7 @@ class EmptyValueGenerator {
     }
 
     /**
-     * Get an instanace of an empty map.
+     * Get an instance of an empty map.
      * @return {*} an map value.
      */
     getMap() {
@@ -338,7 +338,7 @@ class SampleValueGenerator extends EmptyValueGenerator {
 
     /**
      * Get a map instance with randomly generated values for key & value.
-     * @return {*} an enum value.
+     * @return {*} a map value.
      */
     getMap() {
         return new Map([[this.getString(1,10), this.getString(1,10)]]);

--- a/packages/concerto-core/lib/serializer/valuegenerator.js
+++ b/packages/concerto-core/lib/serializer/valuegenerator.js
@@ -231,6 +231,14 @@ class EmptyValueGenerator {
     }
 
     /**
+     * Get an instanace of an empty map.
+     * @return {*} an map value.
+     */
+    getMap() {
+        return new Map();
+    }
+
+    /**
      * Get an array using the supplied callback to obtain array values.
      * @param {Function} valueSupplier - callback to obtain values.
      * @return {Array} an array
@@ -326,6 +334,14 @@ class SampleValueGenerator extends EmptyValueGenerator {
      */
     getEnum(enumValues) {
         return enumValues[Math.floor(Math.random() * enumValues.length)];
+    }
+
+    /**
+     * Get a map instance with randomly generated values for key & value.
+     * @return {*} an enum value.
+     */
+    getMap() {
+        return new Map([[this.getString(1,10), this.getString(1,10)]]);
     }
 
     /**

--- a/packages/concerto-core/messages/en.json
+++ b/packages/concerto-core/messages/en.json
@@ -69,6 +69,7 @@
         "resourcevalidator-undeclaredfield": "Instance \"{resourceId}\" has a property named \"{propertyName}\", which is not declared in \"{fullyQualifiedTypeName}\".",
         "resourcevalidator-invalidfieldassignment": "Instance \"{resourceId}\" has a property \"{propertyName}\" with type \"{objectType}\" that is not derived from \"{fieldType}\".",
         "resourcevalidator-emptyidentifier": "Instance \"{resourceId}\" has an empty identifier.",
+        "resourcevalidator-invalidmap": "Model violation in the \"{resourceId}\" instance. Invalid Type for Map Key or Value - expected String type.",
 
         "typenotfounderror-defaultmessage": "Type \"{typeName}\" not found.",
 

--- a/packages/concerto-core/test/data/model/concept.cto
+++ b/packages/concerto-core/test/data/model/concept.cto
@@ -22,7 +22,7 @@ concept InventorySets {
  o String Model
  o Integer invCount
  o assetStatus invType // used or new?
- o Dictionary dictionary
+ o Dictionary dictionary optional
 }
 
 asset MakerInventory identified by makerId {

--- a/packages/concerto-core/test/data/model/concept.cto
+++ b/packages/concerto-core/test/data/model/concept.cto
@@ -22,6 +22,7 @@ concept InventorySets {
  o String Model
  o Integer invCount
  o assetStatus invType // used or new?
+ o Dictionary dictionary
 }
 
 asset MakerInventory identified by makerId {
@@ -34,4 +35,9 @@ enum assetStatus {
  o INUSE
  o REPAIRED
  o RETIRED
+}
+
+map Dictionary {
+ o String
+ o String
 }

--- a/packages/concerto-core/test/model/concept.js
+++ b/packages/concerto-core/test/model/concept.js
@@ -128,6 +128,17 @@ describe('Concept', function () {
             }).should.throw(/Attempting to create an ENUM declaration is not supported./);
         });
 
+        it.only('should generate an error trying to create an Map from JSON', function () {
+            let conceptModel = fs.readFileSync('./test/data/model/concept.cto', 'utf8');
+            modelManager.addCTOModel(conceptModel, 'concept.cto');
+            const factory = new Factory(modelManager);
+            const serializer = new Serializer(factory, modelManager);
+            const jsObject = JSON.parse('{"$class":"org.acme.biznet.Dictionary"}');
+            (function () {
+                serializer.fromJSON(jsObject);
+            }).should.throw(/Attempting to create an Map declaration is not supported./);
+        });
+
     });
 
     describe('#isConcept', () => {

--- a/packages/concerto-core/test/model/concept.js
+++ b/packages/concerto-core/test/model/concept.js
@@ -128,7 +128,7 @@ describe('Concept', function () {
             }).should.throw(/Attempting to create an ENUM declaration is not supported./);
         });
 
-        it.only('should generate an error trying to create an Map from JSON', function () {
+        it('should generate an error trying to create an Map from JSON', function () {
             let conceptModel = fs.readFileSync('./test/data/model/concept.cto', 'utf8');
             modelManager.addCTOModel(conceptModel, 'concept.cto');
             const factory = new Factory(modelManager);

--- a/packages/concerto-core/test/model/concept.js
+++ b/packages/concerto-core/test/model/concept.js
@@ -128,6 +128,29 @@ describe('Concept', function () {
             }).should.throw(/Attempting to create an ENUM declaration is not supported./);
         });
 
+        it('should generate a concept with a Map from JSON', function () {
+            let conceptModel = fs.readFileSync('./test/data/model/concept.cto', 'utf8');
+            modelManager.addCTOModel(conceptModel, 'concept.cto');
+            const factory = new Factory(modelManager);
+            const serializer = new Serializer(factory, modelManager);
+            const jsObject = {
+                $class:'org.acme.biznet.InventorySets',
+                Make:'Make',
+                Model:'Model',
+                invCount:10,
+                invType:'NEWBATCH',
+                dictionary: {
+                    $class: 'org.acme.biznet.Dictionary',
+                    value: {
+                        'key1': 'value1',
+                        'key2': 'value2',
+                    }
+                }
+            };
+            const obj = serializer.fromJSON(jsObject);
+            obj.isConcept().should.be.true;
+        });
+
         it('should generate an error trying to create a Map from JSON', function () {
             let conceptModel = fs.readFileSync('./test/data/model/concept.cto', 'utf8');
             modelManager.addCTOModel(conceptModel, 'concept.cto');

--- a/packages/concerto-core/test/model/concept.js
+++ b/packages/concerto-core/test/model/concept.js
@@ -128,7 +128,7 @@ describe('Concept', function () {
             }).should.throw(/Attempting to create an ENUM declaration is not supported./);
         });
 
-        it('should generate an error trying to create an Map from JSON', function () {
+        it('should generate an error trying to create a Map from JSON', function () {
             let conceptModel = fs.readFileSync('./test/data/model/concept.cto', 'utf8');
             modelManager.addCTOModel(conceptModel, 'concept.cto');
             const factory = new Factory(modelManager);
@@ -136,7 +136,7 @@ describe('Concept', function () {
             const jsObject = JSON.parse('{"$class":"org.acme.biznet.Dictionary"}');
             (function () {
                 serializer.fromJSON(jsObject);
-            }).should.throw(/Attempting to create an Map declaration is not supported./);
+            }).should.throw(/Attempting to create a Map declaration is not supported./);
         });
 
     });

--- a/packages/concerto-core/test/serializer.js
+++ b/packages/concerto-core/test/serializer.js
@@ -407,7 +407,9 @@ describe('Serializer', () => {
                 postcode: 'SO21 2JN',
                 dict: {
                     '$class': 'org.acme.sample.Dictionary',
-                    'Lorem': 'Ipsum',
+                    value: {
+                        'Lorem': 'Ipsum'
+                    }
                 }
             };
             let resource = serializer.fromJSON(json);
@@ -420,6 +422,45 @@ describe('Serializer', () => {
             resource.dict.$class.should.equal('org.acme.sample.Dictionary');
             resource.dict.value.should.be.an.instanceOf(Map);
             resource.dict.value.get('Lorem').should.equal('Ipsum');
+        });
+
+        it('should throw an error when deserializing a map without a $class property', () => {
+
+            let json = {
+                $class: 'org.acme.sample.Address',
+                city: 'Winchester',
+                country: 'UK',
+                elevation: 3.14,
+                postcode: 'SO21 2JN',
+                dict: {
+                    // '$class': 'org.acme.sample.Dictionary',
+                    value: {
+                        'Lorem': 'Ipsum'
+                    }
+                }
+            };
+            (() => {
+                serializer.fromJSON(json);
+            }).should.throw('Invalid JSON data at "$.dict". Map value does not contain a $class type identifier.');
+        });
+
+        it('should throw an error when deserializing a map without a value property', () => {
+            let json = {
+                $class: 'org.acme.sample.Address',
+                city: 'Winchester',
+                country: 'UK',
+                elevation: 3.14,
+                postcode: 'SO21 2JN',
+                dict: {
+                    '$class': 'org.acme.sample.Dictionary',
+                    // value: {
+                    //     'Lorem': 'Ipsum'
+                    // }
+                }
+            };
+            (() => {
+                serializer.fromJSON(json);
+            }).should.throw('Invalid JSON data at "$.dict". Map value does not contain a value property.');
         });
 
         it('should throw validation errors if the validate flag is not specified', () => {

--- a/packages/concerto-core/test/serializer.js
+++ b/packages/concerto-core/test/serializer.js
@@ -261,6 +261,18 @@ describe('Serializer', () => {
             });
         });
 
+        it('should throw if the value for a map is not a Map instance', () => {
+            let address = factory.newConcept('org.acme.sample', 'Address');
+            address.city = 'Winchester';
+            address.country = 'UK';
+            address.elevation = 3.14;
+            address.postcode = 'SO21 2JN';
+            address.testMap = 'xyz'; // bad value
+            (() => {
+                serializer.toJSON(address);
+            }).should.throw(Error, /Expected a Map, but found xyz/);
+        });
+
         it('should generate a field if an empty string is specififed', () => {
             let resource = factory.newResource('org.acme.sample', 'SampleAsset', '1');
             resource.owner = factory.newRelationship('org.acme.sample', 'SampleParticipant', 'alice@email.com');

--- a/packages/concerto-core/test/serializer.js
+++ b/packages/concerto-core/test/serializer.js
@@ -66,6 +66,12 @@ describe('Serializer', () => {
             o String country
             o Double elevation
             o PostalCode postcode optional
+            o TestMap testMap optional
+        }
+
+        map TestMap {
+            o String
+            o String
         }
 
         concept DateTimeTest {
@@ -232,6 +238,29 @@ describe('Serializer', () => {
             });
         });
 
+        it('should generate concept with a map value', () => {
+            let address = factory.newConcept('org.acme.sample', 'Address');
+            address.city = 'Winchester';
+            address.country = 'UK';
+            address.elevation = 3.14;
+            address.postcode = 'SO21 2JN';
+            address.testMap = new Map();
+            address.testMap.set('Lorem','Ipsum');
+
+            // todo test for reserved identifiers in keys ($class)
+            const json = serializer.toJSON(address);
+            json.should.deep.equal({
+                $class: 'org.acme.sample.Address',
+                country: 'UK',
+                elevation: 3.14,
+                city: 'Winchester',
+                postcode: 'SO21 2JN',
+                testMap: {
+                    'Lorem': 'Ipsum'
+                }
+            });
+        });
+
         it('should generate a field if an empty string is specififed', () => {
             let resource = factory.newResource('org.acme.sample', 'SampleAsset', '1');
             resource.owner = factory.newRelationship('org.acme.sample', 'SampleParticipant', 'alice@email.com');
@@ -330,6 +359,28 @@ describe('Serializer', () => {
             resource.country.should.equal('UK');
             resource.elevation.should.equal(3.14);
             resource.postcode.should.equal('SO21 2JN');
+        });
+
+        it('should deserialize a valid concept with a map', () => {
+
+            let json = {
+                $class: 'org.acme.sample.Address',
+                city: 'Winchester',
+                country: 'UK',
+                elevation: 3.14,
+                postcode: 'SO21 2JN',
+                testMap: {
+                    'Lorem': 'Ipsum',
+                }
+            };
+            let resource = serializer.fromJSON(json);
+            resource.should.be.an.instanceOf(Resource);
+            resource.city.should.equal('Winchester');
+            resource.country.should.equal('UK');
+            resource.elevation.should.equal(3.14);
+            resource.postcode.should.equal('SO21 2JN');
+            resource.testMap.should.be.an.instanceOf(Map);
+            resource.testMap.get('Lorem').should.equal('Ipsum');
         });
 
         it('should throw validation errors if the validate flag is not specified', () => {

--- a/packages/concerto-core/test/serializer/instancegenerator.js
+++ b/packages/concerto-core/test/serializer/instancegenerator.js
@@ -88,6 +88,29 @@ describe('InstanceGenerator', () => {
             resource.theValue.should.be.a('string');
         });
 
+        it('should generate default value for a Map', function () {
+            let resource = test(`namespace org.acme.test
+
+            map Foo {
+                o String
+                o String
+            }
+
+            concept MyAsset identified by assetId {
+                o String assetId
+                o Foo bar
+            }
+            `);
+            resource.bar.should.be.an.instanceOf(Map);
+            resource.bar.size.should.be.equal(1);
+
+            const iterator1 = resource.bar.entries();
+            let values = iterator1.next().value;
+
+            values[0].should.be.a('string');
+            values[1].should.be.a('string');
+        });
+
         it('should generate a value with specified lentgh constraint for a string property', () => {
             useSampleGenerator();
             let resource = test(`namespace org.acme.test

--- a/packages/concerto-core/test/serializer/resourcevalidator.js
+++ b/packages/concerto-core/test/serializer/resourcevalidator.js
@@ -50,6 +50,15 @@ describe('ResourceValidator', function () {
       o DEER_OTHER
     }`;
 
+    const mapModelString = `namespace org.acme.map
+    map PhoneBook {
+      o String
+      o String
+    }
+    concept Data {
+        o PhoneBook numbers
+    }`;
+
     const levelOneModel = `namespace org.acme.l1
     enum VehicleType {
       o CAR
@@ -114,6 +123,7 @@ describe('ResourceValidator', function () {
     });
 
     beforeEach(function () {
+        modelManager.addCTOModel(mapModelString);
         modelManager.addCTOModel(enumModelString);
         modelManager.addCTOModel(levelOneModel);
         modelManager.addCTOModel(levelTwoModel);
@@ -333,6 +343,25 @@ describe('ResourceValidator', function () {
             const enumDeclaration = modelManager.getType('org.acme.enumerations.AnimalType');
             const parameters = { stack : typedStack, 'modelManager' : modelManager, rootResourceIdentifier : 'TEST' };
             enumDeclaration.accept(resourceValidator,parameters );
+        });
+    });
+
+    describe('#visitMapDeclaration', function() {
+        it('should validate map', function () {
+            const typedStack = new TypedStack({ 'Lorem': 'Ipsum'});
+            const mapDeclaration = modelManager.getType('org.acme.map.PhoneBook');
+            const parameters = { stack : typedStack, 'modelManager' : modelManager, rootResourceIdentifier : 'TEST' };
+            mapDeclaration.accept(resourceValidator,parameters );
+        });
+
+        it('should not validate map with bad value', function () {
+            const typedStack = new TypedStack({ 'Lorem': 3});
+            const mapDeclaration = modelManager.getType('org.acme.map.PhoneBook');
+            const parameters = { stack : typedStack, 'modelManager' : modelManager, rootResourceIdentifier : 'TEST' };
+
+            (() => {
+                mapDeclaration.accept(resourceValidator,parameters );
+            }).should.throw('Model violation in the "TEST" instance. Invalid Type for Map Key or Value - expected String type.');
         });
     });
 

--- a/packages/concerto-core/test/serializer/resourcevalidator.js
+++ b/packages/concerto-core/test/serializer/resourcevalidator.js
@@ -348,7 +348,7 @@ describe('ResourceValidator', function () {
 
     describe('#visitMapDeclaration', function() {
         it('should validate map', function () {
-            const map = new Map([['Lorem', 'Ipsum']]);
+            const map = { $class: 'org.acme.map.PhoneBook', value: new Map([['Lorem', 'Ipsum']]) };
             const typedStack = new TypedStack(map);
             const mapDeclaration = modelManager.getType('org.acme.map.PhoneBook');
             const parameters = { stack : typedStack, 'modelManager' : modelManager, rootResourceIdentifier : 'TEST' };
@@ -356,7 +356,7 @@ describe('ResourceValidator', function () {
         });
 
         it('should not validate map with bad value', function () {
-            const map = new Map([['Lorem', 3]]);
+            const map = { $class: 'org.acme.map.PhoneBook', value: new Map([['Lorem', 3]]) };
             const typedStack = new TypedStack(map);
             const mapDeclaration = modelManager.getType('org.acme.map.PhoneBook');
             const parameters = { stack : typedStack, 'modelManager' : modelManager, rootResourceIdentifier : 'TEST' };
@@ -367,7 +367,8 @@ describe('ResourceValidator', function () {
         });
 
         it('should not validate map with bad key', function () {
-            const map = new Map([[1, 'Ipsum']]);
+            const map = { $class: 'org.acme.map.PhoneBook', value: new Map([[1, 'Ipsum']]) };
+
             const typedStack = new TypedStack(map);
             const mapDeclaration = modelManager.getType('org.acme.map.PhoneBook');
             const parameters = { stack : typedStack, 'modelManager' : modelManager, rootResourceIdentifier : 'TEST' };

--- a/packages/concerto-core/test/serializer/resourcevalidator.js
+++ b/packages/concerto-core/test/serializer/resourcevalidator.js
@@ -348,14 +348,27 @@ describe('ResourceValidator', function () {
 
     describe('#visitMapDeclaration', function() {
         it('should validate map', function () {
-            const typedStack = new TypedStack({ 'Lorem': 'Ipsum'});
+            const map = new Map([['Lorem', 'Ipsum']]);
+            const typedStack = new TypedStack(map);
             const mapDeclaration = modelManager.getType('org.acme.map.PhoneBook');
             const parameters = { stack : typedStack, 'modelManager' : modelManager, rootResourceIdentifier : 'TEST' };
             mapDeclaration.accept(resourceValidator,parameters );
         });
 
         it('should not validate map with bad value', function () {
-            const typedStack = new TypedStack({ 'Lorem': 3});
+            const map = new Map([['Lorem', 3]]);
+            const typedStack = new TypedStack(map);
+            const mapDeclaration = modelManager.getType('org.acme.map.PhoneBook');
+            const parameters = { stack : typedStack, 'modelManager' : modelManager, rootResourceIdentifier : 'TEST' };
+
+            (() => {
+                mapDeclaration.accept(resourceValidator,parameters );
+            }).should.throw('Model violation in the "TEST" instance. Invalid Type for Map Key or Value - expected String type.');
+        });
+
+        it('should not validate map with bad key', function () {
+            const map = new Map([[1, 'Ipsum']]);
+            const typedStack = new TypedStack(map);
             const mapDeclaration = modelManager.getType('org.acme.map.PhoneBook');
             const parameters = { stack : typedStack, 'modelManager' : modelManager, rootResourceIdentifier : 'TEST' };
 

--- a/packages/concerto-core/test/serializer/valuegenerator.js
+++ b/packages/concerto-core/test/serializer/valuegenerator.js
@@ -62,7 +62,7 @@ describe('ValueGenerator', function() {
             assertFunctionReturnsType('getBoolean', 'boolean');
         });
 
-        it('getBoolean should return a map', function() {
+        it('getMap should return a map', function() {
             assertFunctionReturnsType('getMap', 'Map');
         });
 

--- a/packages/concerto-core/test/serializer/valuegenerator.js
+++ b/packages/concerto-core/test/serializer/valuegenerator.js
@@ -62,6 +62,10 @@ describe('ValueGenerator', function() {
             assertFunctionReturnsType('getBoolean', 'boolean');
         });
 
+        it.only('getBoolean should return a map', function() {
+            assertFunctionReturnsType('getMap', 'Map');
+        });
+
         it('getString should return a string', function() {
             assertFunctionReturnsType('getString', 'string');
         });

--- a/packages/concerto-core/test/serializer/valuegenerator.js
+++ b/packages/concerto-core/test/serializer/valuegenerator.js
@@ -62,7 +62,7 @@ describe('ValueGenerator', function() {
             assertFunctionReturnsType('getBoolean', 'boolean');
         });
 
-        it.only('getBoolean should return a map', function() {
+        it('getBoolean should return a map', function() {
             assertFunctionReturnsType('getMap', 'Map');
         });
 

--- a/packages/concerto-core/types/lib/modelutil.d.ts
+++ b/packages/concerto-core/types/lib/modelutil.d.ts
@@ -92,6 +92,13 @@ declare class ModelUtil {
      */
     private static isEnum;
     /**
+     * Returns the true if the given field is an map type
+     * @param {Field} field - the string
+     * @return {boolean} true if the field is declared as an map
+     * @private
+     */
+    private static isMap;
+    /**
      * Returns the true if the given field is a Scalar type
      * @param {Field} field - the Field to test
      * @return {boolean} true if the field is declared as an scalar

--- a/packages/concerto-core/types/lib/serializer/instancegenerator.d.ts
+++ b/packages/concerto-core/types/lib/serializer/instancegenerator.d.ts
@@ -59,6 +59,14 @@ declare class InstanceGenerator {
      */
     private visitRelationshipDeclaration;
     /**
+     * Visitor design pattern
+     * @param {MapDeclaration} mapDeclaration - the object being visited
+     * @param {Object} parameters  - the parameter
+     * @return {Object} the result of visiting or null
+     * @private
+     */
+    private visitMapDeclaration;
+    /**
      * Generate a random ID for a given type.
      * @private
      * @param {ClassDeclaration} classDeclaration - class declaration for a type.

--- a/packages/concerto-core/types/lib/serializer/jsongenerator.d.ts
+++ b/packages/concerto-core/types/lib/serializer/jsongenerator.d.ts
@@ -40,6 +40,14 @@ declare class JSONGenerator {
     private visit;
     /**
      * Visitor design pattern
+     * @param {MapDeclaration} mapDeclaration - the object being visited
+     * @param {Object} parameters  - the parameter
+     * @return {Object} the result of visiting or null
+     * @private
+     */
+    private visitMapDeclaration;
+    /**
+     * Visitor design pattern
      * @param {ClassDeclaration} classDeclaration - the object being visited
      * @param {Object} parameters  - the parameter
      * @return {Object} the result of visiting or null

--- a/packages/concerto-core/types/lib/serializer/jsonpopulator.d.ts
+++ b/packages/concerto-core/types/lib/serializer/jsonpopulator.d.ts
@@ -43,6 +43,14 @@ declare class JSONPopulator {
     private visitClassDeclaration;
     /**
      * Visitor design pattern
+     * @param {MapDeclaration} mapDeclaration - the object being visited
+     * @param {Object} parameters  - the parameter
+     * @return {Object} the result of visiting or null
+     * @private
+     */
+    private visitMapDeclaration;
+    /**
+     * Visitor design pattern
      * @param {Field} field - the object being visited
      * @param {Object} parameters  - the parameter
      * @return {Object} the result of visiting or null

--- a/packages/concerto-core/types/lib/serializer/resourcevalidator.d.ts
+++ b/packages/concerto-core/types/lib/serializer/resourcevalidator.d.ts
@@ -31,7 +31,7 @@ declare class ResourceValidator {
     /**
      * Throw a new error for a model violation.
      * @param {string} id - the identifier of this instance.
-     * @param {classDeclaration} classDeclaration - the declaration of the classs
+     * @param {ClassDeclaration} classDeclaration - the declaration of the class
      * @param {Object} value - the value of the field.
      * @private
      */
@@ -39,7 +39,15 @@ declare class ResourceValidator {
     /**
      * Throw a new error for a model violation.
      * @param {string} id - the identifier of this instance.
-     * @param {RelationshipDeclaration} relationshipDeclaration - the declaration of the classs
+     * @param {MapDeclaration} mapDeclaration - the declaration of the map
+     * @param {Object} value - the value of the field.
+     * @private
+     */
+    private static reportInvalidMap;
+    /**
+     * Throw a new error for a model violation.
+     * @param {string} id - the identifier of this instance.
+     * @param {RelationshipDeclaration} relationshipDeclaration - the declaration of the class
      * @param {Object} value - the value of the field.
      * @private
      */
@@ -125,6 +133,14 @@ declare class ResourceValidator {
      * @private
      */
     private visitEnumDeclaration;
+    /**
+     * Visitor design pattern
+     *
+     * @param {MapDeclaration} mapDeclaration - the object being visited
+     * @param {Object} parameters  - the parameter
+     * @private
+     */
+    private visitMapDeclaration;
     /**
      * Visitor design pattern
      * @param {ClassDeclaration} classDeclaration - the object being visited


### PR DESCRIPTION
<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
<!--- Provide an overall summary of the pull request -->

This change adds basic serialisation of a map in the form of <string, string>. Further type variations will follow in subsequent PR.

For more information on the design specification see [here](https://github.com/accordproject/concerto/wiki/Aggregate-Types-Design)

### Screenshots or Video
<!--- Provide an easily accessible demonstration of the changes, if applicable -->

### Related Issues
- Issue #447 

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ ] Merging to `main` from `fork:branchname`
