### PR TITLE
bug(vocabulary): fix for vocabulary management for ScalarDeclaration

### DIFF
--- a/packages/concerto-vocabulary/lib/vocabularymanager.js
+++ b/packages/concerto-vocabulary/lib/vocabularymanager.js
@@ -259,7 +259,7 @@ class VocabularyManager {
                     });
                 }
 
-                decl.getProperties().forEach(property => {
+                decl.getProperties?.().forEach(property => {
                     const propertyTerm = this.resolveTerm(modelManager, model.getNamespace(), locale, decl.getName(), property.getName());
 
                     if (propertyTerm) {

--- a/packages/concerto-vocabulary/test/org.acme.cto
+++ b/packages/concerto-vocabulary/test/org.acme.cto
@@ -6,6 +6,8 @@ enum Color {
     o GREEN
 }
 
+scalar SSN extends String default="000-00-0000"
+
 asset Vehicle identified by vin {
     o String vin
     o Color color

--- a/packages/concerto-vocabulary/test/vocabularymanager.js
+++ b/packages/concerto-vocabulary/test/vocabularymanager.js
@@ -248,11 +248,11 @@ describe('VocabularyManager', () => {
         result.additionalVocabularies.length.should.equal(1);
         result.additionalVocabularies[0].getNamespace().should.equal('com.example');
         result.vocabularies['org.acme/en'].additionalTerms.should.have.members(['Vehicle.model']);
-        result.vocabularies['org.acme/en'].missingTerms.should.have.members(['Color.RED', 'Color.BLUE', 'Color.GREEN', 'Vehicle.color']);
+        result.vocabularies['org.acme/en'].missingTerms.should.have.members(['Color.RED', 'Color.BLUE', 'Color.GREEN', 'SSN', 'Vehicle.color']);
         result.vocabularies['org.acme/en-gb'].additionalTerms.should.have.members(['Milkfloat']);
-        result.vocabularies['org.acme/fr'].missingTerms.should.have.members(['Color', 'Vehicle.color', 'Truck']);
+        result.vocabularies['org.acme/fr'].missingTerms.should.have.members(['Color', 'SSN', 'Vehicle.color', 'Truck']);
         result.vocabularies['org.acme/fr'].additionalTerms.should.have.members([]);
-        result.vocabularies['org.acme/zh-cn'].missingTerms.should.have.members(['Truck']);
+        result.vocabularies['org.acme/zh-cn'].missingTerms.should.have.members(['SSN', 'Truck']);
         result.vocabularies['org.acme/zh-cn'].additionalTerms.should.have.members([]);
     });
 
@@ -271,5 +271,10 @@ describe('VocabularyManager', () => {
         const decorator = vehicleDecl.getDecorator('Term');
         decorator.getArguments()[0].should.equal('A road vehicle');
         vehicleDecl.getProperty('vin').getDecorator('Term').getArguments()[0].should.equal('Vehicle Identification Number');
+
+        const scalarDeclarations = mf.getScalarDeclarations();
+        const ssnDeclaration = scalarDeclarations[0];
+        const ssnDecorator = ssnDeclaration.getDecorator('Term');
+        ssnDecorator.getArguments()[0].should.equal('SSN');
     });
 });


### PR DESCRIPTION
<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #656 
<!--- Provide an overall summary of the pull request -->
When adding vobulary terms as decorators to the model, `englishMissingTermGenerator` failed for Scalars. Fixed the issue and modified a test.

### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
- Optionally chained the function call to `getProperties` for the `declarations` object. As Scalars don't have properties, the function won't get called.

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ ] Merging to `main` from `fork:branchname`
