### PR TITLE
feat(decorator): added new methods to extract vocab or non-vocab decorators from model

### DIFF
--- a/packages/concerto-core/api.txt
+++ b/packages/concerto-core/api.txt
@@ -55,14 +55,11 @@ class Concerto {
    + string getNamespace(obj) 
 }
    + object setCurrentTime() 
-class DecoratorExtractor {
-   + void constructor(boolean,string,string,Object,int?) 
-}
 class DecoratorManager {
    + ModelManager validate(decoratorCommandSet,ModelFile[]) throws Error
    + ModelManager decorateModels(ModelManager,decoratorCommandSet,object?,boolean?,boolean?,boolean?,boolean?) 
    + ExtractDecoratorsResult extractDecorators(ModelManager,object,boolean,string) 
-   + ExtractDecoratorsResult extractVocabDecorators(ModelManager,object,boolean,string) 
+   + ExtractDecoratorsResult extractVocabularies(ModelManager,object,boolean,string) 
    + ExtractDecoratorsResult extractNonVocabDecorators(ModelManager,object,boolean,string) 
    + void validateCommand(ModelManager,command) 
    + Boolean falsyOrEqual(string||,string[]) 

--- a/packages/concerto-core/api.txt
+++ b/packages/concerto-core/api.txt
@@ -56,12 +56,14 @@ class Concerto {
 }
    + object setCurrentTime() 
 class DecoratorExtractor {
-   + void constructor(boolean,string,string,Object) 
+   + void constructor(boolean,string,string,Object,int) 
 }
 class DecoratorManager {
    + ModelManager validate(decoratorCommandSet,ModelFile[]) throws Error
    + ModelManager decorateModels(ModelManager,decoratorCommandSet,object?,boolean?,boolean?,boolean?,boolean?) 
    + ExtractDecoratorsResult extractDecorators(ModelManager,object,boolean,string) 
+   + ExtractDecoratorsResult extractVocabDecorators(ModelManager,object,boolean,string) 
+   + ExtractDecoratorsResult extractNonVocabDecorators(ModelManager,object,boolean,string) 
    + void validateCommand(ModelManager,command) 
    + Boolean falsyOrEqual(string||,string[]) 
    + void applyDecorator(decorated,string,newDecorator) 

--- a/packages/concerto-core/api.txt
+++ b/packages/concerto-core/api.txt
@@ -56,7 +56,7 @@ class Concerto {
 }
    + object setCurrentTime() 
 class DecoratorExtractor {
-   + void constructor(boolean,string,string,Object,int) 
+   + void constructor(boolean,string,string,Object,int?) 
 }
 class DecoratorManager {
    + ModelManager validate(decoratorCommandSet,ModelFile[]) throws Error

--- a/packages/concerto-core/changelog.txt
+++ b/packages/concerto-core/changelog.txt
@@ -24,7 +24,7 @@
 # Note that the latest public API is documented using JSDocs and is available in api.txt.
 #
 
-Version 3.17.3 {b3681cbd6299139a8ff372c44e180f58} 2024-07-26
+Version 3.17.3 {1c15de121dd80375cf531bc2244efdd0} 2024-07-26
 - Added new methods to extract vocab or non-vocab decorators from model
 - Fixed some minor bugs related to vocabulary parsing
 - Exposed method to validate locale

--- a/packages/concerto-core/changelog.txt
+++ b/packages/concerto-core/changelog.txt
@@ -24,7 +24,7 @@
 # Note that the latest public API is documented using JSDocs and is available in api.txt.
 #
 
-Version 3.17.4 {da7430db25daa6d54cac03c13ef06b01} 2024-07-26
+Version 3.17.3 {da7430db25daa6d54cac03c13ef06b01} 2024-07-26
 - Added new methods to extract vocab or non-vocab decorators from model
 - Fixed some minor bugs related to vocabulary parsing
 - Exposed method to validate locale

--- a/packages/concerto-core/changelog.txt
+++ b/packages/concerto-core/changelog.txt
@@ -24,6 +24,11 @@
 # Note that the latest public API is documented using JSDocs and is available in api.txt.
 #
 
+Version 3.17.4 {da7430db25daa6d54cac03c13ef06b01} 2024-07-26
+- Added new methods to extract vocab or non-vocab decorators from model
+- Fixed some minor bugs related to vocabulary parsing
+- Exposed method to validate locale
+
 Version 3.17.2 {eb3903401fdcf7c26cca1f3f8a029171} 2024-07-17
 - Added new optimized methods for decorating models with decorator commandsets
 - fixed other decorator command set bugs

--- a/packages/concerto-core/changelog.txt
+++ b/packages/concerto-core/changelog.txt
@@ -24,7 +24,7 @@
 # Note that the latest public API is documented using JSDocs and is available in api.txt.
 #
 
-Version 3.17.3 {da7430db25daa6d54cac03c13ef06b01} 2024-07-26
+Version 3.17.3 {b3681cbd6299139a8ff372c44e180f58} 2024-07-26
 - Added new methods to extract vocab or non-vocab decorators from model
 - Fixed some minor bugs related to vocabulary parsing
 - Exposed method to validate locale

--- a/packages/concerto-core/lib/decoratorextractor.js
+++ b/packages/concerto-core/lib/decoratorextractor.js
@@ -40,9 +40,9 @@ class DecoratorExtractor {
      * @param {string} locale - locale for extracted vocabularies
      * @param {string} dcs_version - version string
      * @param {Object} sourceModelAst - the ast of source models
-     * @param {int} action - the action to be performed
+     * @param {int} [action=DecoratorExtractor.Action.EXTRACT_ALL]  - the action to be performed
      */
-    constructor(removeDecoratorsFromModel, locale, dcs_version, sourceModelAst, action) {
+    constructor(removeDecoratorsFromModel, locale, dcs_version, sourceModelAst, action = DecoratorExtractor.Action.EXTRACT_ALL) {
         this.extractionDictionary = {};
         this.removeDecoratorsFromModel = removeDecoratorsFromModel;
         this.locale = locale;

--- a/packages/concerto-core/lib/decoratorextractor.js
+++ b/packages/concerto-core/lib/decoratorextractor.js
@@ -22,6 +22,7 @@ const { MetaModelNamespace } = require('@accordproject/concerto-metamodel');
  * Utility functions to work with
  * [DecoratorCommandSet](https://models.accordproject.org/concerto/decorators.cto)
  * @memberof module:concerto-core
+ * @private
  */
 class DecoratorExtractor {
     /**

--- a/packages/concerto-core/lib/decoratorextractor.js
+++ b/packages/concerto-core/lib/decoratorextractor.js
@@ -290,19 +290,20 @@ class DecoratorExtractor {
     /**
      * Filter vocab or non-vocab decorators
      * @param {Object} decorators - the collection of decorators
+     * @returns {Object} - the collection of filtered decorators
      * @private
      */
     filterDecorators(decorators){
         if (this.action === DecoratorExtractor.Action.EXTRACT_ALL){
-            decorators = undefined;
+            return undefined;
         }
         else if(this.action === DecoratorExtractor.Action.EXTRACT_VOCAB){
-            decorators = decorators.filter((dcs) => {
+            return decorators.filter((dcs) => {
                 return !this.isVocabDecorator(dcs.name);
             });
         }
         else if(this.action === DecoratorExtractor.Action.EXTRACT_NON_VOCAB){
-            decorators = decorators.filter((dcs) => {
+            return decorators.filter((dcs) => {
                 return this.isVocabDecorator(dcs.name);
             });
         }
@@ -323,7 +324,7 @@ class DecoratorExtractor {
                     mapElement: 'KEY'
                 };
                 this.constructDCSDictionary(namespace, declaration.key.decorators, constructOptions);
-                this.filterDecorators(declaration.key.decorators);
+                declaration.key.decorators = this.filterDecorators(declaration.key.decorators);
             }
         }
         if (declaration.value){
@@ -333,7 +334,7 @@ class DecoratorExtractor {
                     mapElement: 'VALUE'
                 };
                 this.constructDCSDictionary(namespace, declaration.value.decorators, constructOptions);
-                this.filterDecorators(declaration.value.decorators);
+                declaration.value.decorators = this.filterDecorators(declaration.value.decorators);
             }
         }
         return declaration;
@@ -356,7 +357,7 @@ class DecoratorExtractor {
                     property: property.name
                 };
                 this.constructDCSDictionary(namespace, property.decorators, constructOptions );
-                this.filterDecorators(property.decorators);
+                property.decorators = this.filterDecorators(property.decorators);
             }
             return property;
         });
@@ -378,7 +379,7 @@ class DecoratorExtractor {
                     declaration: decl.name,
                 };
                 this.constructDCSDictionary(namespace, decl.decorators, constructOptions);
-                this.filterDecorators(decl.decorators);
+                decl.decorators = this.filterDecorators(decl.decorators);
             }
             if (decl.$class === `${MetaModelNamespace}.MapDeclaration`) {
                 const processedMapDecl = this.processMapDeclaration(decl, namespace);
@@ -402,7 +403,7 @@ class DecoratorExtractor {
         const processedModels = this.sourceModelAst.models.map(model =>{
             if ((model?.decorators.length > 0)){
                 this.constructDCSDictionary(model.namespace, model.decorators, {});
-                this.filterDecorators(model.decorators);
+                model.decorators = this.filterDecorators(model.decorators);
             }
             const processedDecl = this.processDeclarations(model.declarations, model.namespace);
             model.declarations = processedDecl;

--- a/packages/concerto-core/lib/decoratorextractor.js
+++ b/packages/concerto-core/lib/decoratorextractor.js
@@ -300,19 +300,20 @@ class DecoratorExtractor {
      * @returns {Object} - the collection of filtered decorators
      * @private
      */
-    filterDecorators(decorators){
-        if(this.removeDecoratorsFromModel){
-            if (this.action === DecoratorExtractor.Action.EXTRACT_ALL){
-                return undefined;
-            }
-            else if(this.action === DecoratorExtractor.Action.EXTRACT_VOCAB){
-                return decorators.filter((dcs) => !this.isVocabDecorator(dcs.name));
-            }
-            else if(this.action === DecoratorExtractor.Action.EXTRACT_NON_VOCAB){
-                return decorators.filter((dcs) => this.isVocabDecorator(dcs.name));
-            }
+    filterOutDecorators(decorators){
+        if(!this.removeDecoratorsFromModel){
+            return decorators;
         }
-        return decorators;
+
+        if (this.action === DecoratorExtractor.Action.EXTRACT_ALL){
+            return undefined;
+        }
+        else if(this.action === DecoratorExtractor.Action.EXTRACT_VOCAB){
+            return decorators.filter((dcs) => !this.isVocabDecorator(dcs.name));
+        }
+        else{
+            return decorators.filter((dcs) => this.isVocabDecorator(dcs.name));
+        }
     }
     /**
     * Process the map declarations to extract the decorators.
@@ -330,7 +331,7 @@ class DecoratorExtractor {
                     mapElement: 'KEY'
                 };
                 this.constructDCSDictionary(namespace, declaration.key.decorators, constructOptions);
-                declaration.key.decorators = this.filterDecorators(declaration.key.decorators);
+                declaration.key.decorators = this.filterOutDecorators(declaration.key.decorators);
             }
         }
         if (declaration.value){
@@ -340,7 +341,7 @@ class DecoratorExtractor {
                     mapElement: 'VALUE'
                 };
                 this.constructDCSDictionary(namespace, declaration.value.decorators, constructOptions);
-                declaration.value.decorators = this.filterDecorators(declaration.value.decorators);
+                declaration.value.decorators = this.filterOutDecorators(declaration.value.decorators);
             }
         }
         return declaration;
@@ -363,7 +364,7 @@ class DecoratorExtractor {
                     property: property.name
                 };
                 this.constructDCSDictionary(namespace, property.decorators, constructOptions );
-                property.decorators = this.filterDecorators(property.decorators);
+                property.decorators = this.filterOutDecorators(property.decorators);
             }
             return property;
         });
@@ -385,7 +386,7 @@ class DecoratorExtractor {
                     declaration: decl.name,
                 };
                 this.constructDCSDictionary(namespace, decl.decorators, constructOptions);
-                decl.decorators = this.filterDecorators(decl.decorators);
+                decl.decorators = this.filterOutDecorators(decl.decorators);
             }
             if (decl.$class === `${MetaModelNamespace}.MapDeclaration`) {
                 const processedMapDecl = this.processMapDeclaration(decl, namespace);
@@ -409,7 +410,7 @@ class DecoratorExtractor {
         const processedModels = this.sourceModelAst.models.map(model =>{
             if ((model?.decorators?.length > 0)){
                 this.constructDCSDictionary(model.namespace, model.decorators, {});
-                model.decorators = this.filterDecorators(model.decorators);
+                model.decorators = this.filterOutDecorators(model.decorators);
             }
             const processedDecl = this.processDeclarations(model.declarations, model.namespace);
             model.declarations = processedDecl;

--- a/packages/concerto-core/lib/decoratorextractor.js
+++ b/packages/concerto-core/lib/decoratorextractor.js
@@ -50,10 +50,10 @@ class DecoratorExtractor {
         this.sourceModelAst = sourceModelAst;
         this.updatedModelAst = sourceModelAst;
         if (action) {
-            if (Object.values(this.Action).includes(action)) {
+            if (Object.values(DecoratorExtractor.Action).includes(action)) {
                 this.action = action;
             } else {
-                this.action = this.Action.EXTRACT_ALL;
+                this.action = DecoratorExtractor.Action.EXTRACT_ALL;
             }
         }
     }
@@ -267,18 +267,18 @@ class DecoratorExtractor {
                 const target = this.constructTarget(namespace, obj);
                 decos.forEach(dcs =>{
                     const isVocab = this.isVocabDecorator(dcs.name);
-                    if (!isVocab && this.action !== this.Action.EXTRACT_VOCAB){
+                    if (!isVocab && this.action !== DecoratorExtractor.Action.EXTRACT_VOCAB){
                         dcsObjects = this.parseNonVocabularyDecorators(dcsObjects, dcs, this.dcs_version, target);
                     }
-                    if (isVocab && this.action !== this.Action.EXTRACT_NON_VOCAB){
+                    if (isVocab && this.action !== DecoratorExtractor.Action.EXTRACT_NON_VOCAB){
                         vocabObject = this.parseVocabularies(vocabObject, obj, dcs);
                     }
                 });
             });
-            if(this.action !== this.Action.EXTRACT_VOCAB){
+            if(this.action !== DecoratorExtractor.Action.EXTRACT_VOCAB){
                 decoratorData = this.transformNonVocabularyDecorators(dcsObjects, namespace, decoratorData);
             }
-            if(this.action !== this.Action.EXTRACT_NON_VOCAB){
+            if(this.action !== DecoratorExtractor.Action.EXTRACT_NON_VOCAB){
                 vocabData = this.transformVocabularyDecorators(vocabObject, namespace, vocabData);
             }
         });
@@ -293,15 +293,15 @@ class DecoratorExtractor {
      * @private
      */
     filterDecorators(decorators){
-        if (this.action === this.Action.EXTRACT_ALL){
+        if (this.action === DecoratorExtractor.Action.EXTRACT_ALL){
             decorators = undefined;
         }
-        else if(this.action === this.Action.EXTRACT_VOCAB){
+        else if(this.action === DecoratorExtractor.Action.EXTRACT_VOCAB){
             decorators = decorators.filter((dcs) => {
                 return !this.isVocabDecorator(dcs.name);
             });
         }
-        else if(this.action === this.Action.EXTRACT_NON_VOCAB){
+        else if(this.action === DecoratorExtractor.Action.EXTRACT_NON_VOCAB){
             decorators = decorators.filter((dcs) => {
                 return this.isVocabDecorator(dcs.name);
             });

--- a/packages/concerto-core/lib/decoratorextractor.js
+++ b/packages/concerto-core/lib/decoratorextractor.js
@@ -410,7 +410,7 @@ class DecoratorExtractor {
     */
     processModels(){
         const processedModels = this.sourceModelAst.models.map(model =>{
-            if ((model?.decorators.length > 0)){
+            if ((model?.decorators?.length > 0)){
                 this.constructDCSDictionary(model.namespace, model.decorators, {});
                 model.decorators = this.filterDecorators(model.decorators);
             }

--- a/packages/concerto-core/lib/decoratorextractor.js
+++ b/packages/concerto-core/lib/decoratorextractor.js
@@ -305,14 +305,10 @@ class DecoratorExtractor {
                 return undefined;
             }
             else if(this.action === DecoratorExtractor.Action.EXTRACT_VOCAB){
-                return decorators.filter((dcs) => {
-                    return !this.isVocabDecorator(dcs.name);
-                });
+                return decorators.filter((dcs) => !this.isVocabDecorator(dcs.name));
             }
             else if(this.action === DecoratorExtractor.Action.EXTRACT_NON_VOCAB){
-                return decorators.filter((dcs) => {
-                    return this.isVocabDecorator(dcs.name);
-                });
+                return decorators.filter((dcs) => this.isVocabDecorator(dcs.name));
             }
         }
         return decorators;

--- a/packages/concerto-core/lib/decoratorextractor.js
+++ b/packages/concerto-core/lib/decoratorextractor.js
@@ -129,6 +129,7 @@ class DecoratorExtractor {
                     strVoc += `  - ${decl}: ${vocabObject[decl].term}\n`;
                 }
                 const otherProps = Object.keys(vocabObject[decl]).filter((str)=>str !== 'term' && str !== 'propertyVocabs');
+                //If a declaration does not have any Term decorator, then add Term_ decorators to yaml
                 if(otherProps.length > 0){
                     if (!vocabObject[decl].term){
                         strVoc += `  - ${decl}: ${decl}\n`;

--- a/packages/concerto-core/lib/decoratorextractor.js
+++ b/packages/concerto-core/lib/decoratorextractor.js
@@ -60,8 +60,7 @@ class DecoratorExtractor {
      * @private
      */
     isVocabDecorator(decoractorName) {
-        const vocabPattern = /^Term_/;
-        return decoractorName === 'Term' || vocabPattern.test(decoractorName);
+        return decoractorName === 'Term' || decoractorName.startsWith('Term_');
     }
     /**
     * Adds a key-value pair to a dictionary (object) if the key exists,

--- a/packages/concerto-core/lib/decoratorextractor.js
+++ b/packages/concerto-core/lib/decoratorextractor.js
@@ -24,7 +24,9 @@ const { MetaModelNamespace } = require('@accordproject/concerto-metamodel');
  * @memberof module:concerto-core
  */
 class DecoratorExtractor {
-
+    /**
+     * The action to be performed to extract all, only vocab or only non-vocab decorators
+     */
     static Action = {
         EXTRACT_ALL: 0,
         EXTRACT_VOCAB: 1,

--- a/packages/concerto-core/lib/decoratorextractor.js
+++ b/packages/concerto-core/lib/decoratorextractor.js
@@ -24,6 +24,13 @@ const { MetaModelNamespace } = require('@accordproject/concerto-metamodel');
  * @memberof module:concerto-core
  */
 class DecoratorExtractor {
+
+    static Action = {
+        EXTRACT_ALL: 0,
+        EXTRACT_VOCAB: 1,
+        EXTRACT_NON_VOCAB: 2
+    };
+
     /**
      * Create the DecoratorExtractor.
      * @constructor
@@ -31,14 +38,33 @@ class DecoratorExtractor {
      * @param {string} locale - locale for extracted vocabularies
      * @param {string} dcs_version - version string
      * @param {Object} sourceModelAst - the ast of source models
+     * @param {int} action - the action to be performed
      */
-    constructor(removeDecoratorsFromModel, locale, dcs_version, sourceModelAst) {
+    constructor(removeDecoratorsFromModel, locale, dcs_version, sourceModelAst, action) {
         this.extractionDictionary = {};
         this.removeDecoratorsFromModel = removeDecoratorsFromModel;
         this.locale = locale;
         this.dcs_version = dcs_version;
         this.sourceModelAst = sourceModelAst;
         this.updatedModelAst = sourceModelAst;
+        if (action) {
+            if (Object.values(this.Action).includes(action)) {
+                this.action = action;
+            } else {
+                this.action = this.Action.EXTRACT_ALL;
+            }
+        }
+    }
+
+    /**
+     * Returns if the decorator is vocab or not
+     * @param {string} decoractorName - the name of decorator
+     * @returns {boolean} - returns true if the decorator is a vocabulary decorator else false
+     * @private
+     */
+    isVocabDecorator(decoractorName) {
+        const vocabPattern = /^Term_/;
+        return decoractorName === 'Term' || vocabPattern.test(decoractorName);
     }
     /**
     * Adds a key-value pair to a dictionary (object) if the key exists,
@@ -105,18 +131,23 @@ class DecoratorExtractor {
             Object.keys(vocabObject).forEach(decl =>{
                 if (vocabObject[decl].term){
                     strVoc += `  - ${decl}: ${vocabObject[decl].term}\n`;
-                    const otherProps = Object.keys(vocabObject[decl]).filter((str)=>str !== 'term' && str !== 'propertyVocabs');
+                }
+                const otherProps = Object.keys(vocabObject[decl]).filter((str)=>str !== 'term' && str !== 'propertyVocabs');
+                if(otherProps.length > 0){
+                    if (!vocabObject[decl].term){
+                        strVoc += `  - ${decl}: ${decl}\n`;
+                    }
                     otherProps.forEach(key =>{
                         strVoc += `    ${key}: ${vocabObject[decl][key]}\n`;
                     });
                 }
                 if (vocabObject[decl].propertyVocabs && Object.keys(vocabObject[decl].propertyVocabs).length > 0){
-                    if (!vocabObject[decl].term){
+                    if (!vocabObject[decl].term && otherProps.length === 0){
                         strVoc += `  - ${decl}: ${decl}\n`;
                     }
                     strVoc += '    properties:\n';
                     Object.keys(vocabObject[decl].propertyVocabs).forEach(prop =>{
-                        strVoc += `      - ${prop}: ${vocabObject[decl].propertyVocabs[prop].term}\n`;
+                        strVoc += `      - ${prop}: ${vocabObject[decl].propertyVocabs[prop].term || ''}\n`;
                         const otherProps = Object.keys(vocabObject[decl].propertyVocabs[prop]).filter((str)=>str !== 'term');
                         otherProps.forEach(key =>{
                             strVoc += `        ${key}: ${vocabObject[decl].propertyVocabs[prop][key]}\n`;
@@ -227,30 +258,53 @@ class DecoratorExtractor {
         let vocabData = [];
         Object.keys(this.extractionDictionary).forEach(namespace => {
             const jsonData = this.extractionDictionary[namespace];
-            const patternToDetermineVocab = /^Term_/i;
             let dcsObjects = [];
             let vocabObject = {};
             jsonData.forEach(obj =>{
                 const decos = JSON.parse(obj.dcs);
                 const target = this.constructTarget(namespace, obj);
                 decos.forEach(dcs =>{
-                    if (dcs.name !== 'Term' && !patternToDetermineVocab.test(dcs.name)){
+                    const isVocab = this.isVocabDecorator(dcs.name);
+                    if (!isVocab && this.action !== this.Action.EXTRACT_VOCAB){
                         dcsObjects = this.parseNonVocabularyDecorators(dcsObjects, dcs, this.dcs_version, target);
                     }
-                    else {
+                    if (isVocab && this.action !== this.Action.EXTRACT_NON_VOCAB){
                         vocabObject = this.parseVocabularies(vocabObject, obj, dcs);
                     }
                 });
             });
-            decoratorData = this.transformNonVocabularyDecorators(dcsObjects, namespace, decoratorData);
-            vocabData = this.transformVocabularyDecorators(vocabObject, namespace, vocabData);
+            if(this.action !== this.Action.EXTRACT_VOCAB){
+                decoratorData = this.transformNonVocabularyDecorators(dcsObjects, namespace, decoratorData);
+            }
+            if(this.action !== this.Action.EXTRACT_NON_VOCAB){
+                vocabData = this.transformVocabularyDecorators(vocabObject, namespace, vocabData);
+            }
         });
         return {
             decoratorCommandSet: decoratorData,
             vocabularies: vocabData
         };
     }
-
+    /**
+     * Filter vocab or non-vocab decorators
+     * @param {Object} decorators - the collection of decorators
+     * @private
+     */
+    filterDecorators(decorators){
+        if (this.action === this.Action.EXTRACT_ALL){
+            decorators = undefined;
+        }
+        else if(this.action === this.Action.EXTRACT_VOCAB){
+            decorators = decorators.filter((dcs) => {
+                return !this.isVocabDecorator(dcs.name);
+            });
+        }
+        else if(this.action === this.Action.EXTRACT_NON_VOCAB){
+            decorators = decorators.filter((dcs) => {
+                return this.isVocabDecorator(dcs.name);
+            });
+        }
+    }
     /**
     * Process the map declarations to extract the decorators.
     *
@@ -267,9 +321,7 @@ class DecoratorExtractor {
                     mapElement: 'KEY'
                 };
                 this.constructDCSDictionary(namespace, declaration.key.decorators, constructOptions);
-                if (this.removeDecoratorsFromModel){
-                    declaration.key.decorators = undefined;
-                }
+                this.filterDecorators(declaration.key.decorators);
             }
         }
         if (declaration.value){
@@ -279,9 +331,7 @@ class DecoratorExtractor {
                     mapElement: 'VALUE'
                 };
                 this.constructDCSDictionary(namespace, declaration.value.decorators, constructOptions);
-                if (this.removeDecoratorsFromModel){
-                    declaration.value.decorators = undefined;
-                }
+                this.filterDecorators(declaration.value.decorators);
             }
         }
         return declaration;
@@ -304,9 +354,7 @@ class DecoratorExtractor {
                     property: property.name
                 };
                 this.constructDCSDictionary(namespace, property.decorators, constructOptions );
-            }
-            if (this.removeDecoratorsFromModel){
-                property.decorators = undefined;
+                this.filterDecorators(property.decorators);
             }
             return property;
         });
@@ -328,9 +376,7 @@ class DecoratorExtractor {
                     declaration: decl.name,
                 };
                 this.constructDCSDictionary(namespace, decl.decorators, constructOptions);
-            }
-            if (this.removeDecoratorsFromModel){
-                decl.decorators = undefined;
+                this.filterDecorators(decl.decorators);
             }
             if (decl.$class === `${MetaModelNamespace}.MapDeclaration`) {
                 const processedMapDecl = this.processMapDeclaration(decl, namespace);
@@ -354,9 +400,7 @@ class DecoratorExtractor {
         const processedModels = this.sourceModelAst.models.map(model =>{
             if ((model?.decorators.length > 0)){
                 this.constructDCSDictionary(model.namespace, model.decorators, {});
-                if (this.removeDecoratorsFromModel){
-                    model.decorators = undefined;
-                }
+                this.filterDecorators(model.decorators);
             }
             const processedDecl = this.processDeclarations(model.declarations, model.namespace);
             model.declarations = processedDecl;

--- a/packages/concerto-core/lib/decoratormanager.js
+++ b/packages/concerto-core/lib/decoratormanager.js
@@ -424,15 +424,11 @@ class DecoratorManager {
         return newModelManager;
     }
     /**
-     * @typedef decoratorCommandSet
-     * @type {object}
-     * @typedef vocabularies
-     * @type {string}
      * @typedef ExtractDecoratorsResult
      * @type {object}
      * @property {ModelManager} modelManager - A model manager containing models stripped without decorators
-     * @property {decoratorCommandSet} object[] - Stripped out decorators, formed into decorator command sets
-     * @property {vocabularies} object[] - Stripped out vocabularies, formed into vocabulary files
+     * @property {object[]} decoratorCommandSet - Stripped out decorators, formed into decorator command sets
+     * @property {string[]} vocabularies - Stripped out vocabularies, formed into vocabulary files
     */
     /**
      * Extracts all the decorator commands from all the models in modelManager

--- a/packages/concerto-core/lib/decoratormanager.js
+++ b/packages/concerto-core/lib/decoratormanager.js
@@ -461,7 +461,7 @@ class DecoratorManager {
      * @param {string} options.locale - locale for extracted vocabulary set
      * @returns {ExtractDecoratorsResult} - a new model manager with/without the decorators and vocab yamls
      */
-    static extractVocabDecorators(modelManager,options) {
+    static extractVocabularies(modelManager,options) {
         options = {
             removeDecoratorsFromModel: false,
             locale:'en',

--- a/packages/concerto-core/lib/decoratormanager.js
+++ b/packages/concerto-core/lib/decoratormanager.js
@@ -449,7 +449,7 @@ class DecoratorManager {
             ...options
         };
         const sourceAst = modelManager.getAst(true);
-        const decoratorExtrator = new DecoratorExtractor(options.removeDecoratorsFromModel, options.locale, DCS_VERSION, sourceAst);
+        const decoratorExtrator = new DecoratorExtractor(options.removeDecoratorsFromModel, options.locale, DCS_VERSION, sourceAst, DecoratorExtractor.Action.EXTRACT_ALL);
         const collectionResp = decoratorExtrator.extract();
         return {
             modelManager: collectionResp.updatedModelManager,
@@ -457,7 +457,50 @@ class DecoratorManager {
             vocabularies: collectionResp.vocabularies
         };
     }
-
+    /**
+     * Extracts all the vocab decorator commands from all the models in modelManager
+     * @param {ModelManager} modelManager the input model manager
+     * @param {object} options - decorator models options
+     * @param {boolean} options.removeDecoratorsFromModel - flag to strip out vocab decorators from models
+     * @param {string} options.locale - locale for extracted vocabulary set
+     * @returns {ExtractDecoratorsResult} - a new model manager with/without the decorators and vocab yamls
+     */
+    static extractVocabDecorators(modelManager,options) {
+        options = {
+            removeDecoratorsFromModel: false,
+            locale:'en',
+            ...options
+        };
+        const sourceAst = modelManager.getAst(true);
+        const decoratorExtrator = new DecoratorExtractor(options.removeDecoratorsFromModel, options.locale, DCS_VERSION, sourceAst, DecoratorExtractor.Action.EXTRACT_VOCAB);
+        const collectionResp = decoratorExtrator.extract();
+        return {
+            modelManager: collectionResp.updatedModelManager,
+            vocabularies: collectionResp.vocabularies
+        };
+    }
+    /**
+     * Extracts all the non-vocab decorator commands from all the models in modelManager
+     * @param {ModelManager} modelManager the input model manager
+     * @param {object} options - decorator models options
+     * @param {boolean} options.removeDecoratorsFromModel - flag to strip out non-vocab decorators from models
+     * @param {string} options.locale - locale for extracted vocabulary set
+     * @returns {ExtractDecoratorsResult} - a new model manager with/without the decorators and a list of extracted decorator jsons
+     */
+    static extractNonVocabDecorators(modelManager,options) {
+        options = {
+            removeDecoratorsFromModel: false,
+            locale:'en',
+            ...options
+        };
+        const sourceAst = modelManager.getAst(true);
+        const decoratorExtrator = new DecoratorExtractor(options.removeDecoratorsFromModel, options.locale, DCS_VERSION, sourceAst, DecoratorExtractor.Action.EXTRACT_NON_VOCAB);
+        const collectionResp = decoratorExtrator.extract();
+        return {
+            modelManager: collectionResp.updatedModelManager,
+            decoratorCommandSet: collectionResp.decoratorCommandSet
+        };
+    }
     /**
      * Throws an error if the decoractor command is invalid
      * @param {ModelManager} validationModelManager the validation model manager

--- a/packages/concerto-core/lib/decoratormanager.js
+++ b/packages/concerto-core/lib/decoratormanager.js
@@ -427,7 +427,7 @@ class DecoratorManager {
      * @typedef ExtractDecoratorsResult
      * @type {object}
      * @property {ModelManager} modelManager - A model manager containing models stripped without decorators
-     * @property {object[]} decoratorCommandSet - Stripped out decorators, formed into decorator command sets
+     * @property {*} decoratorCommandSet - Stripped out decorators, formed into decorator command sets
      * @property {string[]} vocabularies - Stripped out vocabularies, formed into vocabulary files
     */
     /**

--- a/packages/concerto-core/test/data/decoratorcommands/extract-test-dcs.json
+++ b/packages/concerto-core/test/data/decoratorcommands/extract-test-dcs.json
@@ -1,0 +1,338 @@
+[
+    {
+      "$class": "org.accordproject.decoratorcommands@0.3.0.DecoratorCommandSet",
+      "name": "test",
+      "version": "1.0.0",
+      "commands": [
+        {
+          "$class": "org.accordproject.decoratorcommands@0.3.0.Command",
+          "type": "UPSERT",
+          "target": {
+            "$class": "org.accordproject.decoratorcommands@0.3.0.CommandTarget",
+            "namespace": "test@1.0.0",
+            "declaration": "Dummy"
+          },
+          "decorator": {
+            "$class": "concerto.metamodel@1.0.0.Decorator",
+            "name": "deco"
+          }
+        },
+        {
+          "$class": "org.accordproject.decoratorcommands@0.3.0.Command",
+          "type": "UPSERT",
+          "target": {
+            "$class": "org.accordproject.decoratorcommands@0.3.0.CommandTarget",
+            "namespace": "test@1.0.0",
+            "declaration": "Dummy",
+            "property": "One"
+          },
+          "decorator": {
+            "$class": "concerto.metamodel@1.0.0.Decorator",
+            "name": "one"
+          }
+        },
+        {
+          "$class": "org.accordproject.decoratorcommands@0.3.0.Command",
+          "type": "UPSERT",
+          "target": {
+            "$class": "org.accordproject.decoratorcommands@0.3.0.CommandTarget",
+            "namespace": "test@1.0.0",
+            "declaration": "SSN"
+          },
+          "decorator": {
+            "$class": "concerto.metamodel@1.0.0.Decorator",
+            "name": "scc"
+          }
+        },
+        {
+          "$class": "org.accordproject.decoratorcommands@0.3.0.Command",
+          "type": "UPSERT",
+          "target": {
+            "$class": "org.accordproject.decoratorcommands@0.3.0.CommandTarget",
+            "namespace": "test@1.0.0",
+            "declaration": "participantName"
+          },
+          "decorator": {
+            "$class": "concerto.metamodel@1.0.0.Decorator",
+            "name": "M1"
+          }
+        },
+        {
+          "$class": "org.accordproject.decoratorcommands@0.3.0.Command",
+          "type": "UPSERT",
+          "target": {
+            "$class": "org.accordproject.decoratorcommands@0.3.0.CommandTarget",
+            "namespace": "test@1.0.0",
+            "declaration": "participantName",
+            "property": "participantKey"
+          },
+          "decorator": {
+            "$class": "concerto.metamodel@1.0.0.Decorator",
+            "name": "M3"
+          }
+        },
+        {
+          "$class": "org.accordproject.decoratorcommands@0.3.0.Command",
+          "type": "UPSERT",
+          "target": {
+            "$class": "org.accordproject.decoratorcommands@0.3.0.CommandTarget",
+            "namespace": "test@1.0.0",
+            "declaration": "assetName"
+          },
+          "decorator": {
+            "$class": "concerto.metamodel@1.0.0.Decorator",
+            "name": "Dummy",
+            "arguments": [
+              {
+                "$class": "concerto.metamodel@1.0.0.DecoratorString",
+                "value": "term1"
+              },
+              {
+                "$class": "concerto.metamodel@1.0.0.DecoratorNumber",
+                "value": 2
+              }
+            ]
+          }
+        },
+        {
+          "$class": "org.accordproject.decoratorcommands@0.3.0.Command",
+          "type": "UPSERT",
+          "target": {
+            "$class": "org.accordproject.decoratorcommands@0.3.0.CommandTarget",
+            "namespace": "test@1.0.0",
+            "declaration": "mapName",
+            "mapElement": "KEY"
+          },
+          "decorator": {
+            "$class": "concerto.metamodel@1.0.0.Decorator",
+            "name": "deco",
+            "arguments": [
+              {
+                "$class": "concerto.metamodel@1.0.0.DecoratorNumber",
+                "value": 1
+              }
+            ]
+          }
+        },
+        {
+          "$class": "org.accordproject.decoratorcommands@0.3.0.Command",
+          "type": "UPSERT",
+          "target": {
+            "$class": "org.accordproject.decoratorcommands@0.3.0.CommandTarget",
+            "namespace": "test@1.0.0",
+            "declaration": "Person"
+          },
+          "decorator": {
+            "$class": "concerto.metamodel@1.0.0.Decorator",
+            "name": "Editable"
+          }
+        },
+        {
+          "$class": "org.accordproject.decoratorcommands@0.3.0.Command",
+          "type": "UPSERT",
+          "target": {
+            "$class": "org.accordproject.decoratorcommands@0.3.0.CommandTarget",
+            "namespace": "test@1.0.0",
+            "declaration": "Person",
+            "property": "firstName"
+          },
+          "decorator": {
+            "$class": "concerto.metamodel@1.0.0.Decorator",
+            "name": "Custom"
+          }
+        },
+        {
+          "$class": "org.accordproject.decoratorcommands@0.3.0.Command",
+          "type": "UPSERT",
+          "target": {
+            "$class": "org.accordproject.decoratorcommands@0.3.0.CommandTarget",
+            "namespace": "test@1.0.0",
+            "declaration": "Person",
+            "property": "firstName"
+          },
+          "decorator": {
+            "$class": "concerto.metamodel@1.0.0.Decorator",
+            "name": "Form",
+            "arguments": [
+              {
+                "$class": "concerto.metamodel@1.0.0.DecoratorString",
+                "value": "inputType"
+              },
+              {
+                "$class": "concerto.metamodel@1.0.0.DecoratorString",
+                "value": "text"
+              }
+            ]
+          }
+        },
+        {
+          "$class": "org.accordproject.decoratorcommands@0.3.0.Command",
+          "type": "UPSERT",
+          "target": {
+            "$class": "org.accordproject.decoratorcommands@0.3.0.CommandTarget",
+            "namespace": "test@1.0.0",
+            "declaration": "Person",
+            "property": "firstName"
+          },
+          "decorator": {
+            "$class": "concerto.metamodel@1.0.0.Decorator",
+            "name": "New"
+          }
+        },
+        {
+          "$class": "org.accordproject.decoratorcommands@0.3.0.Command",
+          "type": "UPSERT",
+          "target": {
+            "$class": "org.accordproject.decoratorcommands@0.3.0.CommandTarget",
+            "namespace": "test@1.0.0",
+            "declaration": "Person",
+            "property": "lastName"
+          },
+          "decorator": {
+            "$class": "concerto.metamodel@1.0.0.Decorator",
+            "name": "term",
+            "arguments": [
+              {
+                "$class": "concerto.metamodel@1.0.0.DecoratorString",
+                "value": "custom"
+              }
+            ]
+          }
+        },
+        {
+          "$class": "org.accordproject.decoratorcommands@0.3.0.Command",
+          "type": "UPSERT",
+          "target": {
+            "$class": "org.accordproject.decoratorcommands@0.3.0.CommandTarget",
+            "namespace": "test@1.0.0",
+            "declaration": "Person",
+            "property": "lastName"
+          },
+          "decorator": {
+            "$class": "concerto.metamodel@1.0.0.Decorator",
+            "name": "term_desc",
+            "arguments": [
+              {
+                "$class": "concerto.metamodel@1.0.0.DecoratorString",
+                "value": "custom desc"
+              }
+            ]
+          }
+        },
+        {
+          "$class": "org.accordproject.decoratorcommands@0.3.0.Command",
+          "type": "UPSERT",
+          "target": {
+            "$class": "org.accordproject.decoratorcommands@0.3.0.CommandTarget",
+            "namespace": "test@1.0.0",
+            "declaration": "Person",
+            "property": "lastName"
+          },
+          "decorator": {
+            "$class": "concerto.metamodel@1.0.0.Decorator",
+            "name": "Form",
+            "arguments": [
+              {
+                "$class": "concerto.metamodel@1.0.0.DecoratorString",
+                "value": "inputType"
+              },
+              {
+                "$class": "concerto.metamodel@1.0.0.DecoratorString",
+                "value": "text"
+              }
+            ]
+          }
+        },
+        {
+          "$class": "org.accordproject.decoratorcommands@0.3.0.Command",
+          "type": "UPSERT",
+          "target": {
+            "$class": "org.accordproject.decoratorcommands@0.3.0.CommandTarget",
+            "namespace": "test@1.0.0",
+            "declaration": "Person",
+            "property": "lastName"
+          },
+          "decorator": {
+            "$class": "concerto.metamodel@1.0.0.Decorator",
+            "name": "New"
+          }
+        },
+        {
+          "$class": "org.accordproject.decoratorcommands@0.3.0.Command",
+          "type": "UPSERT",
+          "target": {
+            "$class": "org.accordproject.decoratorcommands@0.3.0.CommandTarget",
+            "namespace": "test@1.0.0",
+            "declaration": "Person",
+            "property": "bio"
+          },
+          "decorator": {
+            "$class": "concerto.metamodel@1.0.0.Decorator",
+            "name": "Form",
+            "arguments": [
+              {
+                "$class": "concerto.metamodel@1.0.0.DecoratorString",
+                "value": "inputType"
+              },
+              {
+                "$class": "concerto.metamodel@1.0.0.DecoratorString",
+                "value": "textArea"
+              }
+            ]
+          }
+        },
+        {
+          "$class": "org.accordproject.decoratorcommands@0.3.0.Command",
+          "type": "UPSERT",
+          "target": {
+            "$class": "org.accordproject.decoratorcommands@0.3.0.CommandTarget",
+            "namespace": "test@1.0.0",
+            "declaration": "Person",
+            "property": "bio"
+          },
+          "decorator": {
+            "$class": "concerto.metamodel@1.0.0.Decorator",
+            "name": "New"
+          }
+        },
+        {
+          "$class": "org.accordproject.decoratorcommands@0.3.0.Command",
+          "type": "UPSERT",
+          "target": {
+            "$class": "org.accordproject.decoratorcommands@0.3.0.CommandTarget",
+            "namespace": "test@1.0.0",
+            "declaration": "Person",
+            "property": "ssn"
+          },
+          "decorator": {
+            "$class": "concerto.metamodel@1.0.0.Decorator",
+            "name": "Form",
+            "arguments": [
+              {
+                "$class": "concerto.metamodel@1.0.0.DecoratorString",
+                "value": "inputType"
+              },
+              {
+                "$class": "concerto.metamodel@1.0.0.DecoratorString",
+                "value": "text"
+              }
+            ]
+          }
+        },
+        {
+          "$class": "org.accordproject.decoratorcommands@0.3.0.Command",
+          "type": "UPSERT",
+          "target": {
+            "$class": "org.accordproject.decoratorcommands@0.3.0.CommandTarget",
+            "namespace": "test@1.0.0",
+            "declaration": "Person",
+            "property": "ssn"
+          },
+          "decorator": {
+            "$class": "concerto.metamodel@1.0.0.Decorator",
+            "name": "New"
+          }
+        }
+      ]
+    }
+  ]

--- a/packages/concerto-core/test/data/decoratorcommands/extract-test-vocab.json
+++ b/packages/concerto-core/test/data/decoratorcommands/extract-test-vocab.json
@@ -1,0 +1,1 @@
+["locale: en\nnamespace: test@1.0.0\ndeclarations:\n  - mapName: Map Name\n    properties:\n      - KEY: some key\n        desc: some key description\n  - Person: Person Class\n    desc: Person Class Description\n    properties:\n      - firstName: HI\n      - bio: some\n        cus: con\n"]

--- a/packages/concerto-core/test/data/decoratorcommands/extract-test.cto
+++ b/packages/concerto-core/test/data/decoratorcommands/extract-test.cto
@@ -18,7 +18,10 @@ asset assetName identified by assetKey {
     o String assetKey
 }
 
+@Term("Map Name")
 map mapName {
+    @Term("some key")
+    @Term_desc("some key description")
     @deco(1)
     o String
     o String
@@ -33,6 +36,8 @@ concept Person {
     @Form("inputType", "text")
     @New
     o String firstName
+    @term("custom")
+    @term_desc("custom desc")
     @Form("inputType", "text")
     @New
     o String lastName

--- a/packages/concerto-core/test/data/decoratorcommands/extract-test.cto
+++ b/packages/concerto-core/test/data/decoratorcommands/extract-test.cto
@@ -25,6 +25,7 @@ map mapName {
 }
 
 @Term("Person Class")
+@Term_desc("Person Class Description")
 @Editable
 concept Person {
     @Term("HI")

--- a/packages/concerto-core/test/decoratormanager.js
+++ b/packages/concerto-core/test/decoratormanager.js
@@ -677,18 +677,20 @@ describe('DecoratorManager', () => {
         it('should be able to extract vocabs from a model', async function() {
             const testModelManager = new ModelManager({strict:true,});
             const modelText = fs.readFileSync(path.join(__dirname,'/data/decoratorcommands/extract-test.cto'), 'utf-8');
+            const expectedVocabs = fs.readFileSync(path.join(__dirname,'/data/decoratorcommands/extract-test-vocab.json'), 'utf-8');
             testModelManager.addCTOModel(modelText, 'test.cto');
             const options = {
                 removeDecoratorsFromModel:true,
                 locale:'en'
             };
-            const resp = DecoratorManager.extractVocabDecorators( testModelManager, options);
+            const resp = DecoratorManager.extractVocabularies( testModelManager, options);
             const vocab = resp.vocabularies;
-            vocab.should.not.be.null;
+            vocab.should.be.deep.equal(JSON.parse(expectedVocabs));
         });
         it('should be able to extract non-vocab decorators from a model', async function() {
             const testModelManager = new ModelManager({strict:true,});
             const modelText = fs.readFileSync(path.join(__dirname,'/data/decoratorcommands/extract-test.cto'), 'utf-8');
+            const expectedDcs = fs.readFileSync(path.join(__dirname,'/data/decoratorcommands/extract-test-dcs.json'), 'utf-8');
             testModelManager.addCTOModel(modelText, 'test.cto');
             const options = {
                 removeDecoratorsFromModel:true,
@@ -696,7 +698,7 @@ describe('DecoratorManager', () => {
             };
             const resp = DecoratorManager.extractNonVocabDecorators( testModelManager, options);
             const dcs = resp.decoratorCommandSet;
-            dcs.should.not.be.null;
+            dcs.should.be.deep.equal(JSON.parse(expectedDcs));
         });
     });
 

--- a/packages/concerto-core/test/decoratormanager.js
+++ b/packages/concerto-core/test/decoratormanager.js
@@ -686,6 +686,7 @@ describe('DecoratorManager', () => {
             const resp = DecoratorManager.extractVocabularies( testModelManager, options);
             const vocab = resp.vocabularies;
             vocab.should.be.deep.equal(JSON.parse(expectedVocabs));
+            vocab[0].should.not.include('custom');
         });
         it('should be able to extract non-vocab decorators from a model', async function() {
             const testModelManager = new ModelManager({strict:true,});
@@ -699,6 +700,7 @@ describe('DecoratorManager', () => {
             const resp = DecoratorManager.extractNonVocabDecorators( testModelManager, options);
             const dcs = resp.decoratorCommandSet;
             dcs.should.be.deep.equal(JSON.parse(expectedDcs));
+            JSON.stringify(dcs).should.include('term_desc');
         });
     });
 

--- a/packages/concerto-core/test/decoratormanager.js
+++ b/packages/concerto-core/test/decoratormanager.js
@@ -600,7 +600,7 @@ describe('DecoratorManager', () => {
     });
 
     describe('#extractDecorators', function() {
-        it('should be able to extract decorators and vocabs from a model withoup options', async function() {
+        it('should be able to extract decorators and vocabs from a model without options', async function() {
             const testModelManager = new ModelManager({strict:true,});
             const modelText = fs.readFileSync(path.join(__dirname,'/data/decoratorcommands/extract-test.cto'), 'utf-8');
             testModelManager.addCTOModel(modelText, 'test.cto');
@@ -673,6 +673,30 @@ describe('DecoratorManager', () => {
             const resp = DecoratorManager.extractDecorators( testModelManager);
             const vocab = resp.vocabularies;
             vocab.should.be.deep.equal([]);
+        });
+        it('should be able to extract vocabs from a model', async function() {
+            const testModelManager = new ModelManager({strict:true,});
+            const modelText = fs.readFileSync(path.join(__dirname,'/data/decoratorcommands/extract-test.cto'), 'utf-8');
+            testModelManager.addCTOModel(modelText, 'test.cto');
+            const options = {
+                removeDecoratorsFromModel:true,
+                locale:'en'
+            };
+            const resp = DecoratorManager.extractVocabDecorators( testModelManager, options);
+            const vocab = resp.vocabularies;
+            vocab.should.not.be.null;
+        });
+        it('should be able to extract non-vocab decorators from a model', async function() {
+            const testModelManager = new ModelManager({strict:true,});
+            const modelText = fs.readFileSync(path.join(__dirname,'/data/decoratorcommands/extract-test.cto'), 'utf-8');
+            testModelManager.addCTOModel(modelText, 'test.cto');
+            const options = {
+                removeDecoratorsFromModel:true,
+                locale:'en'
+            };
+            const resp = DecoratorManager.extractNonVocabDecorators( testModelManager, options);
+            const dcs = resp.decoratorCommandSet;
+            dcs.should.not.be.null;
         });
     });
 

--- a/packages/concerto-vocabulary/lib/vocabulary.js
+++ b/packages/concerto-vocabulary/lib/vocabulary.js
@@ -47,18 +47,11 @@ class Vocabulary {
             throw new Error('Vocabulary object must have declarations');
         }
 
-        if(!voc.locale) {
-            throw new Error('A vocabulary must specify a locale');
-        }
         if(!voc.namespace) {
             throw new Error('A vocabulary must specify a namespace');
         }
 
-        // validate the locale
-        new Intl.Locale(voc.locale);
-        if(voc.locale !== voc.locale.toLowerCase()) {
-            throw new Error('Locale should be lowercase with dashes');
-        }
+        Vocabulary.validateLocale(voc.locale);
 
         this.vocabularyManager = vocabularyManager;
         this.content = voc;
@@ -70,6 +63,37 @@ class Vocabulary {
      */
     getNamespace() {
         return this.content.namespace;
+    }
+
+    /**
+     * Validates a locale
+     * @param {string} locale the locale to validate
+     * @throws {Error} if the locale is invalid
+     * private
+     */
+    static validateLocale(locale) {
+        if(!locale) {
+            throw new Error('A vocabulary must specify a locale');
+        }
+        new Intl.Locale(locale);
+        if(locale !== locale.toLowerCase()) {
+            throw new Error('Locale should be lowercase with dashes');
+        }
+    }
+
+    /**
+     * Returns true if the locale is valid
+     * @param {string} locale the locale to validate
+     * @returns {boolean} true if the locale is valid
+     */
+    static isValidLocale(locale) {
+        try{
+            this.validateLocale(locale);
+        }
+        catch(error){
+            return false;
+        }
+        return true;
     }
 
     /**

--- a/packages/concerto-vocabulary/lib/vocabulary.js
+++ b/packages/concerto-vocabulary/lib/vocabulary.js
@@ -69,7 +69,7 @@ class Vocabulary {
      * Validates a locale
      * @param {string} locale the locale to validate
      * @throws {Error} if the locale is invalid
-     * private
+     * @private
      */
     static validateLocale(locale) {
         if(!locale) {

--- a/packages/concerto-vocabulary/lib/vocabulary.js
+++ b/packages/concerto-vocabulary/lib/vocabulary.js
@@ -51,6 +51,10 @@ class Vocabulary {
             throw new Error('A vocabulary must specify a namespace');
         }
 
+        if(!voc.locale) {
+            throw new Error('A vocabulary must specify a locale');
+        }
+
         Vocabulary.validateLocale(voc.locale);
 
         this.vocabularyManager = vocabularyManager;
@@ -69,31 +73,12 @@ class Vocabulary {
      * Validates a locale
      * @param {string} locale the locale to validate
      * @throws {Error} if the locale is invalid
-     * @private
      */
     static validateLocale(locale) {
-        if(!locale) {
-            throw new Error('A vocabulary must specify a locale');
-        }
         new Intl.Locale(locale);
         if(locale !== locale.toLowerCase()) {
             throw new Error('Locale should be lowercase with dashes');
         }
-    }
-
-    /**
-     * Returns true if the locale is valid
-     * @param {string} locale the locale to validate
-     * @returns {boolean} true if the locale is valid
-     */
-    static isValidLocale(locale) {
-        try{
-            this.validateLocale(locale);
-        }
-        catch(error){
-            return false;
-        }
-        return true;
     }
 
     /**

--- a/packages/concerto-vocabulary/test/vocabulary.js
+++ b/packages/concerto-vocabulary/test/vocabulary.js
@@ -99,4 +99,12 @@ describe('Vocabulary', () => {
         const json = voc.toJSON();
         json.should.not.be.null;
     });
+
+    it('isValidLocale - invalid locale', () => {
+        Vocabulary.isValidLocale('en-US').should.be.false;
+    });
+
+    it('isValidLocale - valid locale', () => {
+        Vocabulary.isValidLocale('en-us').should.be.true;
+    });
 });

--- a/packages/concerto-vocabulary/test/vocabulary.js
+++ b/packages/concerto-vocabulary/test/vocabulary.js
@@ -101,10 +101,10 @@ describe('Vocabulary', () => {
     });
 
     it('isValidLocale - invalid locale', () => {
-        Vocabulary.isValidLocale('en-US').should.be.false;
+        should.Throw(() => Vocabulary.validateLocale('en-US'), Error);
     });
 
     it('isValidLocale - valid locale', () => {
-        Vocabulary.isValidLocale('en-us').should.be.true;
+        should.not.Throw(() => Vocabulary.validateLocale('en-us'), Error);
     });
 });


### PR DESCRIPTION
<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
<!--- # Closes #<CORRESPONDING ISSUE NUMBER -->
<!--- Provide an overall summary of the pull request -->
Added methods to extract vocab/non-vocab decorators, fixed vocabulary parsing bugs, and exposed locale validation method.

### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
- <ONE> Added new methods to extract vocab or non-vocab decorators from model
- <TWO> Fixed some minor bugs related to vocabulary parsing
- <THREE> Exposed method to validate locale

### Flags
<!--- Provide context or concerns a reviewer should be aware of -->

### Screenshots or Video
<!--- Provide an easily accessible demonstration of the changes, if applicable -->

### Related Issues


### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [x] Merging to `main` from `fork:branchname`
