### PR TITLE
fix(dcs): enableMapTypes in internal modelmanagers in dcsmanager

### DIFF
--- a/packages/concerto-core/lib/decoratormanager.js
+++ b/packages/concerto-core/lib/decoratormanager.js
@@ -315,10 +315,12 @@ class DecoratorManager {
         }
 
         if (shouldValidate) {
+            const enableMapType = modelManager?.enableMapType ? true : false;
             const validationModelManager = new ModelManager({
                 strict: true,
                 metamodelValidation: true,
                 addMetamodel: true,
+                enableMapType
             });
             validationModelManager.addModelFiles(modelManager.getModelFiles());
             validationModelManager.addCTOModel(
@@ -419,7 +421,8 @@ class DecoratorManager {
 
             });
         });
-        const newModelManager = new ModelManager();
+        const enableMapType = modelManager?.enableMapType ? true : false;
+        const newModelManager = new ModelManager({ enableMapType });
         newModelManager.fromAst(decoratedAst);
         return newModelManager;
     }

--- a/packages/concerto-core/test/decoratormanager.js
+++ b/packages/concerto-core/test/decoratormanager.js
@@ -302,7 +302,7 @@ describe('DecoratorManager', () => {
 
         it('should decorate the specified MapDeclaration', async function() {
             // load a model to decorate
-            const testModelManager = new ModelManager({strict:true, skipLocationNodes: true});
+            const testModelManager = new ModelManager({strict:true, skipLocationNodes: true, enableMapType: true});
             const modelText = fs.readFileSync(path.join(__dirname,'/data/decoratorcommands/test.cto'), 'utf-8');
             testModelManager.addCTOModel(modelText, 'test.cto');
 


### PR DESCRIPTION
<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #<CORRESPONDING ISSUE NUMBER>
<!--- Provide an overall summary of the pull request -->
If we pass a model manager which has maptype enabled to dcs manager's decorate method we need the new model managers generated and used inside the decorate and validate methods of dcs managers to enable map types as well.

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [x] Extend the documentation, if necessary
- [x] Merging to `main` from `fork:branchname`
