### PR TITLE
feat(map): allows ENABLE_MAP_TYPE env var to be set via ModelManager constructor

### DIFF
--- a/packages/concerto-core/lib/basemodelmanager.js
+++ b/packages/concerto-core/lib/basemodelmanager.js
@@ -93,6 +93,16 @@ class BaseModelManager {
         this.options = options;
         this.addRootModel();
 
+        // TODO remove on full release of Map Type.
+        // Temporarily allow for ENABLE_MAP_TYPE environment variable to be set from options.
+        if (options?.flags) {
+            for (const [key, value] of Object.entries(options.flags)) {
+                if(key === 'ENABLE_MAP_TYPE') {
+                    process.env[key] = value;
+                }
+            }
+        }
+
         // Cache a copy of the Metamodel ModelFile for use when validating the structure of ModelFiles later.
         this.metamodelModelFile = new ModelFile(this, MetaModelUtil.metaModelAst, undefined, MetaModelNamespace);
 

--- a/packages/concerto-core/test/introspect/mapdeclaration.js
+++ b/packages/concerto-core/test/introspect/mapdeclaration.js
@@ -37,11 +37,11 @@ describe('MapDeclaration', () => {
     let introspectUtils;
 
     beforeEach(() => {
-        modelManager = new ModelManager();
+        const options = { flags : {'ENABLE_MAP_TYPE': 'true'} };
+        modelManager = new ModelManager(options);
         Util.addComposerModel(modelManager);
         introspectUtils = new IntrospectUtils(modelManager);
         modelFile = ParserUtil.newModelFile(modelManager, 'namespace com.test', 'mapdeclaration.cto');
-        process.env.ENABLE_MAP_TYPE = 'true'; // TODO Remove on release of MapType.
     });
 
     describe('#constructor', () => {
@@ -125,7 +125,7 @@ describe('MapDeclaration', () => {
     });
 
     describe('#validate success scenarios - Map Key', () => {
-        it('should validate when map key is primitive type datetime', () => {
+        it.only('should validate when map key is primitive type datetime', () => {
             let decl = introspectUtils.loadLastDeclaration('test/data/parser/mapdeclaration/mapdeclaration.goodkey.primitive.datetime.cto', MapDeclaration);
             decl.validate();
         });

--- a/packages/concerto-core/test/introspect/mapdeclaration.js
+++ b/packages/concerto-core/test/introspect/mapdeclaration.js
@@ -125,7 +125,7 @@ describe('MapDeclaration', () => {
     });
 
     describe('#validate success scenarios - Map Key', () => {
-        it.only('should validate when map key is primitive type datetime', () => {
+        it('should validate when map key is primitive type datetime', () => {
             let decl = introspectUtils.loadLastDeclaration('test/data/parser/mapdeclaration/mapdeclaration.goodkey.primitive.datetime.cto', MapDeclaration);
             decl.validate();
         });


### PR DESCRIPTION
### Description

This change allows clients to set the `ENABLE_MAP_TYPE` environment variable via the `ModelManagers` options.  Clients can add any environment variable they wish to the options, but only `ENABLE_MAP_TYPE` will ever be set, if it is configured. This eliminates the possibility that Concerto is used as an attack vector under certain scenarios.

**This change is temporary and will be removed on full release of Map Type.**

### Usage

```
const options = { flags : {'ENABLE_MAP_TYPE': 'true'} }; // add the env var to options
modelManager = new ModelManager(options);
```