### PR TITLE
 fix(class): throw error when class is extending itself

### DIFF
--- a/packages/concerto-core/lib/introspect/classdeclaration.js
+++ b/packages/concerto-core/lib/introspect/classdeclaration.js
@@ -200,6 +200,19 @@ class ClassDeclaration extends Declaration {
 
         // if we have a super type make sure it exists
         if (this.superType !== null) {
+            // and make sure that the class isn't extending itself
+            // (an exemption is made for the core classes)
+            if (
+                this.superType === this.name &&
+                ![
+                    'Concept', 'Asset', 'Participant', 'Transaction', 'Event'
+                ].includes(this.superType)
+            ) {
+                let formatter = Globalize('en').messageFormatter('classdeclaration-validate-selfextending');
+                throw new IllegalModelException(formatter({
+                    'class': this.name,
+                }), this.modelFile, this.ast.location);
+            }
             this._resolveSuperType();
         }
 

--- a/packages/concerto-core/lib/introspect/classdeclaration.js
+++ b/packages/concerto-core/lib/introspect/classdeclaration.js
@@ -205,7 +205,7 @@ class ClassDeclaration extends Declaration {
             if (
                 this.superType === this.name &&
                 ![
-                    'Concept', 'Asset', 'Participant', 'Transaction', 'Event'
+                    'Asset', 'Concept', 'Event', 'Participant', 'Transaction',
                 ].includes(this.superType)
             ) {
                 let formatter = Globalize('en').messageFormatter('classdeclaration-validate-selfextending');

--- a/packages/concerto-core/messages/en.json
+++ b/packages/concerto-core/messages/en.json
@@ -20,6 +20,7 @@
         "classdeclaration-validate-identifiernotstring": "Class \"{class}\" is identified by field \"{idField}\", but the type of the field is not \"String\".",
         "classdeclaration-validate-duplicatefieldname": "Class \"{class}\" has more than one field named \"{fieldName}\".",
         "classdeclaration-validate-missingidentifier" : "Class \"{class}\" is not declared as \"abstract\". It must define an identifying field.",
+        "classdeclaration-validate-selfextending": "Class \"{class}\" cannot extend itself.",
 
         "modelfile-constructor-unrecmodelelem": "Unrecognised model element \"{type}\".",
         "modelfile-resolvetype-undecltype": "Undeclared type \"{type}\" in \"{context}\".",

--- a/packages/concerto-core/test/data/parser/classdeclaration.selfextendingasset.cto
+++ b/packages/concerto-core/test/data/parser/classdeclaration.selfextendingasset.cto
@@ -1,0 +1,20 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace com.testing
+
+asset Self_Extending extends Self_Extending {
+  o String id
+  o String newValue
+}

--- a/packages/concerto-core/test/data/parser/classdeclaration.selfextendingconcept.cto
+++ b/packages/concerto-core/test/data/parser/classdeclaration.selfextendingconcept.cto
@@ -1,0 +1,20 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace com.testing
+
+concept Self_Extending extends Self_Extending {
+  o String id
+  o String newValue
+}

--- a/packages/concerto-core/test/data/parser/classdeclaration.selfextendingevent.cto
+++ b/packages/concerto-core/test/data/parser/classdeclaration.selfextendingevent.cto
@@ -1,0 +1,20 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace com.testing
+
+event Self_Extending extends Self_Extending {
+  o String id
+  o String newValue
+}

--- a/packages/concerto-core/test/data/parser/classdeclaration.selfextendingparticipant.cto
+++ b/packages/concerto-core/test/data/parser/classdeclaration.selfextendingparticipant.cto
@@ -1,0 +1,20 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace com.testing
+
+participant Self_Extending extends Self_Extending {
+  o String id
+  o String newValue
+}

--- a/packages/concerto-core/test/data/parser/classdeclaration.selfextendingtransaction.cto
+++ b/packages/concerto-core/test/data/parser/classdeclaration.selfextendingtransaction.cto
@@ -1,0 +1,20 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace com.testing
+
+transaction Self_Extending extends Self_Extending {
+  o String id
+  o String newValue
+}

--- a/packages/concerto-core/test/introspect/classdeclaration.js
+++ b/packages/concerto-core/test/introspect/classdeclaration.js
@@ -20,6 +20,7 @@ const IllegalModelException = require('../../lib/introspect/illegalmodelexceptio
 const ClassDeclaration = require('../../lib/introspect/classdeclaration');
 const AssetDeclaration = require('../../lib/introspect/assetdeclaration');
 const EnumDeclaration = require('../../lib/introspect/enumdeclaration');
+const EventDeclaration = require('../../lib/introspect/eventdeclaration');
 const ConceptDeclaration = require('../../lib/introspect/conceptdeclaration');
 const ParticipantDeclaration = require('../../lib/introspect/participantdeclaration');
 const TransactionDeclaration = require('../../lib/introspect/transactiondeclaration');
@@ -140,6 +141,41 @@ describe('ClassDeclaration', () => {
         it('should not throw when a scalar array is used as an identifier', () => {
             const clazz = introspectUtils.loadLastDeclaration('test/data/parser/classdeclaration.scalararray.cto', ConceptDeclaration);
             clazz.validate();
+        });
+
+        it('should throw when an asset is extending itself', () => {
+            let asset = introspectUtils.loadLastDeclaration('test/data/parser/classdeclaration.selfextendingasset.cto', AssetDeclaration);
+            (() => {
+                asset.validate();
+            }).should.throw(/Class "Self_Extending" cannot extend itself./);
+        });
+
+        it('should throw when a concept is extending itself', () => {
+            let concept = introspectUtils.loadLastDeclaration('test/data/parser/classdeclaration.selfextendingconcept.cto', ConceptDeclaration);
+            (() => {
+                concept.validate();
+            }).should.throw(/Class "Self_Extending" cannot extend itself./);
+        });
+
+        it('should throw when an event is extending itself', () => {
+            let event = introspectUtils.loadLastDeclaration('test/data/parser/classdeclaration.selfextendingevent.cto', EventDeclaration);
+            (() => {
+                event.validate();
+            }).should.throw(/Class "Self_Extending" cannot extend itself./);
+        });
+
+        it('should throw when a participant is extending itself', () => {
+            let participant = introspectUtils.loadLastDeclaration('test/data/parser/classdeclaration.selfextendingparticipant.cto', ParticipantDeclaration);
+            (() => {
+                participant.validate();
+            }).should.throw(/Class "Self_Extending" cannot extend itself./);
+        });
+
+        it('should throw when a transaction is extending itself', () => {
+            let transaction = introspectUtils.loadLastDeclaration('test/data/parser/classdeclaration.selfextendingtransaction.cto', TransactionDeclaration);
+            (() => {
+                transaction.validate();
+            }).should.throw(/Class "Self_Extending" cannot extend itself./);
         });
     });
 

--- a/packages/concerto-cto/lib/parser.js
+++ b/packages/concerto-cto/lib/parser.js
@@ -624,6 +624,9 @@ function peg$parse(input, options) {
         ...buildRange(location())
       };
       if (classExtension) {
+        if (classExtension.name === id.name) {
+            throw new Error(`The asset "${id.name}" cannot extend itself.`);
+        }
         result.superType = classExtension;
       }
       if (idField) {
@@ -643,6 +646,9 @@ function peg$parse(input, options) {
         ...buildRange(location())
       };
       if (classExtension) {
+        if (classExtension.name === id.name) {
+          throw new Error(`The participant "${id.name}" cannot extend itself.`);
+        }
         result.superType = classExtension;
       }
       if (idField) {
@@ -662,6 +668,9 @@ function peg$parse(input, options) {
         ...buildRange(location())
       };
       if (classExtension) {
+        if (classExtension.name === id.name) {
+          throw new Error(`The transaction "${id.name}" cannot extend itself.`);
+        }
         result.superType = classExtension;
       }
       if (idField) {
@@ -681,6 +690,9 @@ function peg$parse(input, options) {
         ...buildRange(location())
       };
       if (classExtension) {
+        if (classExtension.name === id.name) {
+          throw new Error(`The event "${id.name}" cannot extend itself.`);
+        }
         result.superType = classExtension;
       }
       if (idField) {
@@ -700,6 +712,9 @@ function peg$parse(input, options) {
         ...buildRange(location())
       };
       if (classExtension) {
+        if (classExtension.name === id.name) {
+          throw new Error(`The concept "${id.name}" cannot extend itself.`);
+        }
         result.superType = classExtension;
       }
       if (idField) {

--- a/packages/concerto-cto/lib/parser.pegjs
+++ b/packages/concerto-cto/lib/parser.pegjs
@@ -966,6 +966,9 @@ AssetDeclaration
         ...buildRange(location())
       };
       if (classExtension) {
+        if (classExtension.name === id.name) {
+            throw new Error(`The asset "${id.name}" cannot extend itself.`);
+        }
         result.superType = classExtension;
       }
       if (idField) {
@@ -989,6 +992,9 @@ ParticipantDeclaration
         ...buildRange(location())
       };
       if (classExtension) {
+        if (classExtension.name === id.name) {
+          throw new Error(`The participant "${id.name}" cannot extend itself.`);
+        }
         result.superType = classExtension;
       }
       if (idField) {
@@ -1012,6 +1018,9 @@ TransactionDeclaration
         ...buildRange(location())
       };
       if (classExtension) {
+        if (classExtension.name === id.name) {
+          throw new Error(`The transaction "${id.name}" cannot extend itself.`);
+        }
         result.superType = classExtension;
       }
       if (idField) {
@@ -1035,6 +1044,9 @@ EventDeclaration
         ...buildRange(location())
       };
       if (classExtension) {
+        if (classExtension.name === id.name) {
+          throw new Error(`The event "${id.name}" cannot extend itself.`);
+        }
         result.superType = classExtension;
       }
       if (idField) {
@@ -1058,6 +1070,9 @@ ConceptDeclaration
         ...buildRange(location())
       };
       if (classExtension) {
+        if (classExtension.name === id.name) {
+          throw new Error(`The concept "${id.name}" cannot extend itself.`);
+        }
         result.superType = classExtension;
       }
       if (idField) {

--- a/packages/concerto-cto/lib/printer.js
+++ b/packages/concerto-cto/lib/printer.js
@@ -343,6 +343,9 @@ function declFromMetaModel(mm) {
             }
         }
         if (mm.superType) {
+            if (mm.superType.name === mm.name) {
+                throw new Error(`The declaration "${mm.name}" cannot extend itself.`);
+            }
             result += `extends ${mm.superType.name} `;
         }
         result += '{';

--- a/packages/concerto-cto/test/cto/bad/self-extending-asset.bad.cto
+++ b/packages/concerto-cto/test/cto/bad/self-extending-asset.bad.cto
@@ -1,0 +1,5 @@
+namespace com.acme@1.0.0
+
+asset Self_Extending extends Self_Extending {
+  o String foo optional
+}

--- a/packages/concerto-cto/test/cto/bad/self-extending-concept.bad.cto
+++ b/packages/concerto-cto/test/cto/bad/self-extending-concept.bad.cto
@@ -1,0 +1,5 @@
+namespace com.acme@1.0.0
+
+concept Self_Extending extends Self_Extending {
+  o String foo optional
+}

--- a/packages/concerto-cto/test/cto/bad/self-extending-event.bad.cto
+++ b/packages/concerto-cto/test/cto/bad/self-extending-event.bad.cto
@@ -1,0 +1,5 @@
+namespace com.acme@1.0.0
+
+event Self_Extending extends Self_Extending {
+  o String foo optional
+}

--- a/packages/concerto-cto/test/cto/bad/self-extending-participant.bad.cto
+++ b/packages/concerto-cto/test/cto/bad/self-extending-participant.bad.cto
@@ -1,0 +1,5 @@
+namespace com.acme@1.0.0
+
+participant Self_Extending extends Self_Extending {
+  o String foo optional
+}

--- a/packages/concerto-cto/test/cto/bad/self-extending-transaction.bad.cto
+++ b/packages/concerto-cto/test/cto/bad/self-extending-transaction.bad.cto
@@ -1,0 +1,5 @@
+namespace com.acme@1.0.0
+
+transaction Self_Extending extends Self_Extending {
+  o String foo optional
+}

--- a/packages/concerto-cto/test/parserMain.js
+++ b/packages/concerto-cto/test/parserMain.js
@@ -81,6 +81,24 @@ describe('parser', () => {
         });
     });
 
+    describe('self-extending', () => {
+        const declarationTypes = [
+            'asset',
+            'participant',
+            'transaction',
+            'event',
+            'concept',
+        ];
+        declarationTypes.forEach(declarationType => {
+            it(`Should not parse a self-extending ${declarationType}`, () => {
+                let content = fs.readFileSync(`./test/cto/bad/self-extending-${declarationType}.bad.cto`, 'utf8');
+                (() => {
+                    Parser.parse(content);
+                }).should.throw(new RegExp(`The ${declarationType} ".+" cannot extend itself.`));
+            });
+        });
+    });
+
     describe('identifiers', () => {
 
         const acceptedIdentifiers = [

--- a/packages/concerto-cto/test/printer.js
+++ b/packages/concerto-cto/test/printer.js
@@ -62,4 +62,30 @@ describe('parser', () => {
             declarations: [],
         })).should.throw(Error, 'Unrecognized import');
     });
+
+    it('Should throw error for a self-extending declaration', () => {
+        (() => Printer.toCTO({
+            '$class': 'concerto.metamodel@1.0.0.Model',
+            'namespace': 'com.acme@1.0.0',
+            'declarations': [
+                {
+                    '$class': 'concerto.metamodel@1.0.0.AssetDeclaration',
+                    'name': 'Self_Extending',
+                    'isAbstract': false,
+                    'properties': [
+                        {
+                            '$class': 'concerto.metamodel@1.0.0.StringProperty',
+                            'name': 'foo',
+                            'isArray': false,
+                            'isOptional': true
+                        }
+                    ],
+                    'superType': {
+                        '$class': 'concerto.metamodel@1.0.0.TypeIdentifier',
+                        'name': 'Self_Extending'
+                    }
+                }
+            ]
+        })).should.throw(Error, 'The declaration "Self_Extending" cannot extend itself.');
+    });
 });


### PR DESCRIPTION
<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #750
<!--- Provide an overall summary of the pull request -->

### Changes

Adds validation for cases where a class (an asset, event, concept, participant or transaction) is extending itself. The validations are performed when:
- `parse`-ing CTO to JSON AST.
- `print`-ing JSON AST to CTO.
- Loading JSON AST into the model manager.

The following will be caught by the anti-self-extension validation:

```cto
concept Self_Extending extends Self_Extending {}
```

```json
{
  "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
  "name": "Self_Extending",
  "isAbstract": false,
  "properties": [],
  "superType": {
    "$class": "concerto.metamodel@1.0.0.TypeIdentified",
    "name": "Self_Extending"
  }
}
```

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [x] Merging to `main` from `fork:branchname`
