### PR TITLE
feat(decoratormanager) add support for unversioned namespaces in decorator command set target

### DIFF
--- a/packages/concerto-core/api.txt
+++ b/packages/concerto-core/api.txt
@@ -57,10 +57,11 @@ class Concerto {
 class DecoratorManager {
    + ModelManager decorateModels(ModelManager,decoratorCommandSet,object?,boolean?,boolean?) 
    + void validateCommand(ModelManager,command) 
-   + Boolean falsyOrEqual(string|,string) 
+   + Boolean falsyOrEqual(string|,string[]) 
    + void applyDecorator(decorated,string,newDecorator) 
    + void executeCommand(string,declaration,command) 
 }
+   + boolean isUnversionedNamespaceEqual() 
 class Factory {
    + string newId() 
    + void constructor(ModelManager) 

--- a/packages/concerto-core/changelog.txt
+++ b/packages/concerto-core/changelog.txt
@@ -24,6 +24,9 @@
 # Note that the latest public API is documented using JSDocs and is available in api.txt.
 #
 
+Version 3.12.5 {ea967f943046b2792fe3863943a6b2ba} 2023-09-08
+- Update DecoratorManager to support multiple value compare
+
 Version 3.12.4 {7738d5490ea8438677e1d21d704bb5aa} 2023-08-31
 - Adds validate and validateCommands options to DecoratorManager.decorateModels
 - Adds addMetamodel option to BaseModelManager

--- a/packages/concerto-core/test/data/decoratorcommands/web.json
+++ b/packages/concerto-core/test/data/decoratorcommands/web.json
@@ -67,6 +67,21 @@
             "type" : "UPSERT",
             "target" : {
                 "$class" : "org.accordproject.decoratorcommands@0.2.0.CommandTarget",
+                "namespace" : "test",
+                "declaration" : "Person",
+                "property" : "bio"
+            },
+            "decorator" : {
+                "$class" : "concerto.metamodel@1.0.0.Decorator",
+                "name" : "UnversionedNamespace",
+                "arguments" : []
+            }
+        },
+        {
+            "$class" : "org.accordproject.decoratorcommands@0.2.0.Command",
+            "type" : "UPSERT",
+            "target" : {
+                "$class" : "org.accordproject.decoratorcommands@0.2.0.CommandTarget",
                 "namespace" : "test@1.0.0",
                 "declaration" : "SSN"
             },

--- a/packages/concerto-core/test/decoratormanager.js
+++ b/packages/concerto-core/test/decoratormanager.js
@@ -50,6 +50,35 @@ describe('DecoratorManager', () => {
     });
 
     describe('#decorateModels', function() {
+        it('should support no validation', async function() {
+            const testModelManager = new ModelManager({strict:true});
+            const modelText = fs.readFileSync('./test/data/decoratorcommands/test.cto', 'utf-8');
+            testModelManager.addCTOModel(modelText, 'test.cto');
+            const dcs = fs.readFileSync('./test/data/decoratorcommands/web.json', 'utf-8');
+            let decoratedModelManager = DecoratorManager.decorateModels( testModelManager, JSON.parse(dcs));
+            decoratedModelManager.should.not.be.null;
+        });
+
+        it('should support syntax validation', async function() {
+            const testModelManager = new ModelManager({strict:true});
+            const modelText = fs.readFileSync('./test/data/decoratorcommands/test.cto', 'utf-8');
+            testModelManager.addCTOModel(modelText, 'test.cto');
+            const dcs = fs.readFileSync('./test/data/decoratorcommands/web.json', 'utf-8');
+            let decoratedModelManager = DecoratorManager.decorateModels( testModelManager, JSON.parse(dcs),
+                {validate: true});
+            decoratedModelManager.should.not.be.null;
+        });
+
+        it('should support semantic validation', async function() {
+            const testModelManager = new ModelManager({strict:true});
+            const modelText = fs.readFileSync('./test/data/decoratorcommands/test.cto', 'utf-8');
+            testModelManager.addCTOModel(modelText, 'test.cto');
+            const dcs = fs.readFileSync('./test/data/decoratorcommands/web.json', 'utf-8');
+            let decoratedModelManager = DecoratorManager.decorateModels( testModelManager, JSON.parse(dcs),
+                {validate: true, validateCommands: true});
+            decoratedModelManager.should.not.be.null;
+        });
+
         it('should add decorator', async function() {
             // load a model to decorate
             const testModelManager = new ModelManager({strict:true});
@@ -58,7 +87,7 @@ describe('DecoratorManager', () => {
 
             const dcs = fs.readFileSync('./test/data/decoratorcommands/web.json', 'utf-8');
             const decoratedModelManager = DecoratorManager.decorateModels( testModelManager, JSON.parse(dcs),
-                {validate: true});
+                {validate: true, validateCommands: true});
 
             const ssnDecl = decoratedModelManager.getType('test@1.0.0.SSN');
             ssnDecl.should.not.be.null;
@@ -85,6 +114,9 @@ describe('DecoratorManager', () => {
             decoratorBio.should.not.be.null;
             decoratorBio.getArguments()[0].should.equal('inputType');
             decoratorBio.getArguments()[1].should.equal('textArea');
+
+            const decoratorUnversionedNamespace = bioProperty.getDecorator('UnversionedNamespace');
+            decoratorUnversionedNamespace.should.not.be.null;
         });
 
         it('should fail with invalid command', async function() {


### PR DESCRIPTION
# Closes #710 

Updates decorator manager to allow command targets to use unversioned namespaces.

### Changes
- Update apply decorator
- Update validate decorator command

### Flags
<!--- Provide context or concerns a reviewer should be aware of -->
- <ONE>
- <TWO>

### Screenshots or Video
<!--- Provide an easily accessible demonstration of the changes, if applicable -->

### Related Issues
- Issue #<NUMBER>
- Pull Request #<NUMBER>

### Author Checklist
- [ ] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [ ] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ ] Merging to `main` from `fork:branchname`
