### PR TITLE
fix(core):  missing array modifier for scalar fields

### DIFF
--- a/packages/concerto-core/lib/introspect/field.js
+++ b/packages/concerto-core/lib/introspect/field.js
@@ -199,6 +199,7 @@ class Field extends Property {
 
         fieldAst.name = this.ast.name;
         this.scalarField = new Field(this.getParent(), fieldAst);
+        this.scalarField.array = this.isArray();
         return this.scalarField;
     }
 }

--- a/packages/concerto-core/test/data/parser/classdeclaration.scalararray.cto
+++ b/packages/concerto-core/test/data/parser/classdeclaration.scalararray.cto
@@ -1,0 +1,21 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace com.testing
+
+scalar SSN extends String default="000-00-0000" regex=/\d{3}-\d{2}-\{4}+/
+
+concept Persons {
+    o SSN[] ssnArray
+}

--- a/packages/concerto-core/test/introspect/classdeclaration.js
+++ b/packages/concerto-core/test/introspect/classdeclaration.js
@@ -136,6 +136,11 @@ describe('ClassDeclaration', () => {
             const clazz = introspectUtils.loadLastDeclaration('test/data/parser/classdeclaration.scalaridentifier.cto', ConceptDeclaration);
             clazz.validate();
         });
+
+        it('should not throw when a scalar array is used as an identifier', () => {
+            const clazz = introspectUtils.loadLastDeclaration('test/data/parser/classdeclaration.scalararray.cto', ConceptDeclaration);
+            clazz.validate();
+        });
     });
 
     describe('#accept', () => {

--- a/packages/concerto-core/test/introspect/scalars.js
+++ b/packages/concerto-core/test/introspect/scalars.js
@@ -171,5 +171,21 @@ describe('Scalars', () => {
             p.getScalarField().getType().should.equal('DateTime');
         });
 
+        it("should handle arrays correctly", () => {
+            const p = new Field(mockClassDeclaration, {
+                $class: `${MetaModelNamespace}.StringProperty`,
+                name: "property",
+                array: true
+            });
+            p.getScalarField().isArray().should.equal(true);
+        });
+
+        it("should handle non-arrays correctly", () => {
+            const p = new Field(mockClassDeclaration, {
+                $class: `${MetaModelNamespace}.StringProperty`,
+                name: "property",
+            });
+            p.getScalarField().isArray().should.equal(false);
+        });
     });
 });

--- a/packages/concerto-core/test/introspect/scalars.js
+++ b/packages/concerto-core/test/introspect/scalars.js
@@ -174,7 +174,7 @@ describe('Scalars', () => {
         it('should handle arrays correctly', () => {
             const p = new Field(mockClassDeclaration, {
                 $class: `${MetaModelNamespace}.StringProperty`,
-                name: "property",
+                name: 'property',
                 array: true
             });
             p.getScalarField().isArray().should.equal(true);
@@ -183,7 +183,7 @@ describe('Scalars', () => {
         it('should handle non-arrays correctly', () => {
             const p = new Field(mockClassDeclaration, {
                 $class: `${MetaModelNamespace}.StringProperty`,
-                name: "property",
+                name: 'property',
             });
             p.getScalarField().isArray().should.equal(false);
         });

--- a/packages/concerto-core/test/introspect/scalars.js
+++ b/packages/concerto-core/test/introspect/scalars.js
@@ -172,18 +172,32 @@ describe('Scalars', () => {
         });
 
         it('should handle arrays correctly', () => {
+            mockScalarDeclaration.ast = {
+                $class: `${MetaModelNamespace}.StringScalar`,
+                name: 'MyScalar',
+            };
             const p = new Field(mockClassDeclaration, {
-                $class: `${MetaModelNamespace}.StringProperty`,
+                $class: `${MetaModelNamespace}.ObjectProperty`,
                 name: 'property',
-                array: true
+                type: {
+                    name: 'MyScalar',
+                },
+                isArray: true
             });
             p.getScalarField().isArray().should.equal(true);
         });
 
         it('should handle non-arrays correctly', () => {
+            mockScalarDeclaration.ast = {
+                $class: `${MetaModelNamespace}.StringScalar`,
+                name: 'MyScalar',
+            };
             const p = new Field(mockClassDeclaration, {
-                $class: `${MetaModelNamespace}.StringProperty`,
+                $class: `${MetaModelNamespace}.ObjectProperty`,
                 name: 'property',
+                type: {
+                    name: 'MyScalar',
+                },
             });
             p.getScalarField().isArray().should.equal(false);
         });


### PR DESCRIPTION

<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #745 
<!--- Provide an overall summary of the pull request -->

### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
- added array modifier for scalar field unboxing condition

### Flags

### Screenshots or Video

### Related Issues
- Issue #745

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [x] Extend the documentation, if necessary
- [x] Merging to `main` from `fork:branchname`
