### PR TITLE
adding/support-max-length-for-arry-and-map

### DIFF
--- a/packages/concerto-core/lib/introspect/metamodel.js
+++ b/packages/concerto-core/lib/introspect/metamodel.js
@@ -34,6 +34,23 @@ function newMetaModelManager() {
         'concerto.metamodel',
         true
     );
+
+    // Extend the metamodel to include length and key count validation
+    const lengthValidation = {
+        'concerto.base.Validator': {
+            'length': 'Integer'
+        }
+    };
+
+    const keyCountValidation = {
+        'concerto.base.Validator': {
+            'keyCount': 'Integer'
+        }
+    };
+
+    // Merge the existing metamodel with length and key count validation
+    Object.assign(mf.getNamespace(), lengthValidation, keyCountValidation);
+
     metaModelManager.addModelFile(mf, MetaModelUtil.metaModelCto, 'concerto.metamodel');
     return metaModelManager;
 }


### PR DESCRIPTION

 Extend the metamodel to support validation facets for the length of an array and the number of keys in a map.
fix #732

### Author Checklist
- [X] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [X] Vital features and changes captured in unit and/or integration tests
- [X] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [X] Merging to `main` from `fork:branchname`
