### PR TITLE
feat(introspector): getClassDeclarations filters map declarations

### DIFF
--- a/packages/concerto-core/lib/introspect/introspector.js
+++ b/packages/concerto-core/lib/introspect/introspector.js
@@ -59,11 +59,12 @@ class Introspector {
         const modelFiles = this.modelManager.getModelFiles();
         for(let n=0; n < modelFiles.length; n++) {
             const modelFile = modelFiles[n];
-            result = result.concat(
-                modelFile.getAllDeclarations()
-                    .filter(declaration => !declaration.isScalarDeclaration?.()
-                    )
-            );
+
+            const filteredDeclarations = modelFile.getAllDeclarations()
+                .filter(declaration => !declaration.isScalarDeclaration?.())
+                .filter(declaration =>  !declaration.isMapDeclaration?.());
+
+            result = result.concat(filteredDeclarations);
         }
         return result;
     }

--- a/packages/concerto-core/lib/introspect/introspector.js
+++ b/packages/concerto-core/lib/introspect/introspector.js
@@ -61,8 +61,7 @@ class Introspector {
             const modelFile = modelFiles[n];
 
             const filteredDeclarations = modelFile.getAllDeclarations()
-                .filter(declaration => !declaration.isScalarDeclaration?.())
-                .filter(declaration =>  !declaration.isMapDeclaration?.());
+                .filter(declaration =>  !declaration.isMapDeclaration?.() && !declaration.isScalarDeclaration?.());
 
             result = result.concat(filteredDeclarations);
         }

--- a/packages/concerto-core/test/introspect/introspector.js
+++ b/packages/concerto-core/test/introspect/introspector.js
@@ -56,7 +56,11 @@ describe('Introspector', () => {
             modelManager.addCTOModel(modelBase, 'model-base.cto');
             const introspector = new Introspector(modelManager);
             let classDecl = introspector.getClassDeclarations();
-            classDecl.length.should.equal(45);
+            const scalarDecl = classDecl.filter(declaration =>  declaration.isScalarDeclaration?.());
+            const mapDecl = classDecl.filter(declaration =>  declaration.isMapDeclaration?.());
+            classDecl.length.should.equal(44);
+            scalarDecl.length.should.equal(0);
+            mapDecl.length.should.equal(0);
         });
     });
 


### PR DESCRIPTION
##Description
Introspector.getClassDeclarations should return ClassDeclarations only. This PR filters on declarations of type MapDeclaration.


### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
