### PR TITLE
refactor(declarations): move declaration uniqueness check to model file

### DIFF
--- a/packages/concerto-core/lib/introspect/classdeclaration.js
+++ b/packages/concerto-core/lib/introspect/classdeclaration.js
@@ -190,21 +190,6 @@ class ClassDeclaration extends Declaration {
     validate() {
         super.validate();
 
-        const declarations = this.getModelFile().getAllDeclarations();
-        const declarationNames = declarations.map(
-            d => d.getFullyQualifiedName()
-        );
-        const uniqueNames = new Set(declarationNames);
-
-        if (uniqueNames.size !== declarations.length) {
-            const duplicateElements = declarationNames.filter(
-                (item, index) => declarationNames.indexOf(item) !== index
-            );
-            throw new IllegalModelException(
-                `Duplicate class name ${duplicateElements[0]}`
-            );
-        }
-
         // if we have a super type make sure it exists
         if (this.superType !== null) {
             // and make sure that the class isn't extending itself

--- a/packages/concerto-core/lib/introspect/modelfile.js
+++ b/packages/concerto-core/lib/introspect/modelfile.js
@@ -274,6 +274,22 @@ class ModelFile extends Decorated {
         });
 
         // Validate all of the types in this model file.
+        // Check if names of the declarations are unique.
+        const declarationNames = this.declarations.map(
+            d => d.getFullyQualifiedName()
+        );
+        const uniqueNames = new Set(declarationNames);
+
+        if (uniqueNames.size !== this.declarations.length) {
+            const duplicateElements = declarationNames.filter(
+                (item, index) => declarationNames.indexOf(item) !== index
+            );
+            throw new IllegalModelException(
+                `Duplicate class name ${duplicateElements[0]}`
+            );
+        }
+
+        // Run validations on class declarations
         for(let n=0; n < this.declarations.length; n++) {
             let classDeclaration = this.declarations[n];
             classDeclaration.validate();

--- a/packages/concerto-core/test/introspect/classdeclaration.js
+++ b/packages/concerto-core/test/introspect/classdeclaration.js
@@ -19,10 +19,7 @@ const { MetaModelNamespace } = require('@accordproject/concerto-metamodel');
 const IllegalModelException = require('../../lib/introspect/illegalmodelexception');
 const ClassDeclaration = require('../../lib/introspect/classdeclaration');
 const AssetDeclaration = require('../../lib/introspect/assetdeclaration');
-const EnumDeclaration = require('../../lib/introspect/enumdeclaration');
 const ConceptDeclaration = require('../../lib/introspect/conceptdeclaration');
-const ParticipantDeclaration = require('../../lib/introspect/participantdeclaration');
-const TransactionDeclaration = require('../../lib/introspect/transactiondeclaration');
 const IntrospectUtils = require('./introspectutils');
 const ParserUtil = require('./parserutility');
 
@@ -87,27 +84,6 @@ describe('ClassDeclaration', () => {
     });
 
     describe('#validate', () => {
-        it('should throw when asset name is duplicted in a modelfile', () => {
-            let asset = introspectUtils.loadLastDeclaration('test/data/parser/classdeclaration.dupeassetname.cto', AssetDeclaration);
-            (() => {
-                asset.validate();
-            }).should.throw(/Duplicate class/);
-        });
-
-        it('should throw when transaction name is duplicted in a modelfile', () => {
-            let asset = introspectUtils.loadLastDeclaration('test/data/parser/classdeclaration.dupetransactionname.cto', TransactionDeclaration);
-            (() => {
-                asset.validate();
-            }).should.throw(/Duplicate class/);
-        });
-
-        it('should throw when participant name is duplicted in a modelfile', () => {
-            let asset = introspectUtils.loadLastDeclaration('test/data/parser/classdeclaration.dupeparticipantname.cto', ParticipantDeclaration);
-            (() => {
-                asset.validate();
-            }).should.throw(/Duplicate class/);
-        });
-
         it('should throw when an super type identifier is redeclared', () => {
             let asset = introspectUtils.loadLastDeclaration('test/data/parser/classdeclaration.identifierextendsfromsupertype.cto', AssetDeclaration);
             (() => {
@@ -122,20 +98,6 @@ describe('ClassDeclaration', () => {
         //        asset.validate();
         //    }).should.throw(/Identifier defined in super class/);
         //});
-
-        it('should throw when concept name is duplicted in a modelfile', () => {
-            let asset = introspectUtils.loadLastDeclaration('test/data/parser/classdeclaration.dupeconceptname.cto', ConceptDeclaration);
-            (() => {
-                asset.validate();
-            }).should.throw(/Duplicate class/);
-        });
-
-        it('should throw when enum name is duplicted in a modelfile', () => {
-            let asset = introspectUtils.loadLastDeclaration('test/data/parser/classdeclaration.dupeenumname.cto', EnumDeclaration);
-            (() => {
-                asset.validate();
-            }).should.throw(/Duplicate class/);
-        });
 
         it('should throw when not abstract, not enum and not concept without an identifier', () => {
             let asset = introspectUtils.loadLastDeclaration('test/data/parser/classdeclaration.noidentifier.cto', AssetDeclaration);

--- a/packages/concerto-core/test/introspect/modelfile.js
+++ b/packages/concerto-core/test/introspect/modelfile.js
@@ -24,6 +24,7 @@ const EnumDeclaration = require('../../lib/introspect/enumdeclaration');
 const IllegalModelException = require('../../lib/introspect/illegalmodelexception');
 const ModelFile = require('../../lib/introspect/modelfile');
 const ModelManager = require('../../lib/modelmanager');
+const IntrospectUtils = require('./introspectutils');
 
 const fs = require('fs');
 const path = require('path');
@@ -44,10 +45,12 @@ describe('ModelFile', () => {
     const carLeaseModel = fs.readFileSync(path.resolve(__dirname, '../data/model/carlease.cto'), 'utf8');
     let modelManager;
     let sandbox;
+    let introspectUtils;
 
     beforeEach(() => {
         modelManager = new ModelManager();
         Util.addComposerModel(modelManager);
+        introspectUtils = new IntrospectUtils(modelManager);
         sandbox = sinon.createSandbox();
     });
 
@@ -202,6 +205,41 @@ describe('ModelFile', () => {
     });
 
     describe('#validate', () => {
+
+        it('should throw when asset name is duplicted in a modelfile', () => {
+            let asset = introspectUtils.loadModelFile('test/data/parser/classdeclaration.dupeassetname.cto');
+            (() => {
+                asset.validate();
+            }).should.throw(/Duplicate class/);
+        });
+
+        it('should throw when transaction name is duplicted in a modelfile', () => {
+            let asset = introspectUtils.loadModelFile('test/data/parser/classdeclaration.dupetransactionname.cto');
+            (() => {
+                asset.validate();
+            }).should.throw(/Duplicate class/);
+        });
+
+        it('should throw when participant name is duplicted in a modelfile', () => {
+            let asset = introspectUtils.loadModelFile('test/data/parser/classdeclaration.dupeparticipantname.cto');
+            (() => {
+                asset.validate();
+            }).should.throw(/Duplicate class/);
+        });
+
+        it('should throw when concept name is duplicted in a modelfile', () => {
+            let asset = introspectUtils.loadModelFile('test/data/parser/classdeclaration.dupeconceptname.cto');
+            (() => {
+                asset.validate();
+            }).should.throw(/Duplicate class/);
+        });
+
+        it('should throw when enum name is duplicted in a modelfile', () => {
+            let asset = introspectUtils.loadModelFile('test/data/parser/classdeclaration.dupeenumname.cto');
+            (() => {
+                asset.validate();
+            }).should.throw(/Duplicate class/);
+        });
 
         it('should throw if an import exists for an invalid namespace', () => {
             const model = `


### PR DESCRIPTION
<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #785 
<!--- Provide an overall summary of the pull request -->

This logic doesn't need to run for each declaration in the class. It basically calls the model file and fetches declarations and creates a set. There is nothing special about the particular declaration within this logic.

### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
- Moved unique name check logic to model file
- Updated the tests (move the tests from class declaration to model file as well)

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ ] Merging to `main` from `fork:branchname`
