### PR TITLE
Improved error reporting when decorator manager applies a duplicate decorator

### DIFF
--- a/packages/concerto-core/lib/decoratormanager.js
+++ b/packages/concerto-core/lib/decoratormanager.js
@@ -21,6 +21,7 @@ const ModelUtil = require('./modelutil');
 const { MetaModelNamespace } = require('@accordproject/concerto-metamodel');
 const semver = require('semver');
 const DecoratorExtractor = require('./decoratorextractor');
+const illegalmodelexception = require("./introspect/illegalmodelexception")
 
 // Types needed for TypeScript generation.
 /* eslint-disable no-unused-vars */
@@ -432,6 +433,14 @@ class DecoratorManager {
                     : (decorated.decorators = [newDecorator]);
             }
         } else if (type === 'APPEND') {
+            decorated.decorators.forEach((d)=>{
+                if(d === newDecorator){
+                    throw new IllegalModelException(
+                        `Duplicate decorator ${newDecorator}`,
+                        this.ast.location,
+                    );
+                }
+            })
             decorated.decorators
                 ? decorated.decorators.push(newDecorator)
                 : (decorated.decorators = [newDecorator]);

--- a/packages/concerto-core/lib/decoratormanager.js
+++ b/packages/concerto-core/lib/decoratormanager.js
@@ -21,7 +21,7 @@ const ModelUtil = require('./modelutil');
 const { MetaModelNamespace } = require('@accordproject/concerto-metamodel');
 const semver = require('semver');
 const DecoratorExtractor = require('./decoratorextractor');
-const illegalmodelexception = require("./introspect/illegalmodelexception")
+const IllegalModelException = require("./introspect/illegalmodelexception")
 
 // Types needed for TypeScript generation.
 /* eslint-disable no-unused-vars */
@@ -434,7 +434,7 @@ class DecoratorManager {
             }
         } else if (type === 'APPEND') {
             decorated.decorators.forEach((d)=>{
-                if(d === newDecorator){
+                if(d.name === newDecorator.name){
                     throw new IllegalModelException(
                         `Duplicate decorator ${newDecorator}`,
                         this.ast.location,

--- a/packages/concerto-core/lib/decoratormanager.js
+++ b/packages/concerto-core/lib/decoratormanager.js
@@ -436,8 +436,7 @@ class DecoratorManager {
             decorated.decorators.forEach((d)=>{
                 if(d.name === newDecorator.name){
                     throw new IllegalModelException(
-                        `Duplicate decorator ${newDecorator}`,
-                        this.ast.location,
+                        `Duplicate decorator ${newDecorator.name}`
                     );
                 }
             });

--- a/packages/concerto-core/lib/decoratormanager.js
+++ b/packages/concerto-core/lib/decoratormanager.js
@@ -21,7 +21,7 @@ const ModelUtil = require('./modelutil');
 const { MetaModelNamespace } = require('@accordproject/concerto-metamodel');
 const semver = require('semver');
 const DecoratorExtractor = require('./decoratorextractor');
-const IllegalModelException = require("./introspect/illegalmodelexception")
+const IllegalModelException = require('./introspect/illegalmodelexception');
 
 // Types needed for TypeScript generation.
 /* eslint-disable no-unused-vars */
@@ -440,7 +440,7 @@ class DecoratorManager {
                         this.ast.location,
                     );
                 }
-            })
+            });
             decorated.decorators
                 ? decorated.decorators.push(newDecorator)
                 : (decorated.decorators = [newDecorator]);

--- a/packages/concerto-core/test/decoratormanager.js
+++ b/packages/concerto-core/test/decoratormanager.js
@@ -568,10 +568,14 @@ describe('DecoratorManager', () => {
     });
 
     describe("#applyDecorator",async function(){
-        const testModelManager = new ModelManager({strict:true,});
-            const modelText = fs.readFileSync('./test/data/decoratorcommands/model-without-vocab.cto', 'utf-8');
-            testModelManager.addCTOModel(modelText, 'test.cto');
-            const resp1 = DecoratorManager.applyDecorator(testModelManager,'APPEND',new Decorator(this,'decoratorOne'));
-            DecoratorManager.applyDecorator(testModelManager,'APPEND',new Decorator(this,'decoratorOne').should.throw(/Duplicate decorator decoratorOne /)
-    })
+        it("Duplicate decorator",()=>{
+            const testModelManager = new ModelManager();
+            const modelText = fs.readFileSync(__dirname+'/data/decorators/model.cto', 'utf-8');
+            const modelFile = testModelManager.addCTOModel(modelText, 'model.cto');
+            
+            (()=>{
+                DecoratorManager.applyDecorator(modelFile.getDecorator('noargs').parent,'APPEND',modelFile.getDecorator('noargs').parent.decorators[0]);
+            }).should.throw(/Duplicate decorator noargs/);
+        });
+    });
 });

--- a/packages/concerto-core/test/decoratormanager.js
+++ b/packages/concerto-core/test/decoratormanager.js
@@ -21,6 +21,7 @@ const VocabularyManager= require('../../concerto-vocabulary/lib/vocabularymanage
 const Printer= require('../../concerto-cto/lib/printer');
 
 const chai = require('chai');
+const Decorator = require('../lib/introspect/decorator');
 require('chai').should();
 chai.use(require('chai-things'));
 chai.use(require('chai-as-promised'));
@@ -566,4 +567,11 @@ describe('DecoratorManager', () => {
         });
     });
 
+    describe("#applyDecorator",async function(){
+        const testModelManager = new ModelManager({strict:true,});
+            const modelText = fs.readFileSync('./test/data/decoratorcommands/model-without-vocab.cto', 'utf-8');
+            testModelManager.addCTOModel(modelText, 'test.cto');
+            const resp1 = DecoratorManager.applyDecorator(testModelManager,'APPEND',new Decorator(this,'decoratorOne'));
+            DecoratorManager.applyDecorator(testModelManager,'APPEND',new Decorator(this,'decoratorOne').should.throw(/Duplicate decorator decoratorOne /)
+    })
 });

--- a/packages/concerto-core/test/decoratormanager.js
+++ b/packages/concerto-core/test/decoratormanager.js
@@ -21,7 +21,6 @@ const VocabularyManager= require('../../concerto-vocabulary/lib/vocabularymanage
 const Printer= require('../../concerto-cto/lib/printer');
 
 const chai = require('chai');
-const Decorator = require('../lib/introspect/decorator');
 require('chai').should();
 chai.use(require('chai-things'));
 chai.use(require('chai-as-promised'));
@@ -568,7 +567,7 @@ describe('DecoratorManager', () => {
     });
 
     describe("#applyDecorator",async function(){
-        it("Duplicate decorator",()=>{
+        it("should throw error for appending duplicate decorator",()=>{
             const testModelManager = new ModelManager();
             const modelText = fs.readFileSync(__dirname+'/data/decorators/model.cto', 'utf-8');
             const modelFile = testModelManager.addCTOModel(modelText, 'model.cto');
@@ -578,4 +577,5 @@ describe('DecoratorManager', () => {
             }).should.throw(/Duplicate decorator noargs/);
         });
     });
+    
 });


### PR DESCRIPTION
<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #711 
<!--- Provide an overall summary of the pull request -->

- Improved error reporting when the decorator manager applies a duplicate decorator
- Added test for duplicate decorator

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ ] Merging to `main` from `fork:branchname`
