### PR TITLE
feat(map): remove class reference in Maps

### DIFF
--- a/packages/concerto-core/lib/serializer/jsongenerator.js
+++ b/packages/concerto-core/lib/serializer/jsongenerator.js
@@ -87,12 +87,12 @@ class JSONGenerator {
         const obj = parameters.stack.pop();
 
         // initialise Map with $class property
-        let map = new Map([['$class',obj.get('$class')]]);
+        let map = new Map();
 
         obj.forEach((value, key) => {
 
             // don't serialize System Properties, other than $class
-            if(ModelUtil.isSystemProperty(key) && key !== '$class') {
+            if(ModelUtil.isSystemProperty(key)) {
                 return;
             }
 

--- a/packages/concerto-core/lib/serializer/resourcevalidator.js
+++ b/packages/concerto-core/lib/serializer/resourcevalidator.js
@@ -182,14 +182,6 @@ class ResourceValidator {
             throw new Error('Expected a Map, but found ' + JSON.stringify(obj));
         }
 
-        if (!obj.has('$class')) {
-            throw new Error('Invalid Map. Map must contain a properly formatted $class property');
-        }
-
-        if (obj.get('$class') !== mapDeclaration.getFullyQualifiedName()) {
-            throw new Error(`$class value must match ${mapDeclaration.getFullyQualifiedName()}`);
-        }
-
         obj.forEach((value, key) => {
             if (!ModelUtil.isSystemProperty(key)) {
                 // Validate Key

--- a/packages/concerto-core/test/serializer/maptype/serializer.js
+++ b/packages/concerto-core/test/serializer/maptype/serializer.js
@@ -152,7 +152,6 @@ describe('Serializer', () => {
             let concept = factory.newConcept('org.acme.sample', 'Concepts');
 
             concept.dict = new Map();
-            concept.dict.set('$class', 'org.acme.sample.Dictionary');
             concept.dict.set('Lorem', 'Ipsum');
             concept.dict.set('Ipsum', 'Lorem');
 
@@ -162,7 +161,6 @@ describe('Serializer', () => {
             json.should.deep.equal({
                 $class: 'org.acme.sample.Concepts',
                 dict: {
-                    $class: 'org.acme.sample.Dictionary',
                     Lorem: 'Ipsum',
                     Ipsum: 'Lorem'
                 }
@@ -173,7 +171,6 @@ describe('Serializer', () => {
 
             resource.should.be.an.instanceOf(Resource);
             resource.dict.should.be.an.instanceOf(Map);
-            resource.dict.get('$class').should.equal('org.acme.sample.Dictionary');
             resource.dict.get('Lorem').should.equal('Ipsum');
             resource.dict.get('Ipsum').should.equal('Lorem');
         });
@@ -183,7 +180,6 @@ describe('Serializer', () => {
             let concept = factory.newConcept('org.acme.sample', 'Concepts');
 
             concept.score = new Map();
-            concept.score.set('$class', 'org.acme.sample.Score');
             concept.score.set('Bob', 1);
             concept.score.set('Alice', 1);
 
@@ -193,7 +189,6 @@ describe('Serializer', () => {
             json.should.deep.equal({
                 $class: 'org.acme.sample.Concepts',
                 score: {
-                    $class: 'org.acme.sample.Score',
                     Bob: 1,
                     Alice: 1
                 }
@@ -204,7 +199,6 @@ describe('Serializer', () => {
 
             resource.should.be.an.instanceOf(Resource);
             resource.score.should.be.an.instanceOf(Map);
-            resource.score.get('$class').should.equal('org.acme.sample.Score');
             resource.score.get('Bob').should.equal(1);
             resource.score.get('Alice').should.equal(1);
         });
@@ -214,7 +208,6 @@ describe('Serializer', () => {
             let concept = factory.newConcept('org.acme.sample', 'Concepts');
 
             concept.points = new Map();
-            concept.points.set('$class', 'org.acme.sample.Points');
             concept.points.set('Bob', -398741129664271);
             concept.points.set('Alice', 8999999125356546);
 
@@ -224,7 +217,6 @@ describe('Serializer', () => {
             json.should.deep.equal({
                 $class: 'org.acme.sample.Concepts',
                 points: {
-                    $class: 'org.acme.sample.Points',
                     Bob: -398741129664271,
                     Alice: 8999999125356546
                 }
@@ -235,7 +227,6 @@ describe('Serializer', () => {
 
             resource.should.be.an.instanceOf(Resource);
             resource.points.should.be.an.instanceOf(Map);
-            resource.points.get('$class').should.equal('org.acme.sample.Points');
             resource.points.get('Bob').should.equal(-398741129664271);
             resource.points.get('Alice').should.equal(8999999125356546);
         });
@@ -245,7 +236,6 @@ describe('Serializer', () => {
             let concept = factory.newConcept('org.acme.sample', 'Concepts');
 
             concept.balance = new Map();
-            concept.balance.set('$class', 'org.acme.sample.Balance');
             concept.balance.set('Bob', 99999.99);
             concept.balance.set('Alice', 1000000.00);
 
@@ -255,7 +245,6 @@ describe('Serializer', () => {
             json.should.deep.equal({
                 $class: 'org.acme.sample.Concepts',
                 balance: {
-                    $class: 'org.acme.sample.Balance',
                     Bob: 99999.99,
                     Alice: 1000000.00
                 }
@@ -266,7 +255,6 @@ describe('Serializer', () => {
 
             resource.should.be.an.instanceOf(Resource);
             resource.balance.should.be.an.instanceOf(Map);
-            resource.balance.get('$class').should.equal('org.acme.sample.Balance');
             resource.balance.get('Bob').should.equal(99999.99);
             resource.balance.get('Alice').should.equal(1000000.00);
         });
@@ -276,7 +264,6 @@ describe('Serializer', () => {
             let concept = factory.newConcept('org.acme.sample', 'Concepts');
 
             concept.rsvp = new Map();
-            concept.rsvp.set('$class', 'org.acme.sample.RSVP');
             concept.rsvp.set('Bob', true);
             concept.rsvp.set('Alice', false);
 
@@ -286,7 +273,6 @@ describe('Serializer', () => {
             json.should.deep.equal({
                 $class: 'org.acme.sample.Concepts',
                 rsvp: {
-                    $class: 'org.acme.sample.RSVP',
                     Bob: true,
                     Alice: false
                 }
@@ -297,7 +283,6 @@ describe('Serializer', () => {
 
             resource.should.be.an.instanceOf(Resource);
             resource.rsvp.should.be.an.instanceOf(Map);
-            resource.rsvp.get('$class').should.equal('org.acme.sample.RSVP');
             resource.rsvp.get('Bob').should.equal(true);
             resource.rsvp.get('Alice').should.equal(false);
         });
@@ -307,7 +292,6 @@ describe('Serializer', () => {
             let concept = factory.newConcept('org.acme.sample', 'Concepts');
 
             concept.birthday = new Map();
-            concept.birthday.set('$class', 'org.acme.sample.Birthday');
             concept.birthday.set('Bob', '2023-10-28T01:02:03Z');
             concept.birthday.set('Alice', '2024-10-28T01:02:03Z');
 
@@ -317,7 +301,6 @@ describe('Serializer', () => {
             json.should.deep.equal({
                 $class: 'org.acme.sample.Concepts',
                 birthday: {
-                    $class: 'org.acme.sample.Birthday',
                     Bob: '2023-10-28T01:02:03Z',
                     Alice: '2024-10-28T01:02:03Z'
                 }
@@ -328,7 +311,6 @@ describe('Serializer', () => {
 
             resource.should.be.an.instanceOf(Resource);
             resource.birthday.should.be.an.instanceOf(Map);
-            resource.birthday.get('$class').should.equal('org.acme.sample.Birthday');
             resource.birthday.get('Bob').should.equal('2023-10-28T01:02:03Z');
             resource.birthday.get('Alice').should.equal('2024-10-28T01:02:03Z');
         });
@@ -338,7 +320,6 @@ describe('Serializer', () => {
             let concept = factory.newConcept('org.acme.sample', 'Concepts');
 
             concept.celebration = new Map();
-            concept.celebration.set('$class', 'org.acme.sample.Celebration');
             concept.celebration.set('BobBirthday', '2022-11-28T01:02:03Z');
             concept.celebration.set('AliceAnniversary', '2023-10-28T01:02:03Z');
 
@@ -348,7 +329,6 @@ describe('Serializer', () => {
             json.should.deep.equal({
                 $class: 'org.acme.sample.Concepts',
                 celebration: {
-                    $class: 'org.acme.sample.Celebration',
                     'BobBirthday': '2022-11-28T01:02:03Z',
                     'AliceAnniversary': '2023-10-28T01:02:03Z',
                 }
@@ -359,7 +339,6 @@ describe('Serializer', () => {
 
             resource.should.be.an.instanceOf(Resource);
             resource.celebration.should.be.an.instanceOf(Map);
-            resource.celebration.get('$class').should.equal('org.acme.sample.Celebration');
             resource.celebration.get('BobBirthday').should.equal('2022-11-28T01:02:03Z');
             resource.celebration.get('AliceAnniversary').should.equal('2023-10-28T01:02:03Z');
         });
@@ -372,7 +351,6 @@ describe('Serializer', () => {
             const alice = factory.newConcept('org.acme.sample', 'Person', 'Alice');
 
             concept.rolodex = new Map();
-            concept.rolodex.set('$class', 'org.acme.sample.Rolodex');
             concept.rolodex.set('Dublin', bob);
             concept.rolodex.set('London', alice);
 
@@ -382,7 +360,6 @@ describe('Serializer', () => {
             json.should.deep.equal({
                 $class: 'org.acme.sample.Concepts',
                 rolodex: {
-                    $class: 'org.acme.sample.Rolodex',
                     'Dublin': {'$class':'org.acme.sample.Person','name':'Bob'},
                     'London': {'$class':'org.acme.sample.Person','name':'Alice'}
                 }
@@ -393,7 +370,6 @@ describe('Serializer', () => {
 
             resource.should.be.an.instanceOf(Resource);
             resource.rolodex.should.be.an.instanceOf(Map);
-            resource.rolodex.get('$class').should.equal('org.acme.sample.Rolodex');
 
             resource.rolodex.get('Dublin').should.be.an.instanceOf(Resource);
             resource.rolodex.get('London').should.be.an.instanceOf(Resource);
@@ -407,7 +383,6 @@ describe('Serializer', () => {
             let concept = factory.newConcept('org.acme.sample', 'Concepts');
 
             concept.appointment = new Map();
-            concept.appointment.set('$class', 'org.acme.sample.Appointment');
             concept.appointment.set('2023-11-28T01:02:03Z', 'BobBirthday');
             concept.appointment.set('2024-10-28T01:02:03Z', 'AliceAnniversary');
 
@@ -417,7 +392,6 @@ describe('Serializer', () => {
             json.should.deep.equal({
                 $class: 'org.acme.sample.Concepts',
                 appointment: {
-                    '$class': 'org.acme.sample.Appointment',
                     '2023-11-28T01:02:03Z': 'BobBirthday',
                     '2024-10-28T01:02:03Z': 'AliceAnniversary'
                 }
@@ -428,7 +402,6 @@ describe('Serializer', () => {
 
             resource.should.be.an.instanceOf(Resource);
             resource.appointment.should.be.an.instanceOf(Map);
-            resource.appointment.get('$class').should.equal('org.acme.sample.Appointment');
             resource.appointment.get('2023-11-28T01:02:03Z').should.equal('BobBirthday');
             resource.appointment.get('2024-10-28T01:02:03Z').should.equal('AliceAnniversary');
         });
@@ -438,7 +411,6 @@ describe('Serializer', () => {
             let concept = factory.newConcept('org.acme.sample', 'Concepts');
 
             concept.database = new Map();
-            concept.database.set('$class', 'org.acme.sample.Database');
             concept.database.set('D4F45017-AD2B-416B-AD9F-3B74F7DEA291', 'Bob');
             concept.database.set('E17B69D9-9B57-4C4A-957E-8B202D7B6C5A', 'Alice');
 
@@ -448,7 +420,6 @@ describe('Serializer', () => {
             json.should.deep.equal({
                 $class: 'org.acme.sample.Concepts',
                 database: {
-                    '$class': 'org.acme.sample.Database',
                     'D4F45017-AD2B-416B-AD9F-3B74F7DEA291': 'Bob',
                     'E17B69D9-9B57-4C4A-957E-8B202D7B6C5A': 'Alice'
                 }
@@ -459,7 +430,6 @@ describe('Serializer', () => {
 
             resource.should.be.an.instanceOf(Resource);
             resource.database.should.be.an.instanceOf(Map);
-            resource.database.get('$class').should.equal('org.acme.sample.Database');
             resource.database.get('D4F45017-AD2B-416B-AD9F-3B74F7DEA291').should.equal('Bob');
             resource.database.get('E17B69D9-9B57-4C4A-957E-8B202D7B6C5A').should.equal('Alice');
         });
@@ -469,7 +439,6 @@ describe('Serializer', () => {
             let concept = factory.newConcept('org.acme.sample', 'Concepts');
 
             concept.stopwatch = new Map();
-            concept.stopwatch.set('$class', 'org.acme.sample.StopWatch');
             concept.stopwatch.set('2023-10-28T00:00:00Z', '2023-10-28T11:12:13Z');
             concept.stopwatch.set('2024-11-28T00:00:00Z', '2024-11-28T11:12:13Z');
 
@@ -479,7 +448,6 @@ describe('Serializer', () => {
             json.should.deep.equal({
                 $class: 'org.acme.sample.Concepts',
                 stopwatch: {
-                    $class: 'org.acme.sample.StopWatch',
                     '2023-10-28T00:00:00Z': '2023-10-28T11:12:13Z',
                     '2024-11-28T00:00:00Z': '2024-11-28T11:12:13Z',
                 }
@@ -490,7 +458,6 @@ describe('Serializer', () => {
 
             resource.should.be.an.instanceOf(Resource);
             resource.stopwatch.should.be.an.instanceOf(Map);
-            resource.stopwatch.get('$class').should.equal('org.acme.sample.StopWatch');
             resource.stopwatch.get('2023-10-28T00:00:00Z').should.equal('2023-10-28T11:12:13Z');
             resource.stopwatch.get('2024-11-28T00:00:00Z').should.equal('2024-11-28T11:12:13Z');
         });
@@ -503,7 +470,6 @@ describe('Serializer', () => {
             const alice = factory.newConcept('org.acme.sample', 'Person', 'Alice');
 
             concept.directory = new Map();
-            concept.directory.set('$class', 'org.acme.sample.Directory');
             concept.directory.set('D4F45017-AD2B-416B-AD9F-3B74F7DEA291', bob);
             concept.directory.set('9FAE34BF-18C3-4770-A6AA-6F7656C356B8', alice);
 
@@ -513,7 +479,6 @@ describe('Serializer', () => {
             json.should.deep.equal({
                 $class: 'org.acme.sample.Concepts',
                 directory: {
-                    $class: 'org.acme.sample.Directory',
                     'D4F45017-AD2B-416B-AD9F-3B74F7DEA291': {'$class':'org.acme.sample.Person','name':'Bob'},
                     '9FAE34BF-18C3-4770-A6AA-6F7656C356B8': {'$class':'org.acme.sample.Person','name':'Alice'},
                 }
@@ -524,8 +489,6 @@ describe('Serializer', () => {
 
             resource.should.be.an.instanceOf(Resource);
             resource.directory.should.be.an.instanceOf(Map);
-
-            resource.directory.get('$class').should.equal('org.acme.sample.Directory');
 
             resource.directory.get('D4F45017-AD2B-416B-AD9F-3B74F7DEA291').should.be.an.instanceOf(Resource);
             resource.directory.get('9FAE34BF-18C3-4770-A6AA-6F7656C356B8').should.be.an.instanceOf(Resource);
@@ -539,7 +502,6 @@ describe('Serializer', () => {
             let concept = factory.newConcept('org.acme.sample', 'Concepts');
 
             concept.diary = new Map();
-            concept.diary.set('$class', 'org.acme.sample.Diary');
             concept.diary.set('2023-10-28T01:02:03Z', 'Birthday');
             concept.diary.set('2024-10-28T01:02:03Z', 'Anniversary');
 
@@ -549,7 +511,6 @@ describe('Serializer', () => {
             json.should.deep.equal({
                 $class: 'org.acme.sample.Concepts',
                 diary: {
-                    $class: 'org.acme.sample.Diary',
                     '2023-10-28T01:02:03Z': 'Birthday',
                     '2024-10-28T01:02:03Z': 'Anniversary'
                 }
@@ -560,7 +521,6 @@ describe('Serializer', () => {
 
             resource.should.be.an.instanceOf(Resource);
             resource.diary.should.be.an.instanceOf(Map);
-            resource.diary.get('$class').should.equal('org.acme.sample.Diary');
             resource.diary.get('2023-10-28T01:02:03Z').should.equal('Birthday');
             resource.diary.get('2024-10-28T01:02:03Z').should.equal('Anniversary');
         });
@@ -572,7 +532,6 @@ describe('Serializer', () => {
             let json = {
                 $class: 'org.acme.sample.Concepts',
                 dict: {
-                    '$class': 'org.acme.sample.Dictionary',
                     Bob: 'Ipsum',
                     Alice: 'Lorem'
                 }
@@ -583,7 +542,6 @@ describe('Serializer', () => {
 
             resource.should.be.an.instanceOf(Resource);
             resource.dict.should.be.an.instanceOf(Map);
-            resource.dict.get('$class').should.equal('org.acme.sample.Dictionary');
             resource.dict.get('Bob').should.equal('Ipsum');
             resource.dict.get('Alice').should.equal('Lorem');
 
@@ -593,7 +551,6 @@ describe('Serializer', () => {
             json.should.deep.equal({
                 $class: 'org.acme.sample.Concepts',
                 dict: {
-                    $class: 'org.acme.sample.Dictionary',
                     Bob: 'Ipsum',
                     Alice: 'Lorem'
                 }
@@ -605,7 +562,6 @@ describe('Serializer', () => {
             let json = {
                 $class: 'org.acme.sample.Concepts',
                 score: {
-                    '$class': 'org.acme.sample.Score',
                     Bob: 1,
                     Alice: 1
                 }
@@ -616,7 +572,6 @@ describe('Serializer', () => {
 
             resource.should.be.an.instanceOf(Resource);
             resource.score.should.be.an.instanceOf(Map);
-            resource.score.get('$class').should.equal('org.acme.sample.Score');
             resource.score.get('Bob').should.equal(1);
             resource.score.get('Alice').should.equal(1);
 
@@ -626,7 +581,6 @@ describe('Serializer', () => {
             json.should.deep.equal({
                 $class: 'org.acme.sample.Concepts',
                 score: {
-                    $class: 'org.acme.sample.Score',
                     Bob: 1,
                     Alice: 1
                 }
@@ -638,7 +592,6 @@ describe('Serializer', () => {
             let json = {
                 $class: 'org.acme.sample.Concepts',
                 points: {
-                    '$class': 'org.acme.sample.Points',
                     Bob: -398741129664271,
                     Alice: 8999999125356546
                 }
@@ -649,7 +602,6 @@ describe('Serializer', () => {
 
             resource.should.be.an.instanceOf(Resource);
             resource.points.should.be.an.instanceOf(Map);
-            resource.points.get('$class').should.equal('org.acme.sample.Points');
             resource.points.get('Bob').should.equal(-398741129664271);
             resource.points.get('Alice').should.equal(8999999125356546);
 
@@ -659,7 +611,6 @@ describe('Serializer', () => {
             json.should.deep.equal({
                 $class: 'org.acme.sample.Concepts',
                 points: {
-                    $class: 'org.acme.sample.Points',
                     Bob: -398741129664271,
                     Alice: 8999999125356546
                 }
@@ -671,7 +622,6 @@ describe('Serializer', () => {
             let json = {
                 $class: 'org.acme.sample.Concepts',
                 balance: {
-                    $class: 'org.acme.sample.Balance',
                     Bob: 99999.99,
                     Alice: 1000000.00
                 }
@@ -682,7 +632,6 @@ describe('Serializer', () => {
 
             resource.should.be.an.instanceOf(Resource);
             resource.balance.should.be.an.instanceOf(Map);
-            resource.balance.get('$class').should.equal('org.acme.sample.Balance');
             resource.balance.get('Bob').should.equal(99999.99);
             resource.balance.get('Alice').should.equal(1000000.00);
 
@@ -692,7 +641,6 @@ describe('Serializer', () => {
             json.should.deep.equal({
                 $class: 'org.acme.sample.Concepts',
                 balance: {
-                    $class: 'org.acme.sample.Balance',
                     Bob: 99999.99,
                     Alice: 1000000.00
                 }
@@ -704,7 +652,6 @@ describe('Serializer', () => {
             let json = {
                 $class: 'org.acme.sample.Concepts',
                 rsvp: {
-                    $class: 'org.acme.sample.RSVP',
                     Bob: true,
                     Alice: false
                 }
@@ -715,7 +662,6 @@ describe('Serializer', () => {
 
             resource.should.be.an.instanceOf(Resource);
             resource.rsvp.should.be.an.instanceOf(Map);
-            resource.rsvp.get('$class').should.equal('org.acme.sample.RSVP');
             resource.rsvp.get('Bob').should.equal(true);
             resource.rsvp.get('Alice').should.equal(false);
 
@@ -725,7 +671,6 @@ describe('Serializer', () => {
             json.should.deep.equal({
                 $class: 'org.acme.sample.Concepts',
                 rsvp: {
-                    $class: 'org.acme.sample.RSVP',
                     Bob: true,
                     Alice: false
                 }
@@ -737,7 +682,6 @@ describe('Serializer', () => {
             let json = {
                 $class: 'org.acme.sample.Concepts',
                 birthday: {
-                    $class: 'org.acme.sample.Birthday',
                     Bob: '2023-10-28T01:02:03Z',
                     Alice: '2024-10-28T01:02:03Z'
                 }
@@ -748,7 +692,6 @@ describe('Serializer', () => {
 
             resource.should.be.an.instanceOf(Resource);
             resource.birthday.should.be.an.instanceOf(Map);
-            resource.birthday.get('$class').should.equal('org.acme.sample.Birthday');
             resource.birthday.get('Bob').should.equal('2023-10-28T01:02:03Z');
             resource.birthday.get('Alice').should.equal('2024-10-28T01:02:03Z');
 
@@ -758,7 +701,6 @@ describe('Serializer', () => {
             json.should.deep.equal({
                 $class: 'org.acme.sample.Concepts',
                 birthday: {
-                    $class: 'org.acme.sample.Birthday',
                     Bob: '2023-10-28T01:02:03Z',
                     Alice: '2024-10-28T01:02:03Z'
                 }
@@ -770,7 +712,6 @@ describe('Serializer', () => {
             let json = {
                 $class: 'org.acme.sample.Concepts',
                 celebration: {
-                    $class: 'org.acme.sample.Celebration',
                     'BobBirthday': '2022-11-28T01:02:03Z',
                     'AliceAnniversary': '2023-10-28T01:02:03Z',
                 }
@@ -781,7 +722,6 @@ describe('Serializer', () => {
 
             resource.should.be.an.instanceOf(Resource);
             resource.celebration.should.be.an.instanceOf(Map);
-            resource.celebration.get('$class').should.equal('org.acme.sample.Celebration');
             resource.celebration.get('BobBirthday').should.equal('2022-11-28T01:02:03Z');
             resource.celebration.get('AliceAnniversary').should.equal('2023-10-28T01:02:03Z');
 
@@ -791,7 +731,6 @@ describe('Serializer', () => {
             json.should.deep.equal({
                 $class: 'org.acme.sample.Concepts',
                 celebration: {
-                    $class: 'org.acme.sample.Celebration',
                     'BobBirthday': '2022-11-28T01:02:03Z',
                     'AliceAnniversary': '2023-10-28T01:02:03Z',
                 }
@@ -804,7 +743,6 @@ describe('Serializer', () => {
             let json = {
                 $class: 'org.acme.sample.Concepts',
                 rolodex: {
-                    $class: 'org.acme.sample.Rolodex',
                     'Dublin': {'$class':'org.acme.sample.Person','name':'Bob'},
                     'London': {'$class':'org.acme.sample.Person','name':'Alice'}
                 }
@@ -815,7 +753,6 @@ describe('Serializer', () => {
 
             resource.should.be.an.instanceOf(Resource);
             resource.rolodex.should.be.an.instanceOf(Map);
-            resource.rolodex.get('$class').should.equal('org.acme.sample.Rolodex');
 
             resource.rolodex.get('Dublin').should.be.an.instanceOf(Resource);
             resource.rolodex.get('London').should.be.an.instanceOf(Resource);
@@ -829,7 +766,6 @@ describe('Serializer', () => {
             json.should.deep.equal({
                 $class: 'org.acme.sample.Concepts',
                 rolodex: {
-                    $class: 'org.acme.sample.Rolodex',
                     'Dublin': {'$class':'org.acme.sample.Person','name':'Bob'},
                     'London': {'$class':'org.acme.sample.Person','name':'Alice'}
                 }
@@ -841,7 +777,6 @@ describe('Serializer', () => {
             let json = {
                 $class: 'org.acme.sample.Concepts',
                 appointment: {
-                    '$class': 'org.acme.sample.Appointment',
                     '2023-11-28T01:02:03Z': 'Lorem',
                     '2024-10-28T01:02:03Z': 'Ipsum'
                 }
@@ -852,7 +787,6 @@ describe('Serializer', () => {
 
             resource.should.be.an.instanceOf(Resource);
             resource.appointment.should.be.an.instanceOf(Map);
-            resource.appointment.get('$class').should.equal('org.acme.sample.Appointment');
             resource.appointment.get('2023-11-28T01:02:03Z').should.equal('Lorem');
             resource.appointment.get('2024-10-28T01:02:03Z').should.equal('Ipsum');
 
@@ -862,7 +796,6 @@ describe('Serializer', () => {
             json.should.deep.equal({
                 $class: 'org.acme.sample.Concepts',
                 appointment: {
-                    '$class': 'org.acme.sample.Appointment',
                     '2023-11-28T01:02:03Z': 'Lorem',
                     '2024-10-28T01:02:03Z': 'Ipsum'
                 }
@@ -874,7 +807,6 @@ describe('Serializer', () => {
             let json = {
                 $class: 'org.acme.sample.Concepts',
                 database: {
-                    '$class': 'org.acme.sample.Database',
                     'D4F45017-AD2B-416B-AD9F-3B74F7DEA291': 'Lorem',
                     'E17B69D9-9B57-4C4A-957E-8B202D7B6C5A': 'Ipsum'
                 }
@@ -885,7 +817,6 @@ describe('Serializer', () => {
 
             resource.should.be.an.instanceOf(Resource);
             resource.database.should.be.an.instanceOf(Map);
-            resource.database.get('$class').should.equal('org.acme.sample.Database');
             resource.database.get('D4F45017-AD2B-416B-AD9F-3B74F7DEA291').should.equal('Lorem');
             resource.database.get('E17B69D9-9B57-4C4A-957E-8B202D7B6C5A').should.equal('Ipsum');
 
@@ -895,7 +826,6 @@ describe('Serializer', () => {
             json.should.deep.equal({
                 $class: 'org.acme.sample.Concepts',
                 database: {
-                    '$class': 'org.acme.sample.Database',
                     'D4F45017-AD2B-416B-AD9F-3B74F7DEA291': 'Lorem',
                     'E17B69D9-9B57-4C4A-957E-8B202D7B6C5A': 'Ipsum'
                 }
@@ -907,7 +837,6 @@ describe('Serializer', () => {
             let json = {
                 $class: 'org.acme.sample.Concepts',
                 stopwatch: {
-                    $class: 'org.acme.sample.StopWatch',
                     '2023-10-28T00:00:00Z': '2023-10-28T11:12:13Z',
                     '2024-11-28T00:00:00Z': '2024-11-28T11:12:13Z',
                 }
@@ -918,7 +847,6 @@ describe('Serializer', () => {
 
             resource.should.be.an.instanceOf(Resource);
             resource.stopwatch.should.be.an.instanceOf(Map);
-            resource.stopwatch.get('$class').should.equal('org.acme.sample.StopWatch');
             resource.stopwatch.get('2023-10-28T00:00:00Z').should.equal('2023-10-28T11:12:13Z');
             resource.stopwatch.get('2024-11-28T00:00:00Z').should.equal('2024-11-28T11:12:13Z');
 
@@ -928,7 +856,6 @@ describe('Serializer', () => {
             json.should.deep.equal({
                 $class: 'org.acme.sample.Concepts',
                 stopwatch: {
-                    $class: 'org.acme.sample.StopWatch',
                     '2023-10-28T00:00:00Z': '2023-10-28T11:12:13Z',
                     '2024-11-28T00:00:00Z': '2024-11-28T11:12:13Z',
                 }
@@ -940,7 +867,6 @@ describe('Serializer', () => {
             let json = {
                 $class: 'org.acme.sample.Concepts',
                 directory: {
-                    $class: 'org.acme.sample.Directory',
                     'D4F45017-AD2B-416B-AD9F-3B74F7DEA291': {'$class':'org.acme.sample.Person','name':'Bob'},
                     '9FAE34BF-18C3-4770-A6AA-6F7656C356B8': {'$class':'org.acme.sample.Person','name':'Alice'},
                 }
@@ -951,7 +877,6 @@ describe('Serializer', () => {
 
             resource.should.be.an.instanceOf(Resource);
             resource.directory.should.be.an.instanceOf(Map);
-            resource.directory.get('$class').should.equal('org.acme.sample.Directory');
             resource.directory.get('D4F45017-AD2B-416B-AD9F-3B74F7DEA291').should.be.an.instanceOf(Resource);
             resource.directory.get('9FAE34BF-18C3-4770-A6AA-6F7656C356B8').should.be.an.instanceOf(Resource);
             resource.directory.get('D4F45017-AD2B-416B-AD9F-3B74F7DEA291').toJSON().should.deep.equal({ '$class': 'org.acme.sample.Person', name: 'Bob' });
@@ -963,7 +888,6 @@ describe('Serializer', () => {
             json.should.deep.equal({
                 $class: 'org.acme.sample.Concepts',
                 directory: {
-                    $class: 'org.acme.sample.Directory',
                     'D4F45017-AD2B-416B-AD9F-3B74F7DEA291': {'$class':'org.acme.sample.Person','name':'Bob'},
                     '9FAE34BF-18C3-4770-A6AA-6F7656C356B8': {'$class':'org.acme.sample.Person','name':'Alice'},
                 }
@@ -975,7 +899,6 @@ describe('Serializer', () => {
             let json = {
                 $class: 'org.acme.sample.Concepts',
                 diary: {
-                    $class: 'org.acme.sample.Diary',
                     '2023-10-28T01:02:03Z': 'Birthday',
                     '2024-10-28T01:02:03Z': 'Anniversary'
                 }
@@ -986,7 +909,6 @@ describe('Serializer', () => {
 
             resource.should.be.an.instanceOf(Resource);
             resource.diary.should.be.an.instanceOf(Map);
-            resource.diary.get('$class').should.equal('org.acme.sample.Diary');
             resource.diary.get('2023-10-28T01:02:03Z').should.equal('Birthday');
             resource.diary.get('2024-10-28T01:02:03Z').should.equal('Anniversary');
 
@@ -996,7 +918,6 @@ describe('Serializer', () => {
             json.should.deep.equal({
                 $class: 'org.acme.sample.Concepts',
                 diary: {
-                    $class: 'org.acme.sample.Diary',
                     '2023-10-28T01:02:03Z': 'Birthday',
                     '2024-10-28T01:02:03Z': 'Anniversary'
                 }
@@ -1009,7 +930,6 @@ describe('Serializer', () => {
             let concept = factory.newConcept('org.acme.sample', 'Concepts');
 
             concept.appointment = new Map();
-            concept.appointment.set('$class', 'org.acme.sample.Appointment');
             concept.appointment.set('BAD-DATE-28T01:02:03Z', 'Lorem'); // Bad DateTime
 
             (() => {
@@ -1021,7 +941,6 @@ describe('Serializer', () => {
             let concept = factory.newConcept('org.acme.sample', 'Concepts');
 
             concept.dict = new Map();
-            concept.dict.set('$class', 'org.acme.sample.Dictionary');
             concept.dict.set(1234, 'Lorem'); // Bad key
 
             (() => {
@@ -1033,7 +952,6 @@ describe('Serializer', () => {
             let concept = factory.newConcept('org.acme.sample', 'Concepts');
 
             concept.rsvp = new Map();
-            concept.rsvp.set('$class', 'org.acme.sample.RSVP');
             concept.rsvp.set('Lorem', true);
             concept.rsvp.set('Ipsum', 'false');
 
@@ -1046,7 +964,6 @@ describe('Serializer', () => {
             let concept = factory.newConcept('org.acme.sample', 'Concepts');
 
             concept.dict = new Map();
-            concept.dict.set('$class', 'org.acme.sample.Dictionary');
             concept.dict.set('Lorem', 1234);
 
             (() => {
@@ -1058,7 +975,6 @@ describe('Serializer', () => {
             let concept = factory.newConcept('org.acme.sample', 'Concepts');
 
             concept.timer = new Map();
-            concept.timer.set('$class', 'org.acme.sample.Timer');
             concept.timer.set('2023-10-28T01:02:03Z', '2023-10-28T01:02:03Z');
             concept.timer.set('2023-10-28T01:02:03Z', 'BAD-DATE-VALUE');
 
@@ -1077,23 +993,10 @@ describe('Serializer', () => {
             }).should.throw(`Expected a Map, but found ${JSON.stringify(concept.dict)}`);
         });
 
-        it('should throw validation error when there is a mismatch on map $class property', () => {
-            let concept = factory.newConcept('org.acme.sample', 'Concepts');
-
-            concept.dict = new Map();
-            concept.dict.set('$class', 'org.acme.sample.PhoneBook'); // dict is not a PhoneBook.
-            concept.dict.set('Lorem', 'Ipsum');
-
-            (() => {
-                serializer.toJSON(concept);
-            }).should.throw('$class value must match org.acme.sample.Dictionary');
-        });
-
         it('should ignore system properties', () => {
             let concept = factory.newConcept('org.acme.sample', 'Concepts');
 
             concept.dict = new Map();
-            concept.dict.set('$class', 'org.acme.sample.Dictionary');
             concept.dict.set('$type', 'foo');
             concept.dict.set('Lorem', 'Ipsum');
             concept.dict.set('Ipsum', 'Lorem');
@@ -1103,7 +1006,6 @@ describe('Serializer', () => {
             json.should.deep.equal({
                 $class: 'org.acme.sample.Concepts',
                 dict: {
-                    $class: 'org.acme.sample.Dictionary',
                     Lorem: 'Ipsum',
                     Ipsum: 'Lorem'
                 }
@@ -1112,24 +1014,12 @@ describe('Serializer', () => {
     });
 
     describe('#fromJSON failure scenarios', () => {
-        it('should throw an error when deserializing a Map without a $class property', () => {
-            let json = {
-                $class: 'org.acme.sample.Concepts',
-                dict: {
-                    // '$class': 'org.acme.sample.Dictionary',
-                    'Lorem': 'Ipsum'
-                }
-            };
-            (() => {
-                serializer.fromJSON(json);
-            }).should.throw('Invalid Map. Map must contain a properly formatted $class property');
-        });
+
 
         it('should throw an error when deserializing a Map using a reserved Identifier as a Key property', () => {
             let json = {
                 $class: 'org.acme.sample.Concepts',
                 dict: {
-                    '$class': 'org.acme.sample.Dictionary',
                     '$namespace': 'com.reserved.property',
                     'Lorem': 'Ipsum'
                 }
@@ -1143,7 +1033,6 @@ describe('Serializer', () => {
             let json = {
                 $class: 'org.acme.sample.Concepts',
                 stateLog: {
-                    '$class': 'org.acme.sample.StateLog',
                     'ON': '2000-01-01T00:00:00.000Z',
                     'OFF': '2000-01-01T00:00:00.000Z',
                 }


### PR DESCRIPTION
### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
Removes the $class reference found in MapDeclarations.

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)

