### PR TITLE
fix(filter) : remove imports of filtered types

### DIFF
--- a/packages/concerto-core/lib/basemodelmanager.js
+++ b/packages/concerto-core/lib/basemodelmanager.js
@@ -766,16 +766,24 @@ class BaseModelManager {
                         const remove = ModelUtil.getShortName(imp.$class) === 'ImportType' &&
                             imp.name === removeName &&
                             imp.namespace === removeNamespace;
+                        if(remove) {
+                            modified = true;
+                        }
                         return !remove;
                     });
                     ast.imports.forEach( imp => {
                         if(imp.namespace === removeNamespace) {
                             if(ModelUtil.getShortName(imp.$class) === 'ImportTypes') {
-                                imp.types = imp.types.filter((type) => type !== removeName);
+                                imp.types = imp.types.filter((type) => {
+                                    const remove = (type === removeName);
+                                    if(remove) {
+                                        modified = true;
+                                    }
+                                    return !remove;
+                                });
                             }
                         }
                     });
-                    modified = true;
                 }
             });
             if(modified) {

--- a/packages/concerto-core/lib/introspect/modelfile.js
+++ b/packages/concerto-core/lib/introspect/modelfile.js
@@ -200,7 +200,8 @@ class ModelFile extends Decorated {
     /**
      * Returns the types that have been imported into this ModelFile.
      *
-     * @return {string[]} The array of imports for this ModelFile
+     * @return {string[]} The array of fully-qualified names for types imported by
+     * this ModelFile
      */
     getImports() {
         let result = [];
@@ -830,11 +831,23 @@ class ModelFile extends Decorated {
      *
      * @param {FilterFunction} predicate - the filter function over a Declaration object
      * @param {ModelManager} modelManager - the target ModelManager for the filtered ModelFile
+     * @param {string[]} removedDeclarations - an array that will be populated with the FQN of removed declarations
      * @returns {ModelFile?} - the filtered ModelFile
      * @private
      */
-    filter(predicate, modelManager){
-        const declarations = this.declarations?.filter(predicate).map(declaration => declaration.ast);
+    filter(predicate, modelManager, removedDeclarations){
+
+        let declarations = []; // ast for all included declarations
+        this.declarations?.forEach( declaration => {
+            const included = predicate(declaration);
+            if(!included) {
+                removedDeclarations.push(declaration.getFullyQualifiedName());
+            }
+            else {
+                declarations.push(declaration.ast);
+            }
+        } );
+
         const ast = {
             ...this.ast,
             declarations: declarations,

--- a/packages/concerto-core/lib/introspect/modelfile.js
+++ b/packages/concerto-core/lib/introspect/modelfile.js
@@ -836,7 +836,6 @@ class ModelFile extends Decorated {
      * @private
      */
     filter(predicate, modelManager, removedDeclarations){
-
         let declarations = []; // ast for all included declarations
         this.declarations?.forEach( declaration => {
             const included = predicate(declaration);

--- a/packages/concerto-core/test/modelmanager.js
+++ b/packages/concerto-core/test/modelmanager.js
@@ -1080,21 +1080,25 @@ concept Bar {
             `, 'child.cto', true);
 
             modelManager.addCTOModel(`namespace cousin@1.0.0
-            concept Used2 {}
+            concept AlsoUsed {}
             `, 'cousin.cto', true);
+
+            modelManager.addCTOModel(`namespace orphan@1.0.0
+            concept Orphan {}
+            `, 'orphan.cto', true);
 
             modelManager.addCTOModel(`namespace test@1.0.0
             import child@1.0.0.Unused
             import child@1.0.0.Used
-            import cousing@1.0.0.Used2
+            import cousin@1.0.0.AlsoUsed
             import child@1.0.0.{Used,Unused}
             concept Person {
                 o Used used
-                o Used2 used2
+                o AlsoUsed alsoUsed
             }
             `, 'test.cto');
             const filtered = modelManager.filter(declaration =>
-                ['concerto@1.0.0.Concept','test@1.0.0.Person','child@1.0.0.Used'].includes(declaration.getFullyQualifiedName()));
+                ['concerto@1.0.0.Concept','test@1.0.0.Person','child@1.0.0.Used', 'cousin@1.0.0.AlsoUsed'].includes(declaration.getFullyQualifiedName()));
             filtered.validateModelFiles();
         });
     });

--- a/packages/concerto-core/test/modelmanager.js
+++ b/packages/concerto-core/test/modelmanager.js
@@ -1072,5 +1072,24 @@ concept Bar {
 
             filtered.validateModelFiles();
         });
+
+        it('should remove imports for filtered types', () => {
+            modelManager.addCTOModel(`namespace child@1.0.0
+            concept Used {}
+            concept Unused {}
+            `, 'child.cto', true);
+
+            modelManager.addCTOModel(`namespace test@1.0.0
+            import child@1.0.0.Unused
+            import child@1.0.0.Used
+            import child@1.0.0.{Used,Unused}
+            concept Person {
+                o Used used
+            }
+            `, 'test.cto');
+            const filtered = modelManager.filter(declaration =>
+                ['concerto@1.0.0.Concept','test@1.0.0.Person','child@1.0.0.Used'].includes(declaration.getFullyQualifiedName()));
+            filtered.validateModelFiles();
+        });
     });
 });

--- a/packages/concerto-core/test/modelmanager.js
+++ b/packages/concerto-core/test/modelmanager.js
@@ -1079,12 +1079,18 @@ concept Bar {
             concept Unused {}
             `, 'child.cto', true);
 
+            modelManager.addCTOModel(`namespace cousin@1.0.0
+            concept Used2 {}
+            `, 'cousin.cto', true);
+
             modelManager.addCTOModel(`namespace test@1.0.0
             import child@1.0.0.Unused
             import child@1.0.0.Used
+            import cousing@1.0.0.Used2
             import child@1.0.0.{Used,Unused}
             concept Person {
                 o Used used
+                o Used2 used2
             }
             `, 'test.cto');
             const filtered = modelManager.filter(declaration =>


### PR DESCRIPTION
# Closes #682 

Updates the `BaseModelManager.filter` method to update all the imports in the model manager based on the types that were removed by calls to `ModelFiler.filter`. 

### Changes
- ModelFile.filter method updated to return an array of the types that were removed by the filter predicate
- BaseModelManager.filter method updated to remove imports of removed types
- Unit test

### Flags
<!--- Provide context or concerns a reviewer should be aware of -->
- The change to ModelFile.filter to take `removedDeclarations` as an extra argument is technically a breaking change however if we assume that the only caller of this function is BaseModelManager then we could argue that this is a pure bug fix.
- I'm uncertain about this behaviour: `ModelFiles with no declarations after filtering will be removed.` — I suspect this could break wildcard imports when Concerto is used with `strict:false`. I'm choosing to ignore this given folks should be using `strict:true` and the likelihood that they are not and also using `filter` is small.

### Screenshots or Video
<!--- Provide an easily accessible demonstration of the changes, if applicable -->

### Related Issues
- Issue #<NUMBER>
- Pull Request #<NUMBER>

### Author Checklist
- [ ] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [ ] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ ] Merging to `main` from `fork:branchname`
