### PR TITLE
feat(maps): patch concept serialization

### DIFF
--- a/packages/concerto-core/lib/serializer/jsongenerator.js
+++ b/packages/concerto-core/lib/serializer/jsongenerator.js
@@ -106,7 +106,7 @@ class JSONGenerator {
                 parameters.stack.push(value);
                 const jsonValue = decl.accept(this, parameters);
 
-                value = JSON.stringify(jsonValue);
+                value = jsonValue;
             }
 
             map.set(key, value);

--- a/packages/concerto-core/lib/serializer/jsonpopulator.js
+++ b/packages/concerto-core/lib/serializer/jsonpopulator.js
@@ -220,7 +220,7 @@ class JSONPopulator {
             let subResource = parameters.factory.newConcept(decl.getNamespace(),
                 decl.getName(), decl.getIdentifierFieldName() );
 
-            parameters.jsonStack.push(JSON.parse(value));
+            parameters.jsonStack.push(value);
             parameters.resourceStack.push(subResource);
             return decl.accept(this, parameters);
         }

--- a/packages/concerto-core/test/serializer/maptype/serializer.js
+++ b/packages/concerto-core/test/serializer/maptype/serializer.js
@@ -383,8 +383,8 @@ describe('Serializer', () => {
                 $class: 'org.acme.sample.Concepts',
                 rolodex: {
                     $class: 'org.acme.sample.Rolodex',
-                    'Dublin': '{"$class":"org.acme.sample.Person","name":"Bob"}',
-                    'London': '{"$class":"org.acme.sample.Person","name":"Alice"}'
+                    'Dublin': {'$class':'org.acme.sample.Person','name':'Bob'},
+                    'London': {'$class':'org.acme.sample.Person','name':'Alice'}
                 }
             });
 
@@ -514,8 +514,8 @@ describe('Serializer', () => {
                 $class: 'org.acme.sample.Concepts',
                 directory: {
                     $class: 'org.acme.sample.Directory',
-                    'D4F45017-AD2B-416B-AD9F-3B74F7DEA291': '{"$class":"org.acme.sample.Person","name":"Bob"}',
-                    '9FAE34BF-18C3-4770-A6AA-6F7656C356B8': '{"$class":"org.acme.sample.Person","name":"Alice"}',
+                    'D4F45017-AD2B-416B-AD9F-3B74F7DEA291': {'$class':'org.acme.sample.Person','name':'Bob'},
+                    '9FAE34BF-18C3-4770-A6AA-6F7656C356B8': {'$class':'org.acme.sample.Person','name':'Alice'},
                 }
             });
 
@@ -805,8 +805,8 @@ describe('Serializer', () => {
                 $class: 'org.acme.sample.Concepts',
                 rolodex: {
                     $class: 'org.acme.sample.Rolodex',
-                    'Dublin': '{"$class":"org.acme.sample.Person","name":"Bob"}',
-                    'London': '{"$class":"org.acme.sample.Person","name":"Alice"}'
+                    'Dublin': {'$class':'org.acme.sample.Person','name':'Bob'},
+                    'London': {'$class':'org.acme.sample.Person','name':'Alice'}
                 }
             };
 
@@ -830,8 +830,8 @@ describe('Serializer', () => {
                 $class: 'org.acme.sample.Concepts',
                 rolodex: {
                     $class: 'org.acme.sample.Rolodex',
-                    'Dublin': '{"$class":"org.acme.sample.Person","name":"Bob"}',
-                    'London': '{"$class":"org.acme.sample.Person","name":"Alice"}'
+                    'Dublin': {'$class':'org.acme.sample.Person','name':'Bob'},
+                    'London': {'$class':'org.acme.sample.Person','name':'Alice'}
                 }
             });
         });
@@ -941,8 +941,8 @@ describe('Serializer', () => {
                 $class: 'org.acme.sample.Concepts',
                 directory: {
                     $class: 'org.acme.sample.Directory',
-                    'D4F45017-AD2B-416B-AD9F-3B74F7DEA291': '{"$class":"org.acme.sample.Person","name":"Bob"}',
-                    '9FAE34BF-18C3-4770-A6AA-6F7656C356B8': '{"$class":"org.acme.sample.Person","name":"Alice"}',
+                    'D4F45017-AD2B-416B-AD9F-3B74F7DEA291': {'$class':'org.acme.sample.Person','name':'Bob'},
+                    '9FAE34BF-18C3-4770-A6AA-6F7656C356B8': {'$class':'org.acme.sample.Person','name':'Alice'},
                 }
             };
 
@@ -964,8 +964,8 @@ describe('Serializer', () => {
                 $class: 'org.acme.sample.Concepts',
                 directory: {
                     $class: 'org.acme.sample.Directory',
-                    'D4F45017-AD2B-416B-AD9F-3B74F7DEA291': '{"$class":"org.acme.sample.Person","name":"Bob"}',
-                    '9FAE34BF-18C3-4770-A6AA-6F7656C356B8': '{"$class":"org.acme.sample.Person","name":"Alice"}',
+                    'D4F45017-AD2B-416B-AD9F-3B74F7DEA291': {'$class':'org.acme.sample.Person','name':'Bob'},
+                    '9FAE34BF-18C3-4770-A6AA-6F7656C356B8': {'$class':'org.acme.sample.Person','name':'Alice'},
                 }
             });
         });


### PR DESCRIPTION
### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
Patch fix for the serialization of Concepts when used as Map values.



```
// Valid
{
    $class: 'org.acme.sample.Concepts',
    rolodex: {
        $class: 'org.acme.sample.Rolodex',
        'Dublin': {'$class':'org.acme.sample.Person','name':'Bob'}, // Concept is an Object
        'London': {'$class':'org.acme.sample.Person','name':'Alice'}
    }
};
```

```
// Invalid
{
    $class: 'org.acme.sample.Concepts',
    rolodex: {
        $class: 'org.acme.sample.Rolodex',
        'Dublin': '{"$class":"org.acme.sample.Person","name":"Bob"}',  // Concept is not a String
        'London': '{"$class":"org.acme.sample.Person","name":"Alice"}'
    }
};
```

