### PR TITLE
feat: add GH action for closing stale prs and issues 

### DIFF
--- a/.github/workflows/close-stale.yml
+++ b/.github/workflows/close-stale.yml
@@ -1,0 +1,16 @@
+name: 'Close stale issues and PRs'
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          stale-issue-message: 'This issue is stale because it has been open 60 days with no activity. Remove stale label or comment or this will be closed in 10 days.'
+          stale-pr-message: 'This PR is stale because it has been open 15 days with no activity. Remove stale label or comment or this will be closed in 10 days.'
+          days-before-issue-stale: 60
+          days-before-pr-stale: 15
+          days-before-close: 10

--- a/.github/workflows/close-stale.yml
+++ b/.github/workflows/close-stale.yml
@@ -14,3 +14,4 @@ jobs:
           days-before-issue-stale: 60
           days-before-pr-stale: 15
           days-before-close: 10
+          exempt-milestones: 'v4.0'


### PR DESCRIPTION
<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #<CORRESPONDING ISSUE NUMBER>
<!--- Provide an overall summary of the pull request -->

### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
- Marks issues as stale after 60 days of inactivity and closes 10 days later.
- Marks PRs as stale after 15 days of inactivity and closes 10 days later.
-  Exempts anything in v4.0 milestone from being closed
- Uses https://github.com/marketplace/actions/close-stale-issues

### Flags
<!--- Provide context or concerns a reviewer should be aware of -->
- Please provide opinions on the timing for when an issue/PR is stale or closed. I used my best judgement here but would like to hear from the community. Also anything else we should exempt besides the v4.0 milestone items.

### Screenshots or Video
<!--- Provide an easily accessible demonstration of the changes, if applicable -->

### Related Issues
- Issue https://github.com/accordproject/technical-steering-committee/issues/52
- Pull Request #<NUMBER>

### Author Checklist
- [ ] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [ ] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ ] Merging to `main` from `fork:branchname`
