### PR TITLE
feat(maps): assign key type from ast

### DIFF
--- a/packages/concerto-core/lib/introspect/mapkeytype.js
+++ b/packages/concerto-core/lib/introspect/mapkeytype.js
@@ -102,8 +102,7 @@ class MapKeyType extends Decorated {
             this.type = 'String';
             break;
         case `${MetaModelNamespace}.ObjectMapKeyType`:
-            decl = this.parent.getModelFile().getAllDeclarations().find(d => d.name === this.ast.type.name);
-            this.type = decl.getName();
+            this.type = String(this.ast.type.name);
             break;
         }
     }


### PR DESCRIPTION
# Description 

There may be scenarios where a declaration associated with a MapKeyType may not yet be available for reference within the model file, leading to an Edge case where the Key Types value cannot be set. In order to avoid this erroneous behaviour, the Type is set directly from the AST instead of the associated Declaration instance.


### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)

