### PR TITLE
Fixing Inconsistent type declaration of ast property

### DIFF
--- a/packages/concerto-core/types/lib/introspect/declaration.d.ts
+++ b/packages/concerto-core/types/lib/introspect/declaration.d.ts
@@ -16,10 +16,10 @@ declare class Declaration extends Decorated {
      * result of parsing.
      *
      * @param {ModelFile} modelFile - the ModelFile for this class
-     * @param {Object} ast - the AST created by the parser
+     * @param {IDeclaration} ast - the AST created by the parser
      * @throws {IllegalModelException}
      */
-    constructor(modelFile: ModelFile, ast: any);
+    constructor(modelFile: ModelFile, ast: IDeclaration);
     modelFile: ModelFile;
     name: any;
     fqn: string;
@@ -93,3 +93,4 @@ declare class Declaration extends Decorated {
 }
 import Decorated = require("./decorated");
 import ModelFile = require("./modelfile");
+import {IDeclaration} from "../../../../concerto-types/src/generated/unions/concerto.metamodel@1.0.0"


### PR DESCRIPTION
<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #721
<!--- Provide an overall summary of the pull request -->
Fixing Inconsistent type declaration of ast property

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [ ] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ ] Merging to `main` from `fork:branchname`
