### PR TITLE
fix(vocabulary): ignore empty terms

### DIFF
--- a/packages/concerto-core/test/data/decoratorcommands/invalid-null-argument-value.json
+++ b/packages/concerto-core/test/data/decoratorcommands/invalid-null-argument-value.json
@@ -1,6 +1,6 @@
 {
     "$class" : "org.accordproject.decoratorcommands@0.3.0.DecoratorCommandSet",
-    "name" : "invalid-null-argument",
+    "name" : "invalid-null-argument-value",
     "version": "1.0.0",
     "commands" : [
         {
@@ -13,7 +13,12 @@
             "decorator" : {
                 "$class" : "concerto.metamodel@1.0.0.Decorator",
                 "name" : "Test",
-                "arguments" : [null]
+                "arguments" : [
+                    {
+                        "$class": "concerto.metamodel@1.0.0.DecoratorString",
+                        "value": null
+                    }
+                ]
             }
         }
     ]

--- a/packages/concerto-core/test/data/decoratorcommands/invalid-null-argument.json
+++ b/packages/concerto-core/test/data/decoratorcommands/invalid-null-argument.json
@@ -1,0 +1,25 @@
+{
+    "$class" : "org.accordproject.decoratorcommands@0.3.0.DecoratorCommandSet",
+    "name" : "invalid-null-argument",
+    "version": "1.0.0",
+    "commands" : [
+        {
+            "$class" : "org.accordproject.decoratorcommands@0.3.0.Command",
+            "type" : "UPSERT",
+            "target" : {
+                "$class" : "org.accordproject.decoratorcommands@0.3.0.CommandTarget",
+                "namespace" : "test@1.0.0",
+                "declaration" : "Person"            },
+            "decorator" : {
+                "$class" : "concerto.metamodel@1.0.0.Decorator",
+                "name" : "Test",
+                "arguments" : [
+                    {
+                        "$class": "concerto.metamodel@1.0.0.DecoratorString",
+                        "value": null
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/packages/concerto-core/test/decoratormanager.js
+++ b/packages/concerto-core/test/decoratormanager.js
@@ -91,7 +91,7 @@ describe('DecoratorManager', () => {
             }).should.throw(/Invalid JSON data/);
         });
 
-        it.only('should not validate a command with null decorator arg value', async function () {
+        it('should not validate a command with null decorator arg', async function () {
             // load a model to decorate
             const testModelManager = new ModelManager({ strict: true, skipLocationNodes: true });
             const modelText = fs.readFileSync(path.join(__dirname, '/data/decoratorcommands/test.cto'), 'utf-8');
@@ -100,8 +100,21 @@ describe('DecoratorManager', () => {
             (() => {
                 DecoratorManager.decorateModels(testModelManager, JSON.parse(dcs),
                     { validate: true });
+            }).should.throw(/Cannot read properties of null/);
+        });
+
+        it('should not validate a command with null decorator arg value', async function () {
+            // load a model to decorate
+            const testModelManager = new ModelManager({ strict: true, skipLocationNodes: true });
+            const modelText = fs.readFileSync(path.join(__dirname, '/data/decoratorcommands/test.cto'), 'utf-8');
+            testModelManager.addCTOModel(modelText, 'test.cto');
+            const dcs = fs.readFileSync(path.join(__dirname, '/data/decoratorcommands/invalid-null-argument-value.json'), 'utf-8');
+            (() => {
+                DecoratorManager.decorateModels(testModelManager, JSON.parse(dcs),
+                    { validate: true });
             }).should.throw(/The instance "concerto.metamodel@1.0.0.DecoratorString" is missing the required field "value"/);
         });
+
     });
 
     describe('#decorateModels', function () {

--- a/packages/concerto-core/test/decoratormanager.js
+++ b/packages/concerto-core/test/decoratormanager.js
@@ -18,8 +18,8 @@ const fs = require('fs');
 const path = require('path');
 const DecoratorManager = require('../lib/decoratormanager');
 const ModelManager = require('../lib/modelmanager');
-const VocabularyManager= require('../../concerto-vocabulary/lib/vocabularymanager');
-const Printer= require('../../concerto-cto/lib/printer');
+const VocabularyManager = require('../../concerto-vocabulary/lib/vocabularymanager');
+const Printer = require('../../concerto-cto/lib/printer');
 
 const chai = require('chai');
 const { DEPRECATION_WARNING, CONCERTO_DEPRECATION_001 } = require('@accordproject/concerto-util/lib/errorcodes');
@@ -36,114 +36,126 @@ describe('DecoratorManager', () => {
     afterEach(() => {
     });
 
-    describe('#falsyOrEqual', function() {
-        it('should match null', async function() {
-            DecoratorManager.falsyOrEqual( null, ['one']).should.be.true;
+    describe('#falsyOrEqual', function () {
+        it('should match null', async function () {
+            DecoratorManager.falsyOrEqual(null, ['one']).should.be.true;
         });
 
-        it('should match undefined', async function() {
-            DecoratorManager.falsyOrEqual( undefined, ['one']).should.be.true;
+        it('should match undefined', async function () {
+            DecoratorManager.falsyOrEqual(undefined, ['one']).should.be.true;
         });
 
-        it('should match token', async function() {
-            DecoratorManager.falsyOrEqual( 'one', ['one']).should.be.true;
+        it('should match token', async function () {
+            DecoratorManager.falsyOrEqual('one', ['one']).should.be.true;
         });
 
-        it('should match token array', async function() {
-            DecoratorManager.falsyOrEqual( ['one', 'two'], ['one', 'three']).should.be.true;
+        it('should match token array', async function () {
+            DecoratorManager.falsyOrEqual(['one', 'two'], ['one', 'three']).should.be.true;
         });
 
-        it('should match token', async function() {
-            DecoratorManager.falsyOrEqual( 'one', ['one']).should.be.true;
+        it('should match token', async function () {
+            DecoratorManager.falsyOrEqual('one', ['one']).should.be.true;
         });
 
-        it('should not match token', async function() {
-            DecoratorManager.falsyOrEqual( 'one', ['two']).should.be.false;
+        it('should not match token', async function () {
+            DecoratorManager.falsyOrEqual('one', ['two']).should.be.false;
         });
     });
 
-    describe('#validate', function() {
-        it('should support syntax validation', async function() {
-            const dcs = fs.readFileSync(path.join(__dirname,'/data/decoratorcommands/web.json'), 'utf-8');
-            const validationModelManager = DecoratorManager.validate( JSON.parse(dcs));
+    describe('#validate', function () {
+        it('should support syntax validation', async function () {
+            const dcs = fs.readFileSync(path.join(__dirname, '/data/decoratorcommands/web.json'), 'utf-8');
+            const validationModelManager = DecoratorManager.validate(JSON.parse(dcs));
             validationModelManager.should.not.be.null;
         });
 
-        it('should support syntax validation with model files', async function() {
-            const testModelManager = new ModelManager({strict:true});
-            const modelText = fs.readFileSync(path.join(__dirname,'/data/decoratorcommands/test.cto'), 'utf-8');
+        it('should support syntax validation with model files', async function () {
+            const testModelManager = new ModelManager({ strict: true });
+            const modelText = fs.readFileSync(path.join(__dirname, '/data/decoratorcommands/test.cto'), 'utf-8');
             testModelManager.addCTOModel(modelText, 'test.cto');
-            const dcs = fs.readFileSync(path.join(__dirname,'/data/decoratorcommands/web.json'), 'utf-8');
+            const dcs = fs.readFileSync(path.join(__dirname, '/data/decoratorcommands/web.json'), 'utf-8');
             const validationModelManager = DecoratorManager.validate(JSON.parse(dcs), testModelManager.getModelFiles());
             validationModelManager.should.not.be.null;
             validationModelManager.getType('test@1.0.0.Person').should.not.be.null;
         });
 
-        it('should fail syntax validation', async function() {
+        it('should fail syntax validation', async function () {
             (() => {
-                DecoratorManager.validate( { $class: 'invalid' });
+                DecoratorManager.validate({ $class: 'invalid' });
             }).should.throw(/Namespace is not defined for type/);
         });
 
-        it('should fail syntax validation', async function() {
+        it('should fail syntax validation', async function () {
             (() => {
-                DecoratorManager.validate( { invalid: true });
+                DecoratorManager.validate({ invalid: true });
             }).should.throw(/Invalid JSON data/);
+        });
+
+        it.only('should not validate a command with null decorator arg value', async function () {
+            // load a model to decorate
+            const testModelManager = new ModelManager({ strict: true, skipLocationNodes: true });
+            const modelText = fs.readFileSync(path.join(__dirname, '/data/decoratorcommands/test.cto'), 'utf-8');
+            testModelManager.addCTOModel(modelText, 'test.cto');
+            const dcs = fs.readFileSync(path.join(__dirname, '/data/decoratorcommands/invalid-null-argument.json'), 'utf-8');
+            (() => {
+                DecoratorManager.decorateModels(testModelManager, JSON.parse(dcs),
+                    { validate: true });
+            }).should.throw(/The instance "concerto.metamodel@1.0.0.DecoratorString" is missing the required field "value"/);
         });
     });
 
-    describe('#decorateModels', function() {
-        it('should produce same result for test.cto model', async function() {
-            const testModelManager = new ModelManager({strict:true});
-            const modelText = fs.readFileSync(path.join(__dirname,'/data/decoratorcommands/test.cto'), 'utf-8');
+    describe('#decorateModels', function () {
+        it('should produce same result for test.cto model', async function () {
+            const testModelManager = new ModelManager({ strict: true });
+            const modelText = fs.readFileSync(path.join(__dirname, '/data/decoratorcommands/test.cto'), 'utf-8');
             testModelManager.addCTOModel(modelText, 'test.cto');
-            const dcs = fs.readFileSync(path.join(__dirname,'/data/decoratorcommands/possible-decorator-command-targets.json'), 'utf-8');
-            let decoratedModelManager = DecoratorManager.decorateModels( testModelManager, JSON.parse(dcs), {validate: true, validateCommands: true});
+            const dcs = fs.readFileSync(path.join(__dirname, '/data/decoratorcommands/possible-decorator-command-targets.json'), 'utf-8');
+            let decoratedModelManager = DecoratorManager.decorateModels(testModelManager, JSON.parse(dcs), { validate: true, validateCommands: true });
             const decoratedAst = decoratedModelManager.getModelFile('test@1.0.0').getAst();
             const decoratedCTO = Printer.toCTO(decoratedAst);
-            const decoratedTest = fs.readFileSync(path.join(__dirname,'/data/decoratorcommands/decoratedTest.cto'), 'utf-8');
+            const decoratedTest = fs.readFileSync(path.join(__dirname, '/data/decoratorcommands/decoratedTest.cto'), 'utf-8');
             const result = decoratedCTO === decoratedTest;
             chai.expect(result).to.be.true;
         });
 
-        it('should support no validation', async function() {
-            const testModelManager = new ModelManager({strict:true});
-            const modelText = fs.readFileSync(path.join(__dirname,'/data/decoratorcommands/test.cto'), 'utf-8');
+        it('should support no validation', async function () {
+            const testModelManager = new ModelManager({ strict: true });
+            const modelText = fs.readFileSync(path.join(__dirname, '/data/decoratorcommands/test.cto'), 'utf-8');
             testModelManager.addCTOModel(modelText, 'test.cto');
-            const dcs = fs.readFileSync(path.join(__dirname,'/data/decoratorcommands/web.json'), 'utf-8');
-            let decoratedModelManager = DecoratorManager.decorateModels( testModelManager, JSON.parse(dcs));
+            const dcs = fs.readFileSync(path.join(__dirname, '/data/decoratorcommands/web.json'), 'utf-8');
+            let decoratedModelManager = DecoratorManager.decorateModels(testModelManager, JSON.parse(dcs));
             decoratedModelManager.should.not.be.null;
         });
 
-        it('should support syntax validation', async function() {
-            const testModelManager = new ModelManager({strict:true});
-            const modelText = fs.readFileSync(path.join(__dirname,'/data/decoratorcommands/test.cto'), 'utf-8');
+        it('should support syntax validation', async function () {
+            const testModelManager = new ModelManager({ strict: true });
+            const modelText = fs.readFileSync(path.join(__dirname, '/data/decoratorcommands/test.cto'), 'utf-8');
             testModelManager.addCTOModel(modelText, 'test.cto');
-            const dcs = fs.readFileSync(path.join(__dirname,'/data/decoratorcommands/web.json'), 'utf-8');
-            let decoratedModelManager = DecoratorManager.decorateModels( testModelManager, JSON.parse(dcs),
-                {validate: true});
+            const dcs = fs.readFileSync(path.join(__dirname, '/data/decoratorcommands/web.json'), 'utf-8');
+            let decoratedModelManager = DecoratorManager.decorateModels(testModelManager, JSON.parse(dcs),
+                { validate: true });
             decoratedModelManager.should.not.be.null;
         });
 
-        it('should support semantic validation', async function() {
-            const testModelManager = new ModelManager({strict:true});
-            const modelText = fs.readFileSync(path.join(__dirname,'/data/decoratorcommands/test.cto'), 'utf-8');
+        it('should support semantic validation', async function () {
+            const testModelManager = new ModelManager({ strict: true });
+            const modelText = fs.readFileSync(path.join(__dirname, '/data/decoratorcommands/test.cto'), 'utf-8');
             testModelManager.addCTOModel(modelText, 'test.cto');
-            const dcs = fs.readFileSync(path.join(__dirname,'/data/decoratorcommands/web.json'), 'utf-8');
-            let decoratedModelManager = DecoratorManager.decorateModels( testModelManager, JSON.parse(dcs),
-                {validate: true, validateCommands: true});
+            const dcs = fs.readFileSync(path.join(__dirname, '/data/decoratorcommands/web.json'), 'utf-8');
+            let decoratedModelManager = DecoratorManager.decorateModels(testModelManager, JSON.parse(dcs),
+                { validate: true, validateCommands: true });
             decoratedModelManager.should.not.be.null;
         });
 
-        it('should add decorators that target declarations', async function() {
+        it('should add decorators that target declarations', async function () {
             // load a model to decorate
-            const testModelManager = new ModelManager({strict:true});
-            const modelText = fs.readFileSync(path.join(__dirname,'/data/decoratorcommands/test.cto'), 'utf-8');
+            const testModelManager = new ModelManager({ strict: true });
+            const modelText = fs.readFileSync(path.join(__dirname, '/data/decoratorcommands/test.cto'), 'utf-8');
             testModelManager.addCTOModel(modelText, 'test.cto');
 
-            const dcs = fs.readFileSync(path.join(__dirname,'/data/decoratorcommands/web.json'), 'utf-8');
-            const decoratedModelManager = DecoratorManager.decorateModels( testModelManager, JSON.parse(dcs),
-                {validate: true, validateCommands: true});
+            const dcs = fs.readFileSync(path.join(__dirname, '/data/decoratorcommands/web.json'), 'utf-8');
+            const decoratedModelManager = DecoratorManager.decorateModels(testModelManager, JSON.parse(dcs),
+                { validate: true, validateCommands: true });
 
             const ssnDecl = decoratedModelManager.getType('test@1.0.0.SSN');
             ssnDecl.should.not.be.null;
@@ -158,7 +170,7 @@ describe('DecoratorManager', () => {
         This test is target to the functionality wherein if there exists a namespace targeted decorator, it applies the decorator to
         all the declarations within the namespace, which has been identified as bug and will be deprecated.
         */
-        it('should add decorators that target namespace and catch warning - behaviour to be deprecated', async function() {
+        it('should add decorators that target namespace and catch warning - behaviour to be deprecated', async function () {
             // event listner to catch the warning
             process.once('warning', (warning) => {
                 chai.expect(warning.message).to.be.equals('DEPRECATED: Functionality for namespace targeted Decorator Command Sets has beed changed. Using namespace targets to apply decorators on all declarations in a namespace will be deprecated soon.');
@@ -167,13 +179,13 @@ describe('DecoratorManager', () => {
                 chai.expect(warning.detail).to.be.equals('Please refer to https://concerto.accordproject.org/deprecation/001');
             });
             // load a model to decorate
-            const testModelManager = new ModelManager({strict:true});
-            const modelText = fs.readFileSync(path.join(__dirname,'/data/decoratorcommands/test.cto'), 'utf-8');
+            const testModelManager = new ModelManager({ strict: true });
+            const modelText = fs.readFileSync(path.join(__dirname, '/data/decoratorcommands/test.cto'), 'utf-8');
             testModelManager.addCTOModel(modelText, 'test.cto');
 
-            const dcs = fs.readFileSync(path.join(__dirname,'/data/decoratorcommands/web.json'), 'utf-8');
-            const decoratedModelManager = DecoratorManager.decorateModels( testModelManager, JSON.parse(dcs),
-                {validate: true, validateCommands: true});
+            const dcs = fs.readFileSync(path.join(__dirname, '/data/decoratorcommands/web.json'), 'utf-8');
+            const decoratedModelManager = DecoratorManager.decorateModels(testModelManager, JSON.parse(dcs),
+                { validate: true, validateCommands: true });
 
             const modelFile = decoratedModelManager.getModelFile('test@1.0.0');
             modelFile.should.not.be.null;
@@ -192,16 +204,16 @@ describe('DecoratorManager', () => {
         This test is target to the functionality wherein if there exists a namespace targeted decorator, it applies the decorator to the
         namespace, which is the new feature added can be accessed using the feature flag: ENABLE_DCS_NAMESPACE_TARGET.
         */
-        it('should add decorators that target namespace - updated behaviour using environment variable', async function() {
+        it('should add decorators that target namespace - updated behaviour using environment variable', async function () {
             process.env.ENABLE_DCS_NAMESPACE_TARGET = 'true';
             // load a model to decorate
-            const testModelManager = new ModelManager({strict:true});
-            const modelText = fs.readFileSync(path.join(__dirname,'/data/decoratorcommands/test.cto'), 'utf-8');
+            const testModelManager = new ModelManager({ strict: true });
+            const modelText = fs.readFileSync(path.join(__dirname, '/data/decoratorcommands/test.cto'), 'utf-8');
             testModelManager.addCTOModel(modelText, 'test.cto');
 
-            const dcs = fs.readFileSync(path.join(__dirname,'/data/decoratorcommands/web.json'), 'utf-8');
-            const decoratedModelManager = DecoratorManager.decorateModels( testModelManager, JSON.parse(dcs),
-                {validate: true, validateCommands: true});
+            const dcs = fs.readFileSync(path.join(__dirname, '/data/decoratorcommands/web.json'), 'utf-8');
+            const decoratedModelManager = DecoratorManager.decorateModels(testModelManager, JSON.parse(dcs),
+                { validate: true, validateCommands: true });
 
             const modelFile = decoratedModelManager.getModelFile('test@1.0.0');
             modelFile.should.not.be.null;
@@ -217,15 +229,15 @@ describe('DecoratorManager', () => {
         This test is target to the functionality wherein if there exists a namespace targeted decorator, it applies the decorator to the
         namespace, which is the new feature added can be accessed using the option parameter: enableDcsNamespaceTarget.
         */
-        it('should add decorators that target namespace - updated behaviour using options parameter', async function() {
+        it('should add decorators that target namespace - updated behaviour using options parameter', async function () {
             // load a model to decorate
-            const testModelManager = new ModelManager({strict:true});
-            const modelText = fs.readFileSync(path.join(__dirname,'/data/decoratorcommands/test.cto'), 'utf-8');
+            const testModelManager = new ModelManager({ strict: true });
+            const modelText = fs.readFileSync(path.join(__dirname, '/data/decoratorcommands/test.cto'), 'utf-8');
             testModelManager.addCTOModel(modelText, 'test.cto');
 
-            const dcs = fs.readFileSync(path.join(__dirname,'/data/decoratorcommands/web.json'), 'utf-8');
-            const decoratedModelManager = DecoratorManager.decorateModels( testModelManager, JSON.parse(dcs),
-                {validate: true, validateCommands: true, enableDcsNamespaceTarget: true});
+            const dcs = fs.readFileSync(path.join(__dirname, '/data/decoratorcommands/web.json'), 'utf-8');
+            const decoratedModelManager = DecoratorManager.decorateModels(testModelManager, JSON.parse(dcs),
+                { validate: true, validateCommands: true, enableDcsNamespaceTarget: true });
 
             const modelFile = decoratedModelManager.getModelFile('test@1.0.0');
             modelFile.should.not.be.null;
@@ -236,15 +248,15 @@ describe('DecoratorManager', () => {
             chai.expect(ssnDecl.getDecorator('IsValid')).to.be.null;
         });
 
-        it('should add decorators that target properties', async function() {
+        it('should add decorators that target properties', async function () {
             // load a model to decorate
-            const testModelManager = new ModelManager({strict:true});
-            const modelText = fs.readFileSync(path.join(__dirname,'/data/decoratorcommands/test.cto'), 'utf-8');
+            const testModelManager = new ModelManager({ strict: true });
+            const modelText = fs.readFileSync(path.join(__dirname, '/data/decoratorcommands/test.cto'), 'utf-8');
             testModelManager.addCTOModel(modelText, 'test.cto');
 
-            const dcs = fs.readFileSync(path.join(__dirname,'/data/decoratorcommands/web.json'), 'utf-8');
-            const decoratedModelManager = DecoratorManager.decorateModels( testModelManager, JSON.parse(dcs),
-                {validate: true, validateCommands: true});
+            const dcs = fs.readFileSync(path.join(__dirname, '/data/decoratorcommands/web.json'), 'utf-8');
+            const decoratedModelManager = DecoratorManager.decorateModels(testModelManager, JSON.parse(dcs),
+                { validate: true, validateCommands: true });
 
             const decl = decoratedModelManager.getType('test@1.0.0.Person');
             decl.should.not.be.null;
@@ -291,7 +303,7 @@ describe('DecoratorManager', () => {
             const zipProperty = decl.getProperty('zip');
             zipProperty.should.not.be.null;
             const decoratorZipProperty = zipProperty.getDecorator('Address');
-            (decoratorZipProperty ===null).should.be.true;
+            (decoratorZipProperty === null).should.be.true;
 
             // applied using properties, no type
             const cityProperty = decl.getProperty('city');
@@ -300,30 +312,30 @@ describe('DecoratorManager', () => {
             decoratorCity2Property.should.not.be.null;
         });
 
-        it('should decorate the specified MapDeclaration', async function() {
+        it('should decorate the specified MapDeclaration', async function () {
             // load a model to decorate
-            const testModelManager = new ModelManager({strict:true, skipLocationNodes: true});
-            const modelText = fs.readFileSync(path.join(__dirname,'/data/decoratorcommands/test.cto'), 'utf-8');
+            const testModelManager = new ModelManager({ strict: true, skipLocationNodes: true });
+            const modelText = fs.readFileSync(path.join(__dirname, '/data/decoratorcommands/test.cto'), 'utf-8');
             testModelManager.addCTOModel(modelText, 'test.cto');
 
-            const dcs = fs.readFileSync(path.join(__dirname,'/data/decoratorcommands/map-declaration.json'), 'utf-8');
-            const decoratedModelManager = DecoratorManager.decorateModels( testModelManager, JSON.parse(dcs),
-                {validate: true, validateCommands: true});
+            const dcs = fs.readFileSync(path.join(__dirname, '/data/decoratorcommands/map-declaration.json'), 'utf-8');
+            const decoratedModelManager = DecoratorManager.decorateModels(testModelManager, JSON.parse(dcs),
+                { validate: true, validateCommands: true });
 
             const dictionary = decoratedModelManager.getType('test@1.0.0.Dictionary');
             dictionary.should.not.be.null;
             dictionary.getDecorator('MapDeclarationDecorator').should.not.be.null;
         });
 
-        it('should decorate the specified element on the specified Map Declaration (Map Key)', async function() {
+        it('should decorate the specified element on the specified Map Declaration (Map Key)', async function () {
             // load a model to decorate
-            const testModelManager = new ModelManager({strict:true, skipLocationNodes: true});
-            const modelText = fs.readFileSync(path.join(__dirname,'/data/decoratorcommands/test.cto'), 'utf-8');
+            const testModelManager = new ModelManager({ strict: true, skipLocationNodes: true });
+            const modelText = fs.readFileSync(path.join(__dirname, '/data/decoratorcommands/test.cto'), 'utf-8');
             testModelManager.addCTOModel(modelText, 'test.cto');
 
-            const dcs = fs.readFileSync(path.join(__dirname,'/data/decoratorcommands/map-declaration.json'), 'utf-8');
-            const decoratedModelManager = DecoratorManager.decorateModels( testModelManager, JSON.parse(dcs),
-                {validate: true, validateCommands: true});
+            const dcs = fs.readFileSync(path.join(__dirname, '/data/decoratorcommands/map-declaration.json'), 'utf-8');
+            const decoratedModelManager = DecoratorManager.decorateModels(testModelManager, JSON.parse(dcs),
+                { validate: true, validateCommands: true });
 
             const dictionary = decoratedModelManager.getType('test@1.0.0.Dictionary');
             dictionary.should.not.be.null;
@@ -331,15 +343,15 @@ describe('DecoratorManager', () => {
             dictionary.key.getDecorator('Qux').should.not.be.null;
         });
 
-        it('should auto upgrade decoratorcommands $class minor version if it is below DCS_VERSION (asserts decorators are correctly applied)', async function() {
+        it('should auto upgrade decoratorcommands $class minor version if it is below DCS_VERSION (asserts decorators are correctly applied)', async function () {
             // load a model to decorate
-            const testModelManager = new ModelManager({strict:true, skipLocationNodes: true});
-            const modelText = fs.readFileSync(path.join(__dirname,'/data/decoratorcommands/test.cto'), 'utf-8');
+            const testModelManager = new ModelManager({ strict: true, skipLocationNodes: true });
+            const modelText = fs.readFileSync(path.join(__dirname, '/data/decoratorcommands/test.cto'), 'utf-8');
             testModelManager.addCTOModel(modelText, 'test.cto');
 
-            const dcs = fs.readFileSync(path.join(__dirname,'/data/decoratorcommands/incompatible_version_dcs.json'), 'utf-8');
-            const decoratedModelManager = DecoratorManager.decorateModels( testModelManager, JSON.parse(dcs),
-                {validate: true, validateCommands: true, migrate: true});
+            const dcs = fs.readFileSync(path.join(__dirname, '/data/decoratorcommands/incompatible_version_dcs.json'), 'utf-8');
+            const decoratedModelManager = DecoratorManager.decorateModels(testModelManager, JSON.parse(dcs),
+                { validate: true, validateCommands: true, migrate: true });
 
             const dictionary = decoratedModelManager.getType('test@1.0.0.Dictionary');
             dictionary.should.not.be.null;
@@ -348,13 +360,13 @@ describe('DecoratorManager', () => {
         });
 
 
-        it('should auto upgrade decoratorcommands $class minor version if it is below DCS_VERSION (asserts correct upgrade on DCS $class properties)', async function() {
+        it('should auto upgrade decoratorcommands $class minor version if it is below DCS_VERSION (asserts correct upgrade on DCS $class properties)', async function () {
             // load a model to decorate
-            const testModelManager = new ModelManager({strict:true, skipLocationNodes: true});
-            const modelText = fs.readFileSync(path.join(__dirname,'/data/decoratorcommands/test.cto'), 'utf-8');
+            const testModelManager = new ModelManager({ strict: true, skipLocationNodes: true });
+            const modelText = fs.readFileSync(path.join(__dirname, '/data/decoratorcommands/test.cto'), 'utf-8');
             testModelManager.addCTOModel(modelText, 'test.cto');
 
-            let dcs = fs.readFileSync(path.join(__dirname,'/data/decoratorcommands/incompatible_version_dcs.json'), 'utf-8');
+            let dcs = fs.readFileSync(path.join(__dirname, '/data/decoratorcommands/incompatible_version_dcs.json'), 'utf-8');
             dcs = DecoratorManager.migrateTo(JSON.parse(dcs), '0.3.0');
 
             dcs.$class.should.equal('org.accordproject.decoratorcommands@0.3.0.DecoratorCommandSet');
@@ -364,30 +376,30 @@ describe('DecoratorManager', () => {
             dcs.commands[0].decorator.$class.should.equal('concerto.metamodel@1.0.0.Decorator'); // concerto metamodel $class does not change
         });
 
-        it('should decorate the specified type on the specified Map Declaration (Map Key)', async function() {
+        it('should decorate the specified type on the specified Map Declaration (Map Key)', async function () {
             // load a model to decorate
-            const testModelManager = new ModelManager({strict:true, skipLocationNodes: true});
-            const modelText = fs.readFileSync(path.join(__dirname,'/data/decoratorcommands/test.cto'), 'utf-8');
+            const testModelManager = new ModelManager({ strict: true, skipLocationNodes: true });
+            const modelText = fs.readFileSync(path.join(__dirname, '/data/decoratorcommands/test.cto'), 'utf-8');
             testModelManager.addCTOModel(modelText, 'test.cto');
 
-            const dcs = fs.readFileSync(path.join(__dirname,'/data/decoratorcommands/map-declaration.json'), 'utf-8');
-            const decoratedModelManager = DecoratorManager.decorateModels( testModelManager, JSON.parse(dcs),
-                {validate: true, validateCommands: true});
+            const dcs = fs.readFileSync(path.join(__dirname, '/data/decoratorcommands/map-declaration.json'), 'utf-8');
+            const decoratedModelManager = DecoratorManager.decorateModels(testModelManager, JSON.parse(dcs),
+                { validate: true, validateCommands: true });
 
             const dictionary = decoratedModelManager.getType('test@1.0.0.Dictionary');
             dictionary.should.not.be.null;
             dictionary.key.getDecorator('DecoratesKeyByType').should.not.be.null;
         });
 
-        it('should decorate the specified element on the specified Map Declaration (Map Value)', async function() {
+        it('should decorate the specified element on the specified Map Declaration (Map Value)', async function () {
             // load a model to decorate
-            const testModelManager = new ModelManager({strict:true, skipLocationNodes: true});
-            const modelText = fs.readFileSync(path.join(__dirname,'/data/decoratorcommands/test.cto'), 'utf-8');
+            const testModelManager = new ModelManager({ strict: true, skipLocationNodes: true });
+            const modelText = fs.readFileSync(path.join(__dirname, '/data/decoratorcommands/test.cto'), 'utf-8');
             testModelManager.addCTOModel(modelText, 'test.cto');
 
-            const dcs = fs.readFileSync(path.join(__dirname,'/data/decoratorcommands/map-declaration.json'), 'utf-8');
-            const decoratedModelManager = DecoratorManager.decorateModels( testModelManager, JSON.parse(dcs),
-                {validate: true, validateCommands: true});
+            const dcs = fs.readFileSync(path.join(__dirname, '/data/decoratorcommands/map-declaration.json'), 'utf-8');
+            const decoratedModelManager = DecoratorManager.decorateModels(testModelManager, JSON.parse(dcs),
+                { validate: true, validateCommands: true });
 
             const dictionary = decoratedModelManager.getType('test@1.0.0.Dictionary');
 
@@ -396,30 +408,30 @@ describe('DecoratorManager', () => {
             dictionary.value.getDecorator('Quux').should.not.be.null;
         });
 
-        it('should decorate the specified type on the specified Map Declaration (Map Value)', async function() {
+        it('should decorate the specified type on the specified Map Declaration (Map Value)', async function () {
             // load a model to decorate
-            const testModelManager = new ModelManager({strict:true, skipLocationNodes: true});
-            const modelText = fs.readFileSync(path.join(__dirname,'/data/decoratorcommands/test.cto'), 'utf-8');
+            const testModelManager = new ModelManager({ strict: true, skipLocationNodes: true });
+            const modelText = fs.readFileSync(path.join(__dirname, '/data/decoratorcommands/test.cto'), 'utf-8');
             testModelManager.addCTOModel(modelText, 'test.cto');
 
-            const dcs = fs.readFileSync(path.join(__dirname,'/data/decoratorcommands/map-declaration.json'), 'utf-8');
-            const decoratedModelManager = DecoratorManager.decorateModels( testModelManager, JSON.parse(dcs),
-                {validate: true, validateCommands: true});
+            const dcs = fs.readFileSync(path.join(__dirname, '/data/decoratorcommands/map-declaration.json'), 'utf-8');
+            const decoratedModelManager = DecoratorManager.decorateModels(testModelManager, JSON.parse(dcs),
+                { validate: true, validateCommands: true });
 
             const dictionary = decoratedModelManager.getType('test@1.0.0.Dictionary');
             dictionary.should.not.be.null;
             dictionary.value.getDecorator('DecoratesValueByType').should.not.be.null;
         });
 
-        it('should decorate Declaration, Key and Value elements on the specified Map Declaration', async function() {
+        it('should decorate Declaration, Key and Value elements on the specified Map Declaration', async function () {
             // load a model to decorate
-            const testModelManager = new ModelManager({strict:true, skipLocationNodes: true});
-            const modelText = fs.readFileSync(path.join(__dirname,'/data/decoratorcommands/test.cto'), 'utf-8');
+            const testModelManager = new ModelManager({ strict: true, skipLocationNodes: true });
+            const modelText = fs.readFileSync(path.join(__dirname, '/data/decoratorcommands/test.cto'), 'utf-8');
             testModelManager.addCTOModel(modelText, 'test.cto');
 
-            const dcs = fs.readFileSync(path.join(__dirname,'/data/decoratorcommands/map-declaration.json'), 'utf-8');
-            const decoratedModelManager = DecoratorManager.decorateModels( testModelManager, JSON.parse(dcs),
-                {validate: true, validateCommands: true});
+            const dcs = fs.readFileSync(path.join(__dirname, '/data/decoratorcommands/map-declaration.json'), 'utf-8');
+            const decoratedModelManager = DecoratorManager.decorateModels(testModelManager, JSON.parse(dcs),
+                { validate: true, validateCommands: true });
 
             const dictionary = decoratedModelManager.getType('test@1.0.0.Dictionary');
 
@@ -429,15 +441,15 @@ describe('DecoratorManager', () => {
             dictionary.value.getDecorator('Baz').should.not.be.null;
         });
 
-        it('should decorate a Key and Value element on an unspecified Map Declaration when a type is specified (type takes precedence over element value KEY_VALUE)', async function() {
+        it('should decorate a Key and Value element on an unspecified Map Declaration when a type is specified (type takes precedence over element value KEY_VALUE)', async function () {
             // load a model to decorate
-            const testModelManager = new ModelManager({strict:true, skipLocationNodes: true});
-            const modelText = fs.readFileSync(path.join(__dirname,'/data/decoratorcommands/test.cto'), 'utf-8');
+            const testModelManager = new ModelManager({ strict: true, skipLocationNodes: true });
+            const modelText = fs.readFileSync(path.join(__dirname, '/data/decoratorcommands/test.cto'), 'utf-8');
             testModelManager.addCTOModel(modelText, 'test.cto');
 
-            const dcs = fs.readFileSync(path.join(__dirname,'/data/decoratorcommands/map-declaration.json'), 'utf-8');
-            const decoratedModelManager = DecoratorManager.decorateModels( testModelManager, JSON.parse(dcs),
-                {validate: true, validateCommands: true});
+            const dcs = fs.readFileSync(path.join(__dirname, '/data/decoratorcommands/map-declaration.json'), 'utf-8');
+            const decoratedModelManager = DecoratorManager.decorateModels(testModelManager, JSON.parse(dcs),
+                { validate: true, validateCommands: true });
 
             const dictionary = decoratedModelManager.getType('test@1.0.0.Dictionary');
 
@@ -446,19 +458,19 @@ describe('DecoratorManager', () => {
             dictionary.value.getDecorator('Bongo').should.not.be.null;
         });
 
-        it('should decorate all Map Declaration Key and Value elements on the model when a declaration is not specified', async function() {
+        it('should decorate all Map Declaration Key and Value elements on the model when a declaration is not specified', async function () {
             // load a model to decorate
-            const testModelManager = new ModelManager({strict:true, skipLocationNodes: true});
-            const modelText = fs.readFileSync(path.join(__dirname,'/data/decoratorcommands/test.cto'), 'utf-8');
+            const testModelManager = new ModelManager({ strict: true, skipLocationNodes: true });
+            const modelText = fs.readFileSync(path.join(__dirname, '/data/decoratorcommands/test.cto'), 'utf-8');
             testModelManager.addCTOModel(modelText, 'test.cto');
 
-            const dcs = fs.readFileSync(path.join(__dirname,'/data/decoratorcommands/map-declaration.json'), 'utf-8');
-            const decoratedModelManager = DecoratorManager.decorateModels( testModelManager, JSON.parse(dcs),
-                {validate: true, validateCommands: true});
+            const dcs = fs.readFileSync(path.join(__dirname, '/data/decoratorcommands/map-declaration.json'), 'utf-8');
+            const decoratedModelManager = DecoratorManager.decorateModels(testModelManager, JSON.parse(dcs),
+                { validate: true, validateCommands: true });
 
 
-            const dictionary    = decoratedModelManager.getType('test@1.0.0.Dictionary');
-            const rolodex       = decoratedModelManager.getType('test@1.0.0.Rolodex');
+            const dictionary = decoratedModelManager.getType('test@1.0.0.Dictionary');
+            const rolodex = decoratedModelManager.getType('test@1.0.0.Rolodex');
 
             dictionary.should.not.be.null;
             dictionary.key.getDecorator('DecoratesAllMapKeys').should.not.be.null;
@@ -469,208 +481,208 @@ describe('DecoratorManager', () => {
             rolodex.value.getDecorator('DecoratesAllMapValues').should.not.be.null;
         });
 
-        it('should fail with invalid command', async function() {
+        it('should fail with invalid command', async function () {
             // load a model to decorate
-            const testModelManager = new ModelManager({strict:true});
-            const modelText = fs.readFileSync(path.join(__dirname,'/data/decoratorcommands/test.cto'), 'utf-8');
+            const testModelManager = new ModelManager({ strict: true });
+            const modelText = fs.readFileSync(path.join(__dirname, '/data/decoratorcommands/test.cto'), 'utf-8');
             testModelManager.addCTOModel(modelText, 'test.cto');
 
-            const dcs = fs.readFileSync(path.join(__dirname,'/data/decoratorcommands/invalid-command.json'), 'utf-8');
+            const dcs = fs.readFileSync(path.join(__dirname, '/data/decoratorcommands/invalid-command.json'), 'utf-8');
 
             (() => {
-                DecoratorManager.decorateModels( testModelManager, JSON.parse(dcs));
+                DecoratorManager.decorateModels(testModelManager, JSON.parse(dcs));
             }).should.throw(/Unknown command type INVALID/);
         });
     });
 
-    describe('#validateCommand', function() {
-        it('should detect invalid type', async function() {
+    describe('#validateCommand', function () {
+        it('should detect invalid type', async function () {
             // load a model to decorate
-            const testModelManager = new ModelManager({strict:true});
-            const modelText = fs.readFileSync(path.join(__dirname,'/data/decoratorcommands/test.cto'), 'utf-8');
+            const testModelManager = new ModelManager({ strict: true });
+            const modelText = fs.readFileSync(path.join(__dirname, '/data/decoratorcommands/test.cto'), 'utf-8');
             testModelManager.addCTOModel(modelText, 'test.cto');
 
-            const dcs = fs.readFileSync(path.join(__dirname,'/data/decoratorcommands/invalid-type.json'), 'utf-8');
+            const dcs = fs.readFileSync(path.join(__dirname, '/data/decoratorcommands/invalid-type.json'), 'utf-8');
 
             (() => {
-                DecoratorManager.decorateModels( testModelManager, JSON.parse(dcs),
-                    {validate: true, validateCommands: true});
+                DecoratorManager.decorateModels(testModelManager, JSON.parse(dcs),
+                    { validate: true, validateCommands: true });
             }).should.throw(/No type "concerto.metamodel@1.0.0.Foo" in namespace "concerto.metamodel@1.0.0" for "DecoratorCommand.type"/);
         });
 
-        it('should detect invalid target namespace', async function() {
+        it('should detect invalid target namespace', async function () {
             // load a model to decorate
-            const testModelManager = new ModelManager({strict:true});
-            const modelText = fs.readFileSync(path.join(__dirname,'/data/decoratorcommands/test.cto'), 'utf-8');
+            const testModelManager = new ModelManager({ strict: true });
+            const modelText = fs.readFileSync(path.join(__dirname, '/data/decoratorcommands/test.cto'), 'utf-8');
             testModelManager.addCTOModel(modelText, 'test.cto');
 
-            const dcs = fs.readFileSync(path.join(__dirname,'/data/decoratorcommands/invalid-target-namespace.json'), 'utf-8');
+            const dcs = fs.readFileSync(path.join(__dirname, '/data/decoratorcommands/invalid-target-namespace.json'), 'utf-8');
 
             (() => {
-                DecoratorManager.decorateModels( testModelManager, JSON.parse(dcs),
-                    {validate: true, validateCommands: true});
+                DecoratorManager.decorateModels(testModelManager, JSON.parse(dcs),
+                    { validate: true, validateCommands: true });
             }).should.throw(/Decorator Command references namespace "missing@1.0.0" which does not exist./);
         });
 
-        it('should detect invalid target declaration', async function() {
+        it('should detect invalid target declaration', async function () {
             // load a model to decorate
-            const testModelManager = new ModelManager({strict:true});
-            const modelText = fs.readFileSync(path.join(__dirname,'/data/decoratorcommands/test.cto'), 'utf-8');
+            const testModelManager = new ModelManager({ strict: true });
+            const modelText = fs.readFileSync(path.join(__dirname, '/data/decoratorcommands/test.cto'), 'utf-8');
             testModelManager.addCTOModel(modelText, 'test.cto');
 
-            const dcs = fs.readFileSync(path.join(__dirname,'/data/decoratorcommands/invalid-target-declaration.json'), 'utf-8');
+            const dcs = fs.readFileSync(path.join(__dirname, '/data/decoratorcommands/invalid-target-declaration.json'), 'utf-8');
 
             (() => {
-                DecoratorManager.decorateModels( testModelManager, JSON.parse(dcs),
-                    {validate: true, validateCommands: true});
+                DecoratorManager.decorateModels(testModelManager, JSON.parse(dcs),
+                    { validate: true, validateCommands: true });
             }).should.throw(/No type "test@1.0.0.Missing" in namespace "test@1.0.0" for "DecoratorCommand.target.declaration./);
         });
 
-        it('should detect invalid target property', async function() {
+        it('should detect invalid target property', async function () {
             // load a model to decorate
-            const testModelManager = new ModelManager({strict:true});
-            const modelText = fs.readFileSync(path.join(__dirname,'/data/decoratorcommands/test.cto'), 'utf-8');
+            const testModelManager = new ModelManager({ strict: true });
+            const modelText = fs.readFileSync(path.join(__dirname, '/data/decoratorcommands/test.cto'), 'utf-8');
             testModelManager.addCTOModel(modelText, 'test.cto');
 
-            const dcs = fs.readFileSync(path.join(__dirname,'/data/decoratorcommands/invalid-target-property.json'), 'utf-8');
+            const dcs = fs.readFileSync(path.join(__dirname, '/data/decoratorcommands/invalid-target-property.json'), 'utf-8');
 
             (() => {
-                DecoratorManager.decorateModels( testModelManager, JSON.parse(dcs),
-                    {validate: true, validateCommands: true});
+                DecoratorManager.decorateModels(testModelManager, JSON.parse(dcs),
+                    { validate: true, validateCommands: true });
             }).should.throw(/Decorator Command references property "test@1.0.0.Person.missing" which does not exist./);
         });
 
-        it('should detect invalid target properties', async function() {
+        it('should detect invalid target properties', async function () {
             // load a model to decorate
-            const testModelManager = new ModelManager({strict:true});
-            const modelText = fs.readFileSync(path.join(__dirname,'/data/decoratorcommands/test.cto'), 'utf-8');
+            const testModelManager = new ModelManager({ strict: true });
+            const modelText = fs.readFileSync(path.join(__dirname, '/data/decoratorcommands/test.cto'), 'utf-8');
             testModelManager.addCTOModel(modelText, 'test.cto');
 
-            const dcs = fs.readFileSync(path.join(__dirname,'/data/decoratorcommands/invalid-target-properties.json'), 'utf-8');
+            const dcs = fs.readFileSync(path.join(__dirname, '/data/decoratorcommands/invalid-target-properties.json'), 'utf-8');
 
             (() => {
-                DecoratorManager.decorateModels( testModelManager, JSON.parse(dcs),
-                    {validate: true, validateCommands: true});
+                DecoratorManager.decorateModels(testModelManager, JSON.parse(dcs),
+                    { validate: true, validateCommands: true });
             }).should.throw(/Decorator Command references property "test@1.0.0.Person.missing" which does not exist./);
         });
 
-        it('should detect target referencing both property and properties', async function() {
+        it('should detect target referencing both property and properties', async function () {
             // load a model to decorate
-            const testModelManager = new ModelManager({strict:true});
-            const modelText = fs.readFileSync(path.join(__dirname,'/data/decoratorcommands/test.cto'), 'utf-8');
+            const testModelManager = new ModelManager({ strict: true });
+            const modelText = fs.readFileSync(path.join(__dirname, '/data/decoratorcommands/test.cto'), 'utf-8');
             testModelManager.addCTOModel(modelText, 'test.cto');
 
-            const dcs = fs.readFileSync(path.join(__dirname,'/data/decoratorcommands/invalid-target-property-properties.json'), 'utf-8');
+            const dcs = fs.readFileSync(path.join(__dirname, '/data/decoratorcommands/invalid-target-property-properties.json'), 'utf-8');
 
             (() => {
-                DecoratorManager.decorateModels( testModelManager, JSON.parse(dcs),
-                    {validate: true, validateCommands: true});
+                DecoratorManager.decorateModels(testModelManager, JSON.parse(dcs),
+                    { validate: true, validateCommands: true });
             }).should.throw(/Decorator Command references both property and properties. You must either reference a single property or a list of properites./);
         });
     });
 
-    describe('#validate', function() {
-        it('should detect decorator command set that is invalid', async function() {
+    describe('#validate', function () {
+        it('should detect decorator command set that is invalid', async function () {
             // load a model to decorate
-            const testModelManager = new ModelManager({strict:true});
-            const modelText = fs.readFileSync(path.join(__dirname,'/data/decoratorcommands/test.cto'), 'utf-8');
+            const testModelManager = new ModelManager({ strict: true });
+            const modelText = fs.readFileSync(path.join(__dirname, '/data/decoratorcommands/test.cto'), 'utf-8');
             testModelManager.addCTOModel(modelText, 'test.cto');
 
-            const dcs = fs.readFileSync(path.join(__dirname,'/data/decoratorcommands/invalid-model.json'), 'utf-8');
+            const dcs = fs.readFileSync(path.join(__dirname, '/data/decoratorcommands/invalid-model.json'), 'utf-8');
 
             (() => {
-                DecoratorManager.decorateModels( testModelManager, JSON.parse(dcs),
-                    {validate: true});
+                DecoratorManager.decorateModels(testModelManager, JSON.parse(dcs),
+                    { validate: true });
             }).should.throw(/Type "Invalid" is not defined in namespace "org.accordproject.decoratorcommands@0.3.0"/);
         });
 
-        it('should detect decorator command set with an invalid command type', async function() {
+        it('should detect decorator command set with an invalid command type', async function () {
             // load a model to decorate
-            const testModelManager = new ModelManager({strict:true});
-            const modelText = fs.readFileSync(path.join(__dirname,'/data/decoratorcommands/test.cto'), 'utf-8');
+            const testModelManager = new ModelManager({ strict: true });
+            const modelText = fs.readFileSync(path.join(__dirname, '/data/decoratorcommands/test.cto'), 'utf-8');
             testModelManager.addCTOModel(modelText, 'test.cto');
 
-            const dcs = fs.readFileSync(path.join(__dirname,'/data/decoratorcommands/invalid-command.json'), 'utf-8');
+            const dcs = fs.readFileSync(path.join(__dirname, '/data/decoratorcommands/invalid-command.json'), 'utf-8');
 
             (() => {
-                DecoratorManager.decorateModels( testModelManager, JSON.parse(dcs),
-                    {validate: true});
+                DecoratorManager.decorateModels(testModelManager, JSON.parse(dcs),
+                    { validate: true });
             }).should.throw(/Model violation in the "concerto.metamodel@1.0.0.Decorator" instance. Invalid enum value of "INVALID" for the field "CommandType"/);
         });
     });
 
-    describe('#extractDecorators', function() {
-        it('should be able to extract decorators and vocabs from a model withoup options', async function() {
-            const testModelManager = new ModelManager({strict:true,});
-            const modelText = fs.readFileSync(path.join(__dirname,'/data/decoratorcommands/extract-test.cto'), 'utf-8');
+    describe('#extractDecorators', function () {
+        it('should be able to extract decorators and vocabs from a model withoup options', async function () {
+            const testModelManager = new ModelManager({ strict: true, });
+            const modelText = fs.readFileSync(path.join(__dirname, '/data/decoratorcommands/extract-test.cto'), 'utf-8');
             testModelManager.addCTOModel(modelText, 'test.cto');
-            const resp = DecoratorManager.extractDecorators( testModelManager);
+            const resp = DecoratorManager.extractDecorators(testModelManager);
             const dcs = resp.decoratorCommandSet;
             dcs.should.not.be.null;
         });
-        it('should be able to extract decorators and vocabs from a model without namespace version', async function() {
+        it('should be able to extract decorators and vocabs from a model without namespace version', async function () {
             const testModelManager = new ModelManager();
-            const modelTextWithoutNamespace = fs.readFileSync(path.join(__dirname,'/data/decoratorcommands/test-decorator-without-version.cto'), 'utf-8');
+            const modelTextWithoutNamespace = fs.readFileSync(path.join(__dirname, '/data/decoratorcommands/test-decorator-without-version.cto'), 'utf-8');
             testModelManager.addCTOModel(modelTextWithoutNamespace, 'test.cto');
             const options = {
-                removeDecoratorsFromModel:true,
-                locale:'en'
+                removeDecoratorsFromModel: true,
+                locale: 'en'
             };
-            const resp = DecoratorManager.extractDecorators( testModelManager, options);
+            const resp = DecoratorManager.extractDecorators(testModelManager, options);
             const vocabs = resp.vocabularies;
             vocabs.should.not.be.null;
         });
-        it('should ensure that extraction and re-application of decorators and vocabs from a model is an identity operation', async function() {
+        it('should ensure that extraction and re-application of decorators and vocabs from a model is an identity operation', async function () {
             const testModelManager = new ModelManager();
             const sourceCTO = [];
             const updatedCTO = [];
-            const modelTextWithoutNamespace = fs.readFileSync(path.join(__dirname,'/data/decoratorcommands/extract-test.cto'), 'utf-8');
+            const modelTextWithoutNamespace = fs.readFileSync(path.join(__dirname, '/data/decoratorcommands/extract-test.cto'), 'utf-8');
             testModelManager.addCTOModel(modelTextWithoutNamespace, 'test.cto');
             const options = {
-                removeDecoratorsFromModel:true,
-                locale:'en'
+                removeDecoratorsFromModel: true,
+                locale: 'en'
             };
-            const namespaceSource = testModelManager.getNamespaces().filter(namespace=>namespace!=='concerto@1.0.0' && namespace!=='concerto');
-            namespaceSource.forEach(name=>{
+            const namespaceSource = testModelManager.getNamespaces().filter(namespace => namespace !== 'concerto@1.0.0' && namespace !== 'concerto');
+            namespaceSource.forEach(name => {
                 let model = testModelManager.getModelFile(name);
-                let modelAst=model.getAst();
-                let data =  Printer.toCTO(modelAst);
+                let modelAst = model.getAst();
+                let data = Printer.toCTO(modelAst);
                 sourceCTO.push(data);
             });
-            const resp = DecoratorManager.extractDecorators( testModelManager, options);
+            const resp = DecoratorManager.extractDecorators(testModelManager, options);
             const dcs = resp.decoratorCommandSet;
-            const vocabs= resp.vocabularies;
-            let newModelManager=resp.modelManager;
+            const vocabs = resp.vocabularies;
+            let newModelManager = resp.modelManager;
             const vocManager = new VocabularyManager();
             vocabs.forEach(content => {
                 vocManager.addVocabulary(content);
             });
-            const vocabKeySet=[];
-            const namespaceUpdated = newModelManager.getNamespaces().filter(namespace=>namespace!=='concerto@1.0.0' && namespace!=='concerto');
-            namespaceUpdated.forEach(name=>{
+            const vocabKeySet = [];
+            const namespaceUpdated = newModelManager.getNamespaces().filter(namespace => namespace !== 'concerto@1.0.0' && namespace !== 'concerto');
+            namespaceUpdated.forEach(name => {
                 let vocab = vocManager.getVocabulariesForNamespace(name);
-                vocab.forEach(voc=>vocabKeySet.push(voc.getLocale()));
+                vocab.forEach(voc => vocabKeySet.push(voc.getLocale()));
             });
-            vocabKeySet.map(voc=>{
+            vocabKeySet.map(voc => {
                 let commandSet = vocManager.generateDecoratorCommands(newModelManager, voc);
                 newModelManager = DecoratorManager.decorateModels(newModelManager, commandSet);
             });
             dcs.forEach(content => {
                 newModelManager = DecoratorManager.decorateModels(newModelManager, (content));
             });
-            namespaceUpdated.forEach(name=>{
+            namespaceUpdated.forEach(name => {
                 let model = newModelManager.getModelFile(name);
-                let modelAst=model.getAst();
-                let data =  Printer.toCTO(modelAst);
+                let modelAst = model.getAst();
+                let data = Printer.toCTO(modelAst);
                 updatedCTO.push(data);
             });
             sourceCTO.should.be.deep.equal(updatedCTO);
         });
-        it('should give proper response in there is no vocabulary on any model', async function() {
-            const testModelManager = new ModelManager({strict:true,});
-            const modelText = fs.readFileSync(path.join(__dirname,'/data/decoratorcommands/model-without-vocab.cto'), 'utf-8');
+        it('should give proper response in there is no vocabulary on any model', async function () {
+            const testModelManager = new ModelManager({ strict: true, });
+            const modelText = fs.readFileSync(path.join(__dirname, '/data/decoratorcommands/model-without-vocab.cto'), 'utf-8');
             testModelManager.addCTOModel(modelText, 'test.cto');
-            const resp = DecoratorManager.extractDecorators( testModelManager);
+            const resp = DecoratorManager.extractDecorators(testModelManager);
             const vocab = resp.vocabularies;
             vocab.should.be.deep.equal([]);
         });
@@ -690,23 +702,23 @@ describe('DecoratorManager', () => {
             };
 
             command = {
-                '$class' : 'org.accordproject.decoratorcommands@0.3.0.Command',
-                'type' : 'UPSERT',
-                'target' : {
-                    '$class' : 'org.accordproject.decoratorcommands@0.3.0.CommandTarget',
-                    'namespace' : 'test@1.0.0'
+                '$class': 'org.accordproject.decoratorcommands@0.3.0.Command',
+                'type': 'UPSERT',
+                'target': {
+                    '$class': 'org.accordproject.decoratorcommands@0.3.0.CommandTarget',
+                    'namespace': 'test@1.0.0'
                 },
-                'decorator' : {
-                    '$class' : 'concerto.metamodel@1.0.0.Decorator',
-                    'name' : 'Form',
-                    'arguments' : [
+                'decorator': {
+                    '$class': 'concerto.metamodel@1.0.0.Decorator',
+                    'name': 'Form',
+                    'arguments': [
                         {
-                            '$class' : 'concerto.metamodel@1.0.0.DecoratorString',
-                            'value' : 'inputType'
+                            '$class': 'concerto.metamodel@1.0.0.DecoratorString',
+                            'value': 'inputType'
                         },
                         {
-                            '$class' : 'concerto.metamodel@1.0.0.DecoratorString',
-                            'value' : 'text'
+                            '$class': 'concerto.metamodel@1.0.0.DecoratorString',
+                            'value': 'text'
                         }
                     ]
                 }

--- a/packages/concerto-vocabulary/lib/vocabulary.js
+++ b/packages/concerto-vocabulary/lib/vocabulary.js
@@ -93,7 +93,8 @@ class Vocabulary {
      * @returns {Array} an array of objects
      */
     getTerms() {
-        return this.content.declarations;
+        // we remove empty terms from the voc
+        return this.content.declarations.filter(d => Object.values(d)[0]);
     }
 
     /**
@@ -104,7 +105,7 @@ class Vocabulary {
      * @returns {string} the term or null if it does not exist
      */
     getTerm(declarationName, propertyName, identifier) {
-        const decl = this.content.declarations.find(d => Object.keys(d)[0] === declarationName);
+        const decl = this.content.declarations.find(d => Object.keys(d)[0] === declarationName && Object.values(d)[0]);
         if(!decl) {
             return null;
         }
@@ -124,7 +125,7 @@ class Vocabulary {
      * @returns {string} the term or null if it does not exist
      */
     getElementTerms(declarationName, propertyName) {
-        const decl = this.content.declarations.find(d => Object.keys(d)[0] === declarationName);
+        const decl = this.content.declarations.find(d => Object.keys(d)[0] === declarationName && Object.values(d)[0]);
         if(!decl) {
             return null;
         }

--- a/packages/concerto-vocabulary/lib/vocabulary.js
+++ b/packages/concerto-vocabulary/lib/vocabulary.js
@@ -103,7 +103,8 @@ class Vocabulary {
      */
     getTerms() {
         // we remove empty terms from the voc
-        return this.content.declarations.filter(d => Object.values(d)[0]);
+        // return this.content.declarations.filter(d => Object.values(d)[0]);
+        return this.content.declarations;
     }
 
     /**
@@ -114,7 +115,7 @@ class Vocabulary {
      * @returns {string} the term or null if it does not exist
      */
     getTerm(declarationName, propertyName, identifier) {
-        const decl = this.content.declarations.find(d => Object.keys(d)[0] === declarationName && Object.values(d)[0]);
+        const decl = this.content.declarations.find(d => Object.keys(d)[0] === declarationName /*&& Object.values(d)[0]*/);
         if(!decl) {
             return null;
         }
@@ -134,7 +135,7 @@ class Vocabulary {
      * @returns {string} the term or null if it does not exist
      */
     getElementTerms(declarationName, propertyName) {
-        const decl = this.content.declarations.find(d => Object.keys(d)[0] === declarationName && Object.values(d)[0]);
+        const decl = this.content.declarations.find(d => Object.keys(d)[0] === declarationName /*&& Object.values(d)[0]*/);
         if(!decl) {
             return null;
         }

--- a/packages/concerto-vocabulary/test/__snapshots__/vocabularymanager.js.snap
+++ b/packages/concerto-vocabulary/test/__snapshots__/vocabularymanager.js.snap
@@ -502,6 +502,105 @@ Object {
         "arguments": Array [
           Object {
             "$class": "concerto.metamodel@1.0.0.DecoratorString",
+            "value": "Motorcycle",
+          },
+        ],
+        "name": "Term",
+      },
+      "target": Object {
+        "$class": "org.accordproject.decoratorcommands@0.3.0.CommandTarget",
+        "declaration": "Motorcycle",
+        "namespace": "org.acme@1.0.0",
+      },
+      "type": "UPSERT",
+    },
+    Object {
+      "$class": "org.accordproject.decoratorcommands@0.3.0.Command",
+      "decorator": Object {
+        "$class": "concerto.metamodel@1.0.0.Decorator",
+        "arguments": Array [
+          Object {
+            "$class": "concerto.metamodel@1.0.0.DecoratorString",
+            "value": "Vehicle Identification Number",
+          },
+        ],
+        "name": "Term",
+      },
+      "target": Object {
+        "$class": "org.accordproject.decoratorcommands@0.3.0.CommandTarget",
+        "declaration": "Motorcycle",
+        "namespace": "org.acme@1.0.0",
+        "property": "vin",
+      },
+      "type": "UPSERT",
+    },
+    Object {
+      "$class": "org.accordproject.decoratorcommands@0.3.0.Command",
+      "decorator": Object {
+        "$class": "concerto.metamodel@1.0.0.Decorator",
+        "arguments": Array [
+          Object {
+            "$class": "concerto.metamodel@1.0.0.DecoratorString",
+            "value": "VIN",
+          },
+        ],
+        "name": "Term_tooltip",
+      },
+      "target": Object {
+        "$class": "org.accordproject.decoratorcommands@0.3.0.CommandTarget",
+        "declaration": "Motorcycle",
+        "namespace": "org.acme@1.0.0",
+        "property": "vin",
+      },
+      "type": "UPSERT",
+    },
+    Object {
+      "$class": "org.accordproject.decoratorcommands@0.3.0.Command",
+      "decorator": Object {
+        "$class": "concerto.metamodel@1.0.0.Decorator",
+        "arguments": Array [
+          Object {
+            "$class": "concerto.metamodel@1.0.0.DecoratorString",
+            "value": "Color of the Vehicle",
+          },
+        ],
+        "name": "Term",
+      },
+      "target": Object {
+        "$class": "org.accordproject.decoratorcommands@0.3.0.CommandTarget",
+        "declaration": "Motorcycle",
+        "namespace": "org.acme@1.0.0",
+        "property": "color",
+      },
+      "type": "UPSERT",
+    },
+    Object {
+      "$class": "org.accordproject.decoratorcommands@0.3.0.Command",
+      "decorator": Object {
+        "$class": "concerto.metamodel@1.0.0.Decorator",
+        "arguments": Array [
+          Object {
+            "$class": "concerto.metamodel@1.0.0.DecoratorString",
+            "value": "Identifier of the Asset",
+          },
+        ],
+        "name": "Term",
+      },
+      "target": Object {
+        "$class": "org.accordproject.decoratorcommands@0.3.0.CommandTarget",
+        "declaration": "Motorcycle",
+        "namespace": "org.acme@1.0.0",
+        "property": "$identifier",
+      },
+      "type": "UPSERT",
+    },
+    Object {
+      "$class": "org.accordproject.decoratorcommands@0.3.0.Command",
+      "decorator": Object {
+        "$class": "concerto.metamodel@1.0.0.Decorator",
+        "arguments": Array [
+          Object {
+            "$class": "concerto.metamodel@1.0.0.DecoratorString",
             "value": "Thing",
           },
         ],

--- a/packages/concerto-vocabulary/test/__snapshots__/vocabularymanager.js.snap
+++ b/packages/concerto-vocabulary/test/__snapshots__/vocabularymanager.js.snap
@@ -502,7 +502,7 @@ Object {
         "arguments": Array [
           Object {
             "$class": "concerto.metamodel@1.0.0.DecoratorString",
-            "value": "Motorcycle",
+            "value": null,
           },
         ],
         "name": "Term",

--- a/packages/concerto-vocabulary/test/org.acme@1.0.0.cto
+++ b/packages/concerto-vocabulary/test/org.acme@1.0.0.cto
@@ -22,3 +22,6 @@ map Address {
 asset Truck extends Vehicle {
     o Double weight
 }
+
+asset Motorcycle extends Vehicle {
+}

--- a/packages/concerto-vocabulary/test/org.acme@1.0.0_en.voc
+++ b/packages/concerto-vocabulary/test/org.acme@1.0.0_en.voc
@@ -22,3 +22,4 @@ declarations:
     properties:
       - KEY: vin of the vehicle
       - VALUE: address of the vehicle
+  - Motorcycle:

--- a/packages/concerto-vocabulary/test/vocabularymanager.js
+++ b/packages/concerto-vocabulary/test/vocabularymanager.js
@@ -367,11 +367,11 @@ describe('VocabularyManager', () => {
         result.additionalVocabularies.length.should.equal(1);
         result.additionalVocabularies[0].getNamespace().should.equal('com.example@1.0.0');
         result.vocabularies['org.acme@1.0.0/en'].additionalTerms.should.have.members(['Vehicle.model', 'Truck.horsePower']);
-        result.vocabularies['org.acme@1.0.0/en'].missingTerms.should.have.members(['Color.RED', 'Color.BLUE', 'Color.GREEN', 'SSN', 'Vehicle.color']);
+        result.vocabularies['org.acme@1.0.0/en'].missingTerms.should.have.members(['Color.RED', 'Color.BLUE', 'Color.GREEN', 'SSN', 'Vehicle.color', 'Motorcycle']);
         result.vocabularies['org.acme@1.0.0/en-gb'].additionalTerms.should.have.members(['Milkfloat', 'Address.BAD_KEY']);
-        result.vocabularies['org.acme@1.0.0/fr'].missingTerms.should.have.members(['Color', 'SSN', 'VIN', 'Vehicle.color', 'Address.VALUE', 'Truck']);
+        result.vocabularies['org.acme@1.0.0/fr'].missingTerms.should.have.members(['Color', 'SSN', 'VIN', 'Vehicle.color', 'Address.VALUE', 'Truck', 'Motorcycle']);
         result.vocabularies['org.acme@1.0.0/fr'].additionalTerms.should.have.members([]);
-        result.vocabularies['org.acme@1.0.0/zh-cn'].missingTerms.should.have.members(['SSN', 'VIN', 'Address', 'Truck']);
+        result.vocabularies['org.acme@1.0.0/zh-cn'].missingTerms.should.have.members(['SSN', 'VIN', 'Address', 'Truck', 'Motorcycle']);
         result.vocabularies['org.acme@1.0.0/zh-cn'].additionalTerms.should.have.members([]);
     });
 


### PR DESCRIPTION
### Changes
- Adds a test case to DecoratorManager to ensure that it catches decorators with a null value
- Updates the Vocabulary to filter our empty terms
- Updates the test cases

### Flags

The term for `Motorcycle` is ignored.

```
locale: en
namespace: org.acme@1.0.0
declarations:
  - Motorcycle:
```

What should this do?

```
locale: en
namespace: org.acme@1.0.0
declarations:
  - Motorcycle:
     description: A motor cycle
     tooltip: Motocyle
```

### Screenshots or Video
<!--- Provide an easily accessible demonstration of the changes, if applicable -->

### Related Issues
- Issue #<NUMBER>
- Pull Request #<NUMBER>

### Author Checklist
- [ ] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [ ] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ ] Merging to `main` from `fork:branchname`
