### PR TITLE
feat(map): add property based flag

### DIFF
--- a/packages/concerto-core/lib/basemodelmanager.js
+++ b/packages/concerto-core/lib/basemodelmanager.js
@@ -93,6 +93,10 @@ class BaseModelManager {
         this.options = options;
         this.addRootModel();
 
+        // TODO Remove on release of MapType
+        // Supports both env var and property based flag
+        this.enableMapType = !!options?.enableMapType;
+
         // Cache a copy of the Metamodel ModelFile for use when validating the structure of ModelFiles later.
         this.metamodelModelFile = new ModelFile(this, MetaModelUtil.metaModelAst, undefined, MetaModelNamespace);
 

--- a/packages/concerto-core/lib/introspect/mapdeclaration.js
+++ b/packages/concerto-core/lib/introspect/mapdeclaration.js
@@ -45,8 +45,9 @@ class MapDeclaration extends Declaration {
      */
     constructor(modelFile, ast) {
         // TODO remove on full release.
-        if(process.env.ENABLE_MAP_TYPE !== 'true') {
-            throw new Error('MapType feature is not enabled. Please set the environment variable "ENABLE_MAP_TYPE=true" to access this functionality.');
+        const mm = modelFile.getModelManager();
+        if(process.env.ENABLE_MAP_TYPE !== 'true' && !mm.enableMapType) {
+            throw new Error('MapType feature is not enabled. Please set the environment variable "ENABLE_MAP_TYPE=true", or add {enableMapType: true} to the ModelManger options, to access this functionality.');
         }
 
         super(modelFile, ast);

--- a/packages/concerto-core/test/introspect/mapdeclaration.js
+++ b/packages/concerto-core/test/introspect/mapdeclaration.js
@@ -100,7 +100,7 @@ describe('MapDeclaration', () => {
             }
         });
 
-        it('should not throw if Map Type not enabled in ModelManager options', () => {
+        it('should not throw if Map Type is enabled in ModelManager options', () => {
             const mm = new ModelManager({enableMapType: true});
             Util.addComposerModel(mm);
             const introspectUtils = new IntrospectUtils(mm);

--- a/packages/concerto-core/test/introspect/mapdeclaration.js
+++ b/packages/concerto-core/test/introspect/mapdeclaration.js
@@ -84,11 +84,29 @@ describe('MapDeclaration', () => {
                         $class: 'concerto.metamodel@1.0.0.StringMapValueType'
                     }
                 });
-            }).should.throw(/MapType feature is not enabled. Please set the environment variable "ENABLE_MAP_TYPE=true" to access this functionality./);
+            }).should.throw(/MapType feature is not enabled. Please set the environment variable "ENABLE_MAP_TYPE=true", or add {enableMapType: true} to the ModelManger options, to access this functionality/);
             process.env.ENABLE_MAP_TYPE = 'true'; // enable after the test run. This is necessary to ensure functioning of other tests.
         });
 
+        it('should throw if Map Type not enabled in ModelManager options', () => {
+            process.env.ENABLE_MAP_TYPE = 'false';
+            const mm = new ModelManager({enableMapType: false});
+            Util.addComposerModel(mm);
+            const introspectUtils = new IntrospectUtils(mm);
+            try {
+                introspectUtils.loadLastDeclaration('test/data/parser/mapdeclaration/mapdeclaration.goodkey.primitive.datetime.cto', MapDeclaration);
+            } catch (error) {
+                expect(error.message).to.equal('MapType feature is not enabled. Please set the environment variable "ENABLE_MAP_TYPE=true", or add {enableMapType: true} to the ModelManger options, to access this functionality.');
+            }
+        });
 
+        it('should not throw if Map Type not enabled in ModelManager options', () => {
+            const mm = new ModelManager({enableMapType: true});
+            Util.addComposerModel(mm);
+            const introspectUtils = new IntrospectUtils(mm);
+            let decl = introspectUtils.loadLastDeclaration('test/data/parser/mapdeclaration/mapdeclaration.goodkey.primitive.datetime.cto', MapDeclaration);
+            decl.validate();
+        });
 
         it('should throw if invalid $class provided for Map Key', () => {
             (() =>


### PR DESCRIPTION
### Description

Add property based flag to `ModelManager` options as an alternative to setting process.env `ENABLE_MAP_TYPE='true`. 

**This change is temporary and will be removed on full release of Map Type.**

### Usage
`modelManager = new ModelManager({enableMapType: true});
`