### PR TITLE
fix(vocabularymanager) analysis fails with scalar. issue 723

### DIFF
--- a/packages/concerto-vocabulary/lib/vocabulary.js
+++ b/packages/concerto-vocabulary/lib/vocabulary.js
@@ -144,12 +144,16 @@ class Vocabulary {
      * @returns {*} an object with missingTerms and additionalTerms properties
      */
     validate(modelFile) {
+        const getOwnProperties = (d) => {
+            // ensures we have a valid return, even for scalars
+            return d.getOwnProperties?.() ? d.getOwnProperties?.() : [];
+        };
         const result = {
             missingTerms: modelFile.getAllDeclarations().flatMap( d => this.getTerm(d.getName())
-                ? d.getOwnProperties().flatMap( p => this.getTerm(d.getName(), p.getName()) ? null : `${d.getName()}.${p.getName()}`)
+                ? getOwnProperties(d).flatMap( p => this.getTerm(d.getName(), p.getName()) ? null : `${d.getName()}.${p.getName()}`)
                 : d.getName() ).filter( i => i !== null),
             additionalTerms: this.content.declarations.flatMap( k => modelFile.getLocalType(Object.keys(k)[0])
-                ? k.properties ? k.properties.flatMap( p => modelFile.getLocalType(Object.keys(k)[0]).getOwnProperty(Object.keys(p)[0]) ? null : `${Object.keys(k)[0]}.${Object.keys(p)[0]}`) : null
+                ? Array.isArray(k.properties) ? k.properties.flatMap( p => modelFile.getLocalType(Object.keys(k)[0]).getOwnProperty(Object.keys(p)[0]) ? null : `${Object.keys(k)[0]}.${Object.keys(p)[0]}`) : null
                 : k ).filter( i => i !== null)
         };
 

--- a/packages/concerto-vocabulary/test/__snapshots__/vocabularymanager.js.snap
+++ b/packages/concerto-vocabulary/test/__snapshots__/vocabularymanager.js.snap
@@ -19,7 +19,7 @@ Object {
       "target": Object {
         "$class": "org.accordproject.decoratorcommands@0.3.0.CommandTarget",
         "declaration": "Color",
-        "namespace": "org.acme",
+        "namespace": "org.acme@1.0.0",
       },
       "type": "UPSERT",
     },
@@ -38,7 +38,7 @@ Object {
       "target": Object {
         "$class": "org.accordproject.decoratorcommands@0.3.0.CommandTarget",
         "declaration": "Color",
-        "namespace": "org.acme",
+        "namespace": "org.acme@1.0.0",
         "property": "RED",
       },
       "type": "UPSERT",
@@ -58,7 +58,7 @@ Object {
       "target": Object {
         "$class": "org.accordproject.decoratorcommands@0.3.0.CommandTarget",
         "declaration": "Color",
-        "namespace": "org.acme",
+        "namespace": "org.acme@1.0.0",
         "property": "BLUE",
       },
       "type": "UPSERT",
@@ -78,7 +78,7 @@ Object {
       "target": Object {
         "$class": "org.accordproject.decoratorcommands@0.3.0.CommandTarget",
         "declaration": "Color",
-        "namespace": "org.acme",
+        "namespace": "org.acme@1.0.0",
         "property": "GREEN",
       },
       "type": "UPSERT",
@@ -98,7 +98,26 @@ Object {
       "target": Object {
         "$class": "org.accordproject.decoratorcommands@0.3.0.CommandTarget",
         "declaration": "SSN",
-        "namespace": "org.acme",
+        "namespace": "org.acme@1.0.0",
+      },
+      "type": "UPSERT",
+    },
+    Object {
+      "$class": "org.accordproject.decoratorcommands@0.3.0.Command",
+      "decorator": Object {
+        "$class": "concerto.metamodel@1.0.0.Decorator",
+        "arguments": Array [
+          Object {
+            "$class": "concerto.metamodel@1.0.0.DecoratorString",
+            "value": "A vehicle identification number",
+          },
+        ],
+        "name": "Term",
+      },
+      "target": Object {
+        "$class": "org.accordproject.decoratorcommands@0.3.0.CommandTarget",
+        "declaration": "VIN",
+        "namespace": "org.acme@1.0.0",
       },
       "type": "UPSERT",
     },
@@ -117,7 +136,7 @@ Object {
       "target": Object {
         "$class": "org.accordproject.decoratorcommands@0.3.0.CommandTarget",
         "declaration": "Vehicle",
-        "namespace": "org.acme",
+        "namespace": "org.acme@1.0.0",
       },
       "type": "UPSERT",
     },
@@ -136,7 +155,7 @@ Object {
       "target": Object {
         "$class": "org.accordproject.decoratorcommands@0.3.0.CommandTarget",
         "declaration": "Vehicle",
-        "namespace": "org.acme",
+        "namespace": "org.acme@1.0.0",
         "property": "vin",
       },
       "type": "UPSERT",
@@ -156,7 +175,7 @@ Object {
       "target": Object {
         "$class": "org.accordproject.decoratorcommands@0.3.0.CommandTarget",
         "declaration": "Vehicle",
-        "namespace": "org.acme",
+        "namespace": "org.acme@1.0.0",
         "property": "vin",
       },
       "type": "UPSERT",
@@ -176,7 +195,7 @@ Object {
       "target": Object {
         "$class": "org.accordproject.decoratorcommands@0.3.0.CommandTarget",
         "declaration": "Vehicle",
-        "namespace": "org.acme",
+        "namespace": "org.acme@1.0.0",
         "property": "color",
       },
       "type": "UPSERT",
@@ -196,7 +215,7 @@ Object {
       "target": Object {
         "$class": "org.accordproject.decoratorcommands@0.3.0.CommandTarget",
         "declaration": "Vehicle",
-        "namespace": "org.acme",
+        "namespace": "org.acme@1.0.0",
         "property": "$identifier",
       },
       "type": "UPSERT",
@@ -216,7 +235,7 @@ Object {
       "target": Object {
         "$class": "org.accordproject.decoratorcommands@0.3.0.CommandTarget",
         "declaration": "Truck",
-        "namespace": "org.acme",
+        "namespace": "org.acme@1.0.0",
       },
       "type": "UPSERT",
     },
@@ -235,7 +254,7 @@ Object {
       "target": Object {
         "$class": "org.accordproject.decoratorcommands@0.3.0.CommandTarget",
         "declaration": "Truck",
-        "namespace": "org.acme",
+        "namespace": "org.acme@1.0.0",
       },
       "type": "UPSERT",
     },
@@ -254,7 +273,7 @@ Object {
       "target": Object {
         "$class": "org.accordproject.decoratorcommands@0.3.0.CommandTarget",
         "declaration": "Truck",
-        "namespace": "org.acme",
+        "namespace": "org.acme@1.0.0",
         "property": "weight",
       },
       "type": "UPSERT",
@@ -274,7 +293,7 @@ Object {
       "target": Object {
         "$class": "org.accordproject.decoratorcommands@0.3.0.CommandTarget",
         "declaration": "Truck",
-        "namespace": "org.acme",
+        "namespace": "org.acme@1.0.0",
         "property": "weight",
       },
       "type": "UPSERT",
@@ -294,7 +313,7 @@ Object {
       "target": Object {
         "$class": "org.accordproject.decoratorcommands@0.3.0.CommandTarget",
         "declaration": "Truck",
-        "namespace": "org.acme",
+        "namespace": "org.acme@1.0.0",
         "property": "weight",
       },
       "type": "UPSERT",
@@ -314,7 +333,7 @@ Object {
       "target": Object {
         "$class": "org.accordproject.decoratorcommands@0.3.0.CommandTarget",
         "declaration": "Truck",
-        "namespace": "org.acme",
+        "namespace": "org.acme@1.0.0",
         "property": "vin",
       },
       "type": "UPSERT",
@@ -334,7 +353,7 @@ Object {
       "target": Object {
         "$class": "org.accordproject.decoratorcommands@0.3.0.CommandTarget",
         "declaration": "Truck",
-        "namespace": "org.acme",
+        "namespace": "org.acme@1.0.0",
         "property": "vin",
       },
       "type": "UPSERT",
@@ -354,7 +373,7 @@ Object {
       "target": Object {
         "$class": "org.accordproject.decoratorcommands@0.3.0.CommandTarget",
         "declaration": "Truck",
-        "namespace": "org.acme",
+        "namespace": "org.acme@1.0.0",
         "property": "color",
       },
       "type": "UPSERT",
@@ -374,7 +393,7 @@ Object {
       "target": Object {
         "$class": "org.accordproject.decoratorcommands@0.3.0.CommandTarget",
         "declaration": "Truck",
-        "namespace": "org.acme",
+        "namespace": "org.acme@1.0.0",
         "property": "$identifier",
       },
       "type": "UPSERT",
@@ -394,7 +413,7 @@ Object {
       "target": Object {
         "$class": "org.accordproject.decoratorcommands@0.3.0.CommandTarget",
         "declaration": "Thing",
-        "namespace": "org.accordproject",
+        "namespace": "org.accordproject@1.0.0",
       },
       "type": "UPSERT",
     },
@@ -413,7 +432,7 @@ Object {
       "target": Object {
         "$class": "org.accordproject.decoratorcommands@0.3.0.CommandTarget",
         "declaration": "Thing",
-        "namespace": "org.accordproject",
+        "namespace": "org.accordproject@1.0.0",
         "property": "name",
       },
       "type": "UPSERT",

--- a/packages/concerto-vocabulary/test/com.example@1.0.0_en.voc
+++ b/packages/concerto-vocabulary/test/com.example@1.0.0_en.voc
@@ -1,5 +1,5 @@
 locale: en
-namespace: com.example
+namespace: com.example@1.0.0
 declarations:
   - Person: A person
     properties:

--- a/packages/concerto-vocabulary/test/org.accordproject@1.0.0.cto
+++ b/packages/concerto-vocabulary/test/org.accordproject@1.0.0.cto
@@ -1,4 +1,4 @@
-namespace org.accordproject
+namespace org.accordproject@1.0.0
 
 concept Thing {
     o String name

--- a/packages/concerto-vocabulary/test/org.acme@1.0.0.cto
+++ b/packages/concerto-vocabulary/test/org.acme@1.0.0.cto
@@ -1,4 +1,4 @@
-namespace org.acme
+namespace org.acme@1.0.0
 
 enum Color {
     o RED
@@ -7,9 +7,10 @@ enum Color {
 }
 
 scalar SSN extends String default="000-00-0000"
+scalar VIN extends String
 
 asset Vehicle identified by vin {
-    o String vin
+    o VIN vin
     o Color color
 }
 

--- a/packages/concerto-vocabulary/test/org.acme@1.0.0_en-gb.voc
+++ b/packages/concerto-vocabulary/test/org.acme@1.0.0_en-gb.voc
@@ -1,5 +1,5 @@
 locale: en-gb
-namespace: org.acme
+namespace: org.acme@1.0.0
 declarations:
   - Truck: A lorry
     description: A heavy goods vehicle

--- a/packages/concerto-vocabulary/test/org.acme@1.0.0_en.voc
+++ b/packages/concerto-vocabulary/test/org.acme@1.0.0_en.voc
@@ -1,6 +1,7 @@
 locale: en
-namespace: org.acme
+namespace: org.acme@1.0.0
 declarations:
+  - VIN: A vehicle identification number
   - Color: A color
   - Vehicle: A road vehicle
     properties:

--- a/packages/concerto-vocabulary/test/org.acme@1.0.0_fr.voc
+++ b/packages/concerto-vocabulary/test/org.acme@1.0.0_fr.voc
@@ -1,5 +1,5 @@
 locale: fr
-namespace: org.acme
+namespace: org.acme@1.0.0
 declarations:
   - Vehicle: Véhicule
     properties:

--- a/packages/concerto-vocabulary/test/org.acme@1.0.0_zh-cn.voc
+++ b/packages/concerto-vocabulary/test/org.acme@1.0.0_zh-cn.voc
@@ -1,5 +1,5 @@
 locale: zh-cn
-namespace: org.acme
+namespace: org.acme@1.0.0
 declarations:
   - Color: 颜色
     properties:

--- a/packages/concerto-vocabulary/test/vocabularymanager.js
+++ b/packages/concerto-vocabulary/test/vocabularymanager.js
@@ -35,21 +35,21 @@ let vocabularyManager = null;
 describe('VocabularyManager', () => {
     beforeEach(() => {
         modelManager = new ModelManager();
-        const model = fs.readFileSync('./test/org.acme.cto', 'utf-8');
+        const model = fs.readFileSync('./test/org.acme@1.0.0.cto', 'utf-8');
         modelManager.addCTOModel(model);
-        const model2 = fs.readFileSync('./test/org.accordproject.cto', 'utf-8');
+        const model2 = fs.readFileSync('./test/org.accordproject@1.0.0.cto', 'utf-8');
         modelManager.addCTOModel(model2);
         vocabularyManager = new VocabularyManager();
         vocabularyManager.should.not.be.null;
-        const enVocString = fs.readFileSync('./test/org.acme_en.voc', 'utf-8');
+        const enVocString = fs.readFileSync('./test/org.acme@1.0.0_en.voc', 'utf-8');
         vocabularyManager.addVocabulary(enVocString);
-        const enGbVocString = fs.readFileSync('./test/org.acme_en-gb.voc', 'utf-8');
+        const enGbVocString = fs.readFileSync('./test/org.acme@1.0.0_en-gb.voc', 'utf-8');
         vocabularyManager.addVocabulary(enGbVocString);
-        const frVocString = fs.readFileSync('./test/org.acme_fr.voc', 'utf-8');
+        const frVocString = fs.readFileSync('./test/org.acme@1.0.0_fr.voc', 'utf-8');
         vocabularyManager.addVocabulary(frVocString);
-        const zhVocString = fs.readFileSync('./test/org.acme_zh-cn.voc', 'utf-8');
+        const zhVocString = fs.readFileSync('./test/org.acme@1.0.0_zh-cn.voc', 'utf-8');
         vocabularyManager.addVocabulary(zhVocString);
-        const enVoc2String = fs.readFileSync('./test/com.example_en.voc', 'utf-8');
+        const enVoc2String = fs.readFileSync('./test/com.example@1.0.0_en.voc', 'utf-8');
         vocabularyManager.addVocabulary(enVoc2String);
     });
 
@@ -70,12 +70,12 @@ describe('VocabularyManager', () => {
     });
 
     it('addVocabulary (duplicate)', () => {
-        const enVocString = fs.readFileSync('./test/org.acme_en.voc', 'utf-8');
+        const enVocString = fs.readFileSync('./test/org.acme@1.0.0_en.voc', 'utf-8');
         should.Throw(() => vocabularyManager.addVocabulary(enVocString), Error);
     });
 
     it('getVocabulary', () => {
-        const voc = vocabularyManager.getVocabulary('org.acme', 'en');
+        const voc = vocabularyManager.getVocabulary('org.acme@1.0.0', 'en');
         voc.should.not.be.null;
     });
 
@@ -85,32 +85,32 @@ describe('VocabularyManager', () => {
     });
 
     it('getVocabulary - missing locale', () => {
-        const voc = vocabularyManager.getVocabulary('org.acme', 'foo');
+        const voc = vocabularyManager.getVocabulary('org.acme@1.0.0', 'foo');
         (voc === null).should.be.true;
     });
 
     it('getVocabulary - lookup', () => {
-        const voc = vocabularyManager.getVocabulary('org.acme', 'en-us', { localeMatcher: 'lookup' });
+        const voc = vocabularyManager.getVocabulary('org.acme@1.0.0', 'en-us', { localeMatcher: 'lookup' });
         voc.should.not.be.null;
     });
 
     it('getVocabulary - lookup fail case insensitive', () => {
-        const voc = vocabularyManager.getVocabulary('org.acme', 'en-US');
+        const voc = vocabularyManager.getVocabulary('org.acme@1.0.0', 'en-US');
         (voc === null).should.be.true;
     });
 
     it('getVocabulary - case insensitive', () => {
-        const voc = vocabularyManager.getVocabulary('org.acme', 'en-GB');
+        const voc = vocabularyManager.getVocabulary('org.acme@1.0.0', 'en-GB');
         voc.should.not.be.null;
     });
 
     it('getVocabulary - lookup fail', () => {
-        const voc = vocabularyManager.getVocabulary('org.acme', 'zh', { localeMatcher: 'lookup' });
+        const voc = vocabularyManager.getVocabulary('org.acme@1.0.0', 'zh', { localeMatcher: 'lookup' });
         (voc === null).should.be.true;
     });
 
     it('getVocabulariesForNamespace', () => {
-        const voc = vocabularyManager.getVocabulariesForNamespace('org.acme');
+        const voc = vocabularyManager.getVocabulariesForNamespace('org.acme@1.0.0');
         voc.length.should.equal(4); // en, en-gb, fr, zh-cn
     });
 
@@ -124,56 +124,56 @@ describe('VocabularyManager', () => {
     });
 
     it('getTerms - en', () => {
-        const voc = vocabularyManager.getVocabulary('org.acme', 'en');
+        const voc = vocabularyManager.getVocabulary('org.acme@1.0.0', 'en');
         voc.should.not.be.null;
         const terms = voc.getTerms();
-        terms.length.should.equal(3);
+        terms.length.should.equal(4);
     });
 
     it('getTerms - fr', () => {
-        const voc = vocabularyManager.getVocabulary('org.acme', 'fr');
+        const voc = vocabularyManager.getVocabulary('org.acme@1.0.0', 'fr');
         voc.should.not.be.null;
         const terms = voc.getTerms();
         terms.length.should.equal(1);
     });
 
     it('getTerms - lookup declaration', () => {
-        const terms = vocabularyManager.getTerms('org.acme', 'en', 'Truck');
+        const terms = vocabularyManager.getTerms('org.acme@1.0.0', 'en', 'Truck');
         terms.Truck.should.equal('A truck');
         terms.description.should.equal('A vehicle capable of carrying cargo');
         terms.tooltip.should.equal('Truck');
     });
 
     it('getTerms - lookup property', () => {
-        const terms = vocabularyManager.getTerms('org.acme', 'en', 'Truck', 'weight');
+        const terms = vocabularyManager.getTerms('org.acme@1.0.0', 'en', 'Truck', 'weight');
         terms.weight.should.equal('The weight of the truck');
         terms.description.should.equal('The weight of the truck in KG');
         terms.tooltip.should.equal('Truck weight');
     });
 
     it('getTerms - lookup unicode', () => {
-        const terms = vocabularyManager.getTerms('org.acme', 'zh-cn', 'Color');
+        const terms = vocabularyManager.getTerms('org.acme@1.0.0', 'zh-cn', 'Color');
         terms.Color.should.equal('颜色');
     });
 
     it('getTerms - lookup unicode property', () => {
-        let terms = vocabularyManager.getTerms('org.acme', 'zh-cn', 'Color', 'RED');
+        let terms = vocabularyManager.getTerms('org.acme@1.0.0', 'zh-cn', 'Color', 'RED');
         terms.RED.should.equal('红色');
 
-        terms = vocabularyManager.getTerms('org.acme', 'zh-cn', 'Color', 'GREEN');
+        terms = vocabularyManager.getTerms('org.acme@1.0.0', 'zh-cn', 'Color', 'GREEN');
         terms.GREEN.should.equal('绿色');
 
-        terms = vocabularyManager.getTerms('org.acme', 'zh-cn', 'Color', 'BLUE');
+        terms = vocabularyManager.getTerms('org.acme@1.0.0', 'zh-cn', 'Color', 'BLUE');
         terms.BLUE.should.equal('蓝色');
     });
 
     it('getTerms - lookup missing property', () => {
-        const terms = vocabularyManager.getTerms('org.acme', 'en-gb', 'Vehicle', 'foo');
+        const terms = vocabularyManager.getTerms('org.acme@1.0.0', 'en-gb', 'Vehicle', 'foo');
         (terms === null).should.be.true;
     });
 
     it('getTerms - lookup missing locale', () => {
-        const terms = vocabularyManager.getTerms('org.acme', 'zh', 'Vehicle', 'vin');
+        const terms = vocabularyManager.getTerms('org.acme@1.0.0', 'zh', 'Vehicle', 'vin');
         (terms === null).should.be.true;
     });
 
@@ -181,12 +181,12 @@ describe('VocabularyManager', () => {
         vocabularyManager = new VocabularyManager({
             missingTermGenerator: VocabularyManager.englishMissingTermGenerator
         });
-        let terms = vocabularyManager.getTerms('org.acme', 'en', 'Truck', 'grossWeight');
+        let terms = vocabularyManager.getTerms('org.acme@1.0.0', 'en', 'Truck', 'grossWeight');
         terms.grossWeight.should.equal('Gross Weight of the Truck');
     });
 
     it('getTerm - en', () => {
-        const voc = vocabularyManager.getVocabulary('org.acme', 'en');
+        const voc = vocabularyManager.getVocabulary('org.acme@1.0.0', 'en');
         voc.should.not.be.null;
         const term = voc.getTerm('Vehicle');
         term.should.equal('A road vehicle');
@@ -195,7 +195,7 @@ describe('VocabularyManager', () => {
     });
 
     it('getTerm - fr', () => {
-        const voc = vocabularyManager.getVocabulary('org.acme', 'fr');
+        const voc = vocabularyManager.getVocabulary('org.acme@1.0.0', 'fr');
         voc.should.not.be.null;
         const term = voc.getTerm('Vehicle');
         term.should.equal('Véhicule');
@@ -204,58 +204,58 @@ describe('VocabularyManager', () => {
     });
 
     it('findVocabulary', () => {
-        const voc = VocabularyManager.findVocabulary('en-gb', vocabularyManager.getVocabulariesForNamespace('org.acme'));
+        const voc = VocabularyManager.findVocabulary('en-gb', vocabularyManager.getVocabulariesForNamespace('org.acme@1.0.0'));
         voc.should.not.be.null;
     });
 
     it('getTerm - lookup declaration', () => {
-        const term = vocabularyManager.getTerm('org.acme', 'en-gb', 'Truck');
+        const term = vocabularyManager.getTerm('org.acme@1.0.0', 'en-gb', 'Truck');
         term.should.equal('A lorry');
     });
 
     it('getTerm - lookup declaration with identifier', () => {
-        const term = vocabularyManager.getTerm('org.acme', 'en', 'Truck', null, 'description');
+        const term = vocabularyManager.getTerm('org.acme@1.0.0', 'en', 'Truck', null, 'description');
         term.should.equal('A vehicle capable of carrying cargo');
     });
 
     it('getTerm - lookup declaration', () => {
-        const term = vocabularyManager.getTerm('org.acme', 'en-gb', 'Color');
+        const term = vocabularyManager.getTerm('org.acme@1.0.0', 'en-gb', 'Color');
         term.should.equal('A colour');
     });
 
     it('getTerm - lookup property', () => {
-        const term = vocabularyManager.getTerm('org.acme', 'en-gb', 'Vehicle', 'vin');
+        const term = vocabularyManager.getTerm('org.acme@1.0.0', 'en-gb', 'Vehicle', 'vin');
         term.should.equal('Vehicle Identification Number');
     });
 
     it('getTerm - lookup property with identifier', () => {
-        const term = vocabularyManager.getTerm('org.acme', 'en-gb', 'Vehicle', 'vin', 'tooltip');
+        const term = vocabularyManager.getTerm('org.acme@1.0.0', 'en-gb', 'Vehicle', 'vin', 'tooltip');
         term.should.equal('VIN');
     });
 
     it('getTerm - lookup unicode', () => {
-        const term = vocabularyManager.getTerm('org.acme', 'zh-cn', 'Color');
+        const term = vocabularyManager.getTerm('org.acme@1.0.0', 'zh-cn', 'Color');
         term.should.equal('颜色');
     });
 
     it('getTerm - lookup unicode property', () => {
-        let term = vocabularyManager.getTerm('org.acme', 'zh-cn', 'Color', 'RED');
+        let term = vocabularyManager.getTerm('org.acme@1.0.0', 'zh-cn', 'Color', 'RED');
         term.should.equal('红色');
 
-        term = vocabularyManager.getTerm('org.acme', 'zh-cn', 'Color', 'GREEN');
+        term = vocabularyManager.getTerm('org.acme@1.0.0', 'zh-cn', 'Color', 'GREEN');
         term.should.equal('绿色');
 
-        term = vocabularyManager.getTerm('org.acme', 'zh-cn', 'Color', 'BLUE');
+        term = vocabularyManager.getTerm('org.acme@1.0.0', 'zh-cn', 'Color', 'BLUE');
         term.should.equal('蓝色');
     });
 
     it('getTerm - lookup missing property', () => {
-        const term = vocabularyManager.getTerm('org.acme', 'en-gb', 'Vehicle', 'foo');
+        const term = vocabularyManager.getTerm('org.acme@1.0.0', 'en-gb', 'Vehicle', 'foo');
         (term === null).should.be.true;
     });
 
     it('getTerm - lookup missing locale', () => {
-        const term = vocabularyManager.getTerm('org.acme', 'zh', 'Vehicle', 'vin');
+        const term = vocabularyManager.getTerm('org.acme@1.0.0', 'zh', 'Vehicle', 'vin');
         (term === null).should.be.true;
     });
 
@@ -263,42 +263,42 @@ describe('VocabularyManager', () => {
         vocabularyManager = new VocabularyManager({
             missingTermGenerator: VocabularyManager.englishMissingTermGenerator
         });
-        let term = vocabularyManager.getTerm('org.acme', 'en', 'Truck', 'grossWeight');
+        let term = vocabularyManager.getTerm('org.acme@1.0.0', 'en', 'Truck', 'grossWeight');
         term.should.equal('Gross Weight of the Truck');
     });
 
     it('resolveTerms - class', () => {
-        const terms = vocabularyManager.resolveTerms(modelManager, 'org.acme', 'en-gb', 'Truck');
+        const terms = vocabularyManager.resolveTerms(modelManager, 'org.acme@1.0.0', 'en-gb', 'Truck');
         terms.Truck.should.equal('A lorry');
     });
 
     it('resolveTerms - class with identifier', () => {
-        const terms = vocabularyManager.resolveTerms(modelManager, 'org.acme', 'en-gb', 'Truck');
+        const terms = vocabularyManager.resolveTerms(modelManager, 'org.acme@1.0.0', 'en-gb', 'Truck');
         terms.description.should.equal('A heavy goods vehicle');
     });
 
     it('resolveTerms - property', () => {
-        const terms = vocabularyManager.resolveTerms(modelManager, 'org.acme', 'en-gb', 'Truck', 'weight');
+        const terms = vocabularyManager.resolveTerms(modelManager, 'org.acme@1.0.0', 'en-gb', 'Truck', 'weight');
         terms.weight.should.equal('The weight of the truck');
     });
 
     it('resolveTerms - property with identifier', () => {
-        const terms = vocabularyManager.resolveTerms(modelManager, 'org.acme', 'en-gb', 'Truck', 'weight', 'description');
+        const terms = vocabularyManager.resolveTerms(modelManager, 'org.acme@1.0.0', 'en-gb', 'Truck', 'weight', 'description');
         terms.description.should.equal('The weight of the truck in KG');
     });
 
     it('resolveTerms - property on super type', () => {
-        const terms = vocabularyManager.resolveTerms(modelManager, 'org.acme', 'en-gb', 'Truck', 'vin');
+        const terms = vocabularyManager.resolveTerms(modelManager, 'org.acme@1.0.0', 'en-gb', 'Truck', 'vin');
         terms.vin.should.equal('Vehicle Identification Number');
     });
 
     it('resolveTerms - missing property', () => {
-        const terms = vocabularyManager.resolveTerms(modelManager, 'org.acme', 'en-gb', 'Truck', 'foo');
+        const terms = vocabularyManager.resolveTerms(modelManager, 'org.acme@1.0.0', 'en-gb', 'Truck', 'foo');
         (terms === null).should.be.true;
     });
 
     it('resolveTerms - missing class', () => {
-        const terms = vocabularyManager.resolveTerms(modelManager, 'org.acme', 'en-gb', 'Dog');
+        const terms = vocabularyManager.resolveTerms(modelManager, 'org.acme@1.0.0', 'en-gb', 'Dog');
         (terms === null).should.be.true;
     });
 
@@ -308,37 +308,37 @@ describe('VocabularyManager', () => {
     });
 
     it('resolveTerm - class', () => {
-        const term = vocabularyManager.resolveTerm(modelManager, 'org.acme', 'en-gb', 'Truck');
+        const term = vocabularyManager.resolveTerm(modelManager, 'org.acme@1.0.0', 'en-gb', 'Truck');
         term.should.equal('A lorry');
     });
 
     it('resolveTerm - class with identifier', () => {
-        const term = vocabularyManager.resolveTerm(modelManager, 'org.acme', 'en-gb', 'Truck', null, 'description');
+        const term = vocabularyManager.resolveTerm(modelManager, 'org.acme@1.0.0', 'en-gb', 'Truck', null, 'description');
         term.should.equal('A heavy goods vehicle');
     });
 
     it('resolveTerm - property', () => {
-        const term = vocabularyManager.resolveTerm(modelManager, 'org.acme', 'en-gb', 'Truck', 'weight');
+        const term = vocabularyManager.resolveTerm(modelManager, 'org.acme@1.0.0', 'en-gb', 'Truck', 'weight');
         term.should.equal('The weight of the truck');
     });
 
     it('resolveTerm - property with identifier', () => {
-        const term = vocabularyManager.resolveTerm(modelManager, 'org.acme', 'en-gb', 'Truck', 'weight', 'description');
+        const term = vocabularyManager.resolveTerm(modelManager, 'org.acme@1.0.0', 'en-gb', 'Truck', 'weight', 'description');
         term.should.equal('The weight of the truck in KG');
     });
 
     it('resolveTerm - property on super type', () => {
-        const term = vocabularyManager.resolveTerm(modelManager, 'org.acme', 'en-gb', 'Truck', 'vin');
+        const term = vocabularyManager.resolveTerm(modelManager, 'org.acme@1.0.0', 'en-gb', 'Truck', 'vin');
         term.should.equal('Vehicle Identification Number');
     });
 
     it('resolveTerm - missing property', () => {
-        const term = vocabularyManager.resolveTerm(modelManager, 'org.acme', 'en-gb', 'Truck', 'foo');
+        const term = vocabularyManager.resolveTerm(modelManager, 'org.acme@1.0.0', 'en-gb', 'Truck', 'foo');
         (term === null).should.be.true;
     });
 
     it('resolveTerm - missing class', () => {
-        const term = vocabularyManager.resolveTerm(modelManager, 'org.acme', 'en-gb', 'Dog');
+        const term = vocabularyManager.resolveTerm(modelManager, 'org.acme@1.0.0', 'en-gb', 'Dog');
         (term === null).should.be.true;
     });
 
@@ -349,44 +349,44 @@ describe('VocabularyManager', () => {
 
     it('clear', () => {
         vocabularyManager.clear();
-        const voc = vocabularyManager.getVocabulary('org.acme', 'en');
+        const voc = vocabularyManager.getVocabulary('org.acme@1.0.0', 'en');
         (voc === null).should.be.true;
     });
 
     it('removeVocabulary', () => {
-        vocabularyManager.removeVocabulary('org.acme', 'en');
-        const voc = vocabularyManager.getVocabulary('org.acme', 'en');
+        vocabularyManager.removeVocabulary('org.acme@1.0.0', 'en');
+        const voc = vocabularyManager.getVocabulary('org.acme@1.0.0', 'en');
         (voc === null).should.be.true;
     });
 
     it('validate', () => {
         const result = vocabularyManager.validate(modelManager);
         result.missingVocabularies.length.should.equal(1);
-        result.missingVocabularies[0].should.equal('org.accordproject');
+        result.missingVocabularies[0].should.equal('org.accordproject@1.0.0');
         result.additionalVocabularies.length.should.equal(1);
-        result.additionalVocabularies[0].getNamespace().should.equal('com.example');
-        result.vocabularies['org.acme/en'].additionalTerms.should.have.members(['Vehicle.model', 'Truck.horsePower']);
-        result.vocabularies['org.acme/en'].missingTerms.should.have.members(['Color.RED', 'Color.BLUE', 'Color.GREEN', 'SSN', 'Vehicle.color']);
-        result.vocabularies['org.acme/en-gb'].additionalTerms.should.have.members(['Milkfloat']);
-        result.vocabularies['org.acme/fr'].missingTerms.should.have.members(['Color', 'SSN', 'Vehicle.color', 'Truck']);
-        result.vocabularies['org.acme/fr'].additionalTerms.should.have.members([]);
-        result.vocabularies['org.acme/zh-cn'].missingTerms.should.have.members(['SSN', 'Truck']);
-        result.vocabularies['org.acme/zh-cn'].additionalTerms.should.have.members([]);
+        result.additionalVocabularies[0].getNamespace().should.equal('com.example@1.0.0');
+        result.vocabularies['org.acme@1.0.0/en'].additionalTerms.should.have.members(['Vehicle.model', 'Truck.horsePower']);
+        result.vocabularies['org.acme@1.0.0/en'].missingTerms.should.have.members(['Color.RED', 'Color.BLUE', 'Color.GREEN', 'SSN', 'Vehicle.color']);
+        result.vocabularies['org.acme@1.0.0/en-gb'].additionalTerms.should.have.members(['Milkfloat']);
+        result.vocabularies['org.acme@1.0.0/fr'].missingTerms.should.have.members(['Color', 'SSN', 'VIN', 'Vehicle.color', 'Truck']);
+        result.vocabularies['org.acme@1.0.0/fr'].additionalTerms.should.have.members([]);
+        result.vocabularies['org.acme@1.0.0/zh-cn'].missingTerms.should.have.members(['SSN', 'VIN', 'Truck']);
+        result.vocabularies['org.acme@1.0.0/zh-cn'].additionalTerms.should.have.members([]);
     });
 
     it('decorateModels', () => {
         vocabularyManager = new VocabularyManager({
             missingTermGenerator: VocabularyManager.englishMissingTermGenerator
         });
-        const enVocString = fs.readFileSync('./test/org.acme_en.voc', 'utf-8');
+        const enVocString = fs.readFileSync('./test/org.acme@1.0.0_en.voc', 'utf-8');
         vocabularyManager.addVocabulary(enVocString);
-        const enGbVocString = fs.readFileSync('./test/org.acme_en-gb.voc', 'utf-8');
+        const enGbVocString = fs.readFileSync('./test/org.acme@1.0.0_en-gb.voc', 'utf-8');
         vocabularyManager.addVocabulary(enGbVocString);
         const commandSet = vocabularyManager.generateDecoratorCommands(modelManager, 'en-GB');
         expect(commandSet).toMatchSnapshot();
         const newModelManager = DecoratorManager.decorateModels( modelManager, commandSet,
             {validate: true, validateCommands: true});
-        const mf = newModelManager.getModelFile('org.acme');
+        const mf = newModelManager.getModelFile('org.acme@1.0.0');
         const vehicleDecl = mf.getAssetDeclaration('Vehicle');
         const decorator = vehicleDecl.getDecorator('Term');
         decorator.getArguments()[0].should.equal('A road vehicle');


### PR DESCRIPTION
# Closes #723 

Ensures that VocabularyManager.validate works with models containing scalars. 

### Changes
- Defensive tests that declaration.getOwnProperties always returns at least `[]`
-  Update tests to use versioned namespaces
- Update tests and snapshots

### Flags
<!--- Provide context or concerns a reviewer should be aware of -->
- <ONE>
- <TWO>

### Screenshots or Video
<!--- Provide an easily accessible demonstration of the changes, if applicable -->

### Related Issues
- Issue #<NUMBER>
- Pull Request #<NUMBER>

### Author Checklist
- [ ] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [ ] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ ] Merging to `main` from `fork:branchname`
