### PR TITLE
chore(decoratormanager) API backwards compat

### DIFF
--- a/packages/concerto-core/api.txt
+++ b/packages/concerto-core/api.txt
@@ -57,7 +57,7 @@ class Concerto {
 class DecoratorManager {
    + ModelManager decorateModels(ModelManager,decoratorCommandSet,object?,boolean?,boolean?) 
    + void validateCommand(ModelManager,command) 
-   + Boolean falsyOrEqual(string|,string[]) 
+   + Boolean falsyOrEqual(string|,string|) 
    + void applyDecorator(decorated,string,newDecorator) 
    + void executeCommand(string,declaration,command) 
 }

--- a/packages/concerto-core/changelog.txt
+++ b/packages/concerto-core/changelog.txt
@@ -24,7 +24,7 @@
 # Note that the latest public API is documented using JSDocs and is available in api.txt.
 #
 
-Version 3.12.5 {ea967f943046b2792fe3863943a6b2ba} 2023-09-08
+Version 3.12.5 {ced48c7ab94de207be87584468517f3e} 2023-09-08
 - Update DecoratorManager to support multiple value compare
 
 Version 3.12.4 {7738d5490ea8438677e1d21d704bb5aa} 2023-08-31

--- a/packages/concerto-core/lib/decoratormanager.js
+++ b/packages/concerto-core/lib/decoratormanager.js
@@ -172,11 +172,13 @@ class DecoratorManager {
      * Compares two values. If the first argument is falsy
      * the function returns true.
      * @param {string | null} test the value to test (lhs)
-     * @param {string[]} values the values to compare (rhs)
+     * @param {string|string[]} values the values to compare (rhs)
      * @returns {Boolean} true if the lhs is falsy or values.includes(test)
      */
     static falsyOrEqual(test, values) {
-        return test ? values.includes(test) : true;
+        return test
+            ? Array.isArray(values) ? values.includes(test) : test === values
+            : true;
     }
 
     /**

--- a/packages/concerto-core/test/decoratormanager.js
+++ b/packages/concerto-core/test/decoratormanager.js
@@ -44,8 +44,16 @@ describe('DecoratorManager', () => {
             DecoratorManager.falsyOrEqual( 'one', 'one').should.be.true;
         });
 
+        it('should match token', async function() {
+            DecoratorManager.falsyOrEqual( 'one', ['one']).should.be.true;
+        });
+
         it('should not match token', async function() {
             DecoratorManager.falsyOrEqual( 'one', 'two').should.be.false;
+        });
+
+        it('should not match token', async function() {
+            DecoratorManager.falsyOrEqual( 'one', ['two']).should.be.false;
         });
     });
 

--- a/packages/concerto-core/types/lib/decoratormanager.d.ts
+++ b/packages/concerto-core/types/lib/decoratormanager.d.ts
@@ -31,10 +31,10 @@ declare class DecoratorManager {
      * Compares two values. If the first argument is falsy
      * the function returns true.
      * @param {string | null} test the value to test (lhs)
-     * @param {string} value the value to compare (rhs)
-     * @returns {Boolean} true if the lhs is falsy or test === value
+     * @param {string|string[]} values the values to compare (rhs)
+     * @returns {Boolean} true if the lhs is falsy or values.includes(test)
      */
-    static falsyOrEqual(test: string | null, value: string): boolean;
+    static falsyOrEqual(test: string | null, values: string | string[]): boolean;
     /**
      * Applies a decorator to a decorated model element.
      * @param {*} decorated the type to apply the decorator to


### PR DESCRIPTION
Updates the DecoratorManager API for backwards compatibility.

### Changes
- Changes the static DecoratorManager.falsyOrEquals method to accept either a single string value, or an array or strings

### Flags
<!--- Provide context or concerns a reviewer should be aware of -->
- <ONE>
- <TWO>

### Screenshots or Video
<!--- Provide an easily accessible demonstration of the changes, if applicable -->

### Related Issues
- Issue #<NUMBER>
- Pull Request #<NUMBER>

### Author Checklist
- [ ] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [ ] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ ] Merging to `main` from `fork:branchname`
