### PR TITLE
chore(dcs): expose canMigrate and migrateTo methods from DecoratorManager

### DIFF
--- a/packages/concerto-core/api.txt
+++ b/packages/concerto-core/api.txt
@@ -58,6 +58,8 @@ class Concerto {
    + object setCurrentTime() 
 class DecoratorManager {
    + ModelManager validate(decoratorCommandSet,ModelFile[]) throws Error
+   + object migrateTo(decoratorCommandSet,string) 
+   + boolean canMigrate(decoratorCommandSet,DCS_VERSION) 
    + ModelManager decorateModels(ModelManager,decoratorCommandSet,object?,boolean?,boolean?,boolean?,boolean?,boolean?) 
    + ExtractDecoratorsResult extractDecorators(ModelManager,object,boolean,string) 
    + ExtractDecoratorsResult extractVocabularies(ModelManager,object,boolean,string) 

--- a/packages/concerto-core/changelog.txt
+++ b/packages/concerto-core/changelog.txt
@@ -24,6 +24,10 @@
 # Note that the latest public API is documented using JSDocs and is available in api.txt.
 #
 
+
+Version 3.20.4 {335406876b7005f0a2e6f9ca3e0d0dbf} 2025-01-21
+- expose canMigrate and MigrateTo methods from decorator manager
+
 Version 3.19.2 {844c910d1f8f61ab31c34e85d8c51546} 2024-10-21
 - update options for ModelManager
 

--- a/packages/concerto-core/lib/decoratormanager.js
+++ b/packages/concerto-core/lib/decoratormanager.js
@@ -199,7 +199,6 @@ class DecoratorManager {
 
     /**
      * Rewrites the $class property on decoratorCommandSet classes.
-     * @private
      * @param {*} decoratorCommandSet the DecoratorCommandSet object
      * @param {string} version the DCS version upgrade target
      * @returns {object} the migrated DecoratorCommandSet object
@@ -224,7 +223,6 @@ class DecoratorManager {
     /**
      * Checks if the supplied decoratorCommandSet can be migrated.
      * Migrations should only take place across minor versions of the same major version.
-     * @private
      * @param {*} decoratorCommandSet the DecoratorCommandSet object
      * @param {*} DCS_VERSION the DecoratorCommandSet version
      * @returns {boolean} returns true if major versions are equal

--- a/packages/concerto-core/types/lib/decoratormanager.d.ts
+++ b/packages/concerto-core/types/lib/decoratormanager.d.ts
@@ -21,21 +21,19 @@ declare class DecoratorManager {
     static validate(decoratorCommandSet: any, modelFiles?: ModelFile[]): ModelManager;
     /**
      * Rewrites the $class property on decoratorCommandSet classes.
-     * @private
      * @param {*} decoratorCommandSet the DecoratorCommandSet object
      * @param {string} version the DCS version upgrade target
      * @returns {object} the migrated DecoratorCommandSet object
      */
-    private static migrateTo;
+    static migrateTo(decoratorCommandSet: any, version: string): object;
     /**
      * Checks if the supplied decoratorCommandSet can be migrated.
      * Migrations should only take place across minor versions of the same major version.
-     * @private
      * @param {*} decoratorCommandSet the DecoratorCommandSet object
      * @param {*} DCS_VERSION the DecoratorCommandSet version
      * @returns {boolean} returns true if major versions are equal
      */
-    private static canMigrate;
+    static canMigrate(decoratorCommandSet: any, DCS_VERSION: any): boolean;
     /**
      * Add decorator commands set with index object to the coresponding target map
      * @param {*} targetMap the target map to add the command to

--- a/packages/concerto-vocabulary/lib/vocabularymanager.js
+++ b/packages/concerto-vocabulary/lib/vocabularymanager.js
@@ -18,7 +18,7 @@ const YAML = require('yaml');
 const { MetaModelNamespace } = require('@accordproject/concerto-metamodel');
 const Vocabulary = require('./vocabulary');
 
-const DC_NAMESPACE = 'org.accordproject.decoratorcommands@0.3.0';
+const DC_NAMESPACE = 'org.accordproject.decoratorcommands@0.4.0';
 
 // Types needed for TypeScript generation.
 /* eslint-disable no-unused-vars */

--- a/packages/concerto-vocabulary/test/__snapshots__/vocabularymanager.js.snap
+++ b/packages/concerto-vocabulary/test/__snapshots__/vocabularymanager.js.snap
@@ -2,10 +2,10 @@
 
 exports[`VocabularyManager decorateModels 1`] = `
 Object {
-  "$class": "org.accordproject.decoratorcommands@0.3.0.DecoratorCommandSet",
+  "$class": "org.accordproject.decoratorcommands@0.4.0.DecoratorCommandSet",
   "commands": Array [
     Object {
-      "$class": "org.accordproject.decoratorcommands@0.3.0.Command",
+      "$class": "org.accordproject.decoratorcommands@0.4.0.Command",
       "decorator": Object {
         "$class": "concerto.metamodel@1.0.0.Decorator",
         "arguments": Array [
@@ -17,14 +17,14 @@ Object {
         "name": "Term",
       },
       "target": Object {
-        "$class": "org.accordproject.decoratorcommands@0.3.0.CommandTarget",
+        "$class": "org.accordproject.decoratorcommands@0.4.0.CommandTarget",
         "declaration": "Color",
         "namespace": "org.acme@1.0.0",
       },
       "type": "UPSERT",
     },
     Object {
-      "$class": "org.accordproject.decoratorcommands@0.3.0.Command",
+      "$class": "org.accordproject.decoratorcommands@0.4.0.Command",
       "decorator": Object {
         "$class": "concerto.metamodel@1.0.0.Decorator",
         "arguments": Array [
@@ -36,7 +36,7 @@ Object {
         "name": "Term",
       },
       "target": Object {
-        "$class": "org.accordproject.decoratorcommands@0.3.0.CommandTarget",
+        "$class": "org.accordproject.decoratorcommands@0.4.0.CommandTarget",
         "declaration": "Color",
         "namespace": "org.acme@1.0.0",
         "property": "RED",
@@ -44,7 +44,7 @@ Object {
       "type": "UPSERT",
     },
     Object {
-      "$class": "org.accordproject.decoratorcommands@0.3.0.Command",
+      "$class": "org.accordproject.decoratorcommands@0.4.0.Command",
       "decorator": Object {
         "$class": "concerto.metamodel@1.0.0.Decorator",
         "arguments": Array [
@@ -56,7 +56,7 @@ Object {
         "name": "Term",
       },
       "target": Object {
-        "$class": "org.accordproject.decoratorcommands@0.3.0.CommandTarget",
+        "$class": "org.accordproject.decoratorcommands@0.4.0.CommandTarget",
         "declaration": "Color",
         "namespace": "org.acme@1.0.0",
         "property": "BLUE",
@@ -64,7 +64,7 @@ Object {
       "type": "UPSERT",
     },
     Object {
-      "$class": "org.accordproject.decoratorcommands@0.3.0.Command",
+      "$class": "org.accordproject.decoratorcommands@0.4.0.Command",
       "decorator": Object {
         "$class": "concerto.metamodel@1.0.0.Decorator",
         "arguments": Array [
@@ -76,7 +76,7 @@ Object {
         "name": "Term",
       },
       "target": Object {
-        "$class": "org.accordproject.decoratorcommands@0.3.0.CommandTarget",
+        "$class": "org.accordproject.decoratorcommands@0.4.0.CommandTarget",
         "declaration": "Color",
         "namespace": "org.acme@1.0.0",
         "property": "GREEN",
@@ -84,7 +84,7 @@ Object {
       "type": "UPSERT",
     },
     Object {
-      "$class": "org.accordproject.decoratorcommands@0.3.0.Command",
+      "$class": "org.accordproject.decoratorcommands@0.4.0.Command",
       "decorator": Object {
         "$class": "concerto.metamodel@1.0.0.Decorator",
         "arguments": Array [
@@ -96,14 +96,14 @@ Object {
         "name": "Term",
       },
       "target": Object {
-        "$class": "org.accordproject.decoratorcommands@0.3.0.CommandTarget",
+        "$class": "org.accordproject.decoratorcommands@0.4.0.CommandTarget",
         "declaration": "SSN",
         "namespace": "org.acme@1.0.0",
       },
       "type": "UPSERT",
     },
     Object {
-      "$class": "org.accordproject.decoratorcommands@0.3.0.Command",
+      "$class": "org.accordproject.decoratorcommands@0.4.0.Command",
       "decorator": Object {
         "$class": "concerto.metamodel@1.0.0.Decorator",
         "arguments": Array [
@@ -115,14 +115,14 @@ Object {
         "name": "Term",
       },
       "target": Object {
-        "$class": "org.accordproject.decoratorcommands@0.3.0.CommandTarget",
+        "$class": "org.accordproject.decoratorcommands@0.4.0.CommandTarget",
         "declaration": "VIN",
         "namespace": "org.acme@1.0.0",
       },
       "type": "UPSERT",
     },
     Object {
-      "$class": "org.accordproject.decoratorcommands@0.3.0.Command",
+      "$class": "org.accordproject.decoratorcommands@0.4.0.Command",
       "decorator": Object {
         "$class": "concerto.metamodel@1.0.0.Decorator",
         "arguments": Array [
@@ -134,14 +134,14 @@ Object {
         "name": "Term",
       },
       "target": Object {
-        "$class": "org.accordproject.decoratorcommands@0.3.0.CommandTarget",
+        "$class": "org.accordproject.decoratorcommands@0.4.0.CommandTarget",
         "declaration": "Vehicle",
         "namespace": "org.acme@1.0.0",
       },
       "type": "UPSERT",
     },
     Object {
-      "$class": "org.accordproject.decoratorcommands@0.3.0.Command",
+      "$class": "org.accordproject.decoratorcommands@0.4.0.Command",
       "decorator": Object {
         "$class": "concerto.metamodel@1.0.0.Decorator",
         "arguments": Array [
@@ -153,7 +153,7 @@ Object {
         "name": "Term",
       },
       "target": Object {
-        "$class": "org.accordproject.decoratorcommands@0.3.0.CommandTarget",
+        "$class": "org.accordproject.decoratorcommands@0.4.0.CommandTarget",
         "declaration": "Vehicle",
         "namespace": "org.acme@1.0.0",
         "property": "vin",
@@ -161,7 +161,7 @@ Object {
       "type": "UPSERT",
     },
     Object {
-      "$class": "org.accordproject.decoratorcommands@0.3.0.Command",
+      "$class": "org.accordproject.decoratorcommands@0.4.0.Command",
       "decorator": Object {
         "$class": "concerto.metamodel@1.0.0.Decorator",
         "arguments": Array [
@@ -173,7 +173,7 @@ Object {
         "name": "Term_tooltip",
       },
       "target": Object {
-        "$class": "org.accordproject.decoratorcommands@0.3.0.CommandTarget",
+        "$class": "org.accordproject.decoratorcommands@0.4.0.CommandTarget",
         "declaration": "Vehicle",
         "namespace": "org.acme@1.0.0",
         "property": "vin",
@@ -181,7 +181,7 @@ Object {
       "type": "UPSERT",
     },
     Object {
-      "$class": "org.accordproject.decoratorcommands@0.3.0.Command",
+      "$class": "org.accordproject.decoratorcommands@0.4.0.Command",
       "decorator": Object {
         "$class": "concerto.metamodel@1.0.0.Decorator",
         "arguments": Array [
@@ -193,7 +193,7 @@ Object {
         "name": "Term",
       },
       "target": Object {
-        "$class": "org.accordproject.decoratorcommands@0.3.0.CommandTarget",
+        "$class": "org.accordproject.decoratorcommands@0.4.0.CommandTarget",
         "declaration": "Vehicle",
         "namespace": "org.acme@1.0.0",
         "property": "color",
@@ -201,7 +201,7 @@ Object {
       "type": "UPSERT",
     },
     Object {
-      "$class": "org.accordproject.decoratorcommands@0.3.0.Command",
+      "$class": "org.accordproject.decoratorcommands@0.4.0.Command",
       "decorator": Object {
         "$class": "concerto.metamodel@1.0.0.Decorator",
         "arguments": Array [
@@ -213,7 +213,7 @@ Object {
         "name": "Term",
       },
       "target": Object {
-        "$class": "org.accordproject.decoratorcommands@0.3.0.CommandTarget",
+        "$class": "org.accordproject.decoratorcommands@0.4.0.CommandTarget",
         "declaration": "Vehicle",
         "namespace": "org.acme@1.0.0",
         "property": "$identifier",
@@ -221,7 +221,7 @@ Object {
       "type": "UPSERT",
     },
     Object {
-      "$class": "org.accordproject.decoratorcommands@0.3.0.Command",
+      "$class": "org.accordproject.decoratorcommands@0.4.0.Command",
       "decorator": Object {
         "$class": "concerto.metamodel@1.0.0.Decorator",
         "arguments": Array [
@@ -233,14 +233,14 @@ Object {
         "name": "Term",
       },
       "target": Object {
-        "$class": "org.accordproject.decoratorcommands@0.3.0.CommandTarget",
+        "$class": "org.accordproject.decoratorcommands@0.4.0.CommandTarget",
         "declaration": "Address",
         "namespace": "org.acme@1.0.0",
       },
       "type": "UPSERT",
     },
     Object {
-      "$class": "org.accordproject.decoratorcommands@0.3.0.Command",
+      "$class": "org.accordproject.decoratorcommands@0.4.0.Command",
       "decorator": Object {
         "$class": "concerto.metamodel@1.0.0.Decorator",
         "arguments": Array [
@@ -252,14 +252,14 @@ Object {
         "name": "Term_description",
       },
       "target": Object {
-        "$class": "org.accordproject.decoratorcommands@0.3.0.CommandTarget",
+        "$class": "org.accordproject.decoratorcommands@0.4.0.CommandTarget",
         "declaration": "Address",
         "namespace": "org.acme@1.0.0",
       },
       "type": "UPSERT",
     },
     Object {
-      "$class": "org.accordproject.decoratorcommands@0.3.0.Command",
+      "$class": "org.accordproject.decoratorcommands@0.4.0.Command",
       "decorator": Object {
         "$class": "concerto.metamodel@1.0.0.Decorator",
         "arguments": Array [
@@ -271,14 +271,14 @@ Object {
         "name": "Term_tooltip",
       },
       "target": Object {
-        "$class": "org.accordproject.decoratorcommands@0.3.0.CommandTarget",
+        "$class": "org.accordproject.decoratorcommands@0.4.0.CommandTarget",
         "declaration": "Address",
         "namespace": "org.acme@1.0.0",
       },
       "type": "UPSERT",
     },
     Object {
-      "$class": "org.accordproject.decoratorcommands@0.3.0.Command",
+      "$class": "org.accordproject.decoratorcommands@0.4.0.Command",
       "decorator": Object {
         "$class": "concerto.metamodel@1.0.0.Decorator",
         "arguments": Array [
@@ -290,7 +290,7 @@ Object {
         "name": "Term",
       },
       "target": Object {
-        "$class": "org.accordproject.decoratorcommands@0.3.0.CommandTarget",
+        "$class": "org.accordproject.decoratorcommands@0.4.0.CommandTarget",
         "declaration": "Address",
         "mapElement": "KEY",
         "namespace": "org.acme@1.0.0",
@@ -298,7 +298,7 @@ Object {
       "type": "UPSERT",
     },
     Object {
-      "$class": "org.accordproject.decoratorcommands@0.3.0.Command",
+      "$class": "org.accordproject.decoratorcommands@0.4.0.Command",
       "decorator": Object {
         "$class": "concerto.metamodel@1.0.0.Decorator",
         "arguments": Array [
@@ -310,7 +310,7 @@ Object {
         "name": "Term",
       },
       "target": Object {
-        "$class": "org.accordproject.decoratorcommands@0.3.0.CommandTarget",
+        "$class": "org.accordproject.decoratorcommands@0.4.0.CommandTarget",
         "declaration": "Address",
         "mapElement": "VALUE",
         "namespace": "org.acme@1.0.0",
@@ -318,7 +318,7 @@ Object {
       "type": "UPSERT",
     },
     Object {
-      "$class": "org.accordproject.decoratorcommands@0.3.0.Command",
+      "$class": "org.accordproject.decoratorcommands@0.4.0.Command",
       "decorator": Object {
         "$class": "concerto.metamodel@1.0.0.Decorator",
         "arguments": Array [
@@ -330,14 +330,14 @@ Object {
         "name": "Term",
       },
       "target": Object {
-        "$class": "org.accordproject.decoratorcommands@0.3.0.CommandTarget",
+        "$class": "org.accordproject.decoratorcommands@0.4.0.CommandTarget",
         "declaration": "Truck",
         "namespace": "org.acme@1.0.0",
       },
       "type": "UPSERT",
     },
     Object {
-      "$class": "org.accordproject.decoratorcommands@0.3.0.Command",
+      "$class": "org.accordproject.decoratorcommands@0.4.0.Command",
       "decorator": Object {
         "$class": "concerto.metamodel@1.0.0.Decorator",
         "arguments": Array [
@@ -349,14 +349,14 @@ Object {
         "name": "Term_description",
       },
       "target": Object {
-        "$class": "org.accordproject.decoratorcommands@0.3.0.CommandTarget",
+        "$class": "org.accordproject.decoratorcommands@0.4.0.CommandTarget",
         "declaration": "Truck",
         "namespace": "org.acme@1.0.0",
       },
       "type": "UPSERT",
     },
     Object {
-      "$class": "org.accordproject.decoratorcommands@0.3.0.Command",
+      "$class": "org.accordproject.decoratorcommands@0.4.0.Command",
       "decorator": Object {
         "$class": "concerto.metamodel@1.0.0.Decorator",
         "arguments": Array [
@@ -368,7 +368,7 @@ Object {
         "name": "Term",
       },
       "target": Object {
-        "$class": "org.accordproject.decoratorcommands@0.3.0.CommandTarget",
+        "$class": "org.accordproject.decoratorcommands@0.4.0.CommandTarget",
         "declaration": "Truck",
         "namespace": "org.acme@1.0.0",
         "property": "weight",
@@ -376,7 +376,7 @@ Object {
       "type": "UPSERT",
     },
     Object {
-      "$class": "org.accordproject.decoratorcommands@0.3.0.Command",
+      "$class": "org.accordproject.decoratorcommands@0.4.0.Command",
       "decorator": Object {
         "$class": "concerto.metamodel@1.0.0.Decorator",
         "arguments": Array [
@@ -388,7 +388,7 @@ Object {
         "name": "Term_description",
       },
       "target": Object {
-        "$class": "org.accordproject.decoratorcommands@0.3.0.CommandTarget",
+        "$class": "org.accordproject.decoratorcommands@0.4.0.CommandTarget",
         "declaration": "Truck",
         "namespace": "org.acme@1.0.0",
         "property": "weight",
@@ -396,7 +396,7 @@ Object {
       "type": "UPSERT",
     },
     Object {
-      "$class": "org.accordproject.decoratorcommands@0.3.0.Command",
+      "$class": "org.accordproject.decoratorcommands@0.4.0.Command",
       "decorator": Object {
         "$class": "concerto.metamodel@1.0.0.Decorator",
         "arguments": Array [
@@ -408,7 +408,7 @@ Object {
         "name": "Term_tooltip",
       },
       "target": Object {
-        "$class": "org.accordproject.decoratorcommands@0.3.0.CommandTarget",
+        "$class": "org.accordproject.decoratorcommands@0.4.0.CommandTarget",
         "declaration": "Truck",
         "namespace": "org.acme@1.0.0",
         "property": "weight",
@@ -416,7 +416,7 @@ Object {
       "type": "UPSERT",
     },
     Object {
-      "$class": "org.accordproject.decoratorcommands@0.3.0.Command",
+      "$class": "org.accordproject.decoratorcommands@0.4.0.Command",
       "decorator": Object {
         "$class": "concerto.metamodel@1.0.0.Decorator",
         "arguments": Array [
@@ -428,7 +428,7 @@ Object {
         "name": "Term",
       },
       "target": Object {
-        "$class": "org.accordproject.decoratorcommands@0.3.0.CommandTarget",
+        "$class": "org.accordproject.decoratorcommands@0.4.0.CommandTarget",
         "declaration": "Truck",
         "namespace": "org.acme@1.0.0",
         "property": "vin",
@@ -436,7 +436,7 @@ Object {
       "type": "UPSERT",
     },
     Object {
-      "$class": "org.accordproject.decoratorcommands@0.3.0.Command",
+      "$class": "org.accordproject.decoratorcommands@0.4.0.Command",
       "decorator": Object {
         "$class": "concerto.metamodel@1.0.0.Decorator",
         "arguments": Array [
@@ -448,7 +448,7 @@ Object {
         "name": "Term_tooltip",
       },
       "target": Object {
-        "$class": "org.accordproject.decoratorcommands@0.3.0.CommandTarget",
+        "$class": "org.accordproject.decoratorcommands@0.4.0.CommandTarget",
         "declaration": "Truck",
         "namespace": "org.acme@1.0.0",
         "property": "vin",
@@ -456,7 +456,7 @@ Object {
       "type": "UPSERT",
     },
     Object {
-      "$class": "org.accordproject.decoratorcommands@0.3.0.Command",
+      "$class": "org.accordproject.decoratorcommands@0.4.0.Command",
       "decorator": Object {
         "$class": "concerto.metamodel@1.0.0.Decorator",
         "arguments": Array [
@@ -468,7 +468,7 @@ Object {
         "name": "Term",
       },
       "target": Object {
-        "$class": "org.accordproject.decoratorcommands@0.3.0.CommandTarget",
+        "$class": "org.accordproject.decoratorcommands@0.4.0.CommandTarget",
         "declaration": "Truck",
         "namespace": "org.acme@1.0.0",
         "property": "color",
@@ -476,7 +476,7 @@ Object {
       "type": "UPSERT",
     },
     Object {
-      "$class": "org.accordproject.decoratorcommands@0.3.0.Command",
+      "$class": "org.accordproject.decoratorcommands@0.4.0.Command",
       "decorator": Object {
         "$class": "concerto.metamodel@1.0.0.Decorator",
         "arguments": Array [
@@ -488,7 +488,7 @@ Object {
         "name": "Term",
       },
       "target": Object {
-        "$class": "org.accordproject.decoratorcommands@0.3.0.CommandTarget",
+        "$class": "org.accordproject.decoratorcommands@0.4.0.CommandTarget",
         "declaration": "Truck",
         "namespace": "org.acme@1.0.0",
         "property": "$identifier",
@@ -496,7 +496,7 @@ Object {
       "type": "UPSERT",
     },
     Object {
-      "$class": "org.accordproject.decoratorcommands@0.3.0.Command",
+      "$class": "org.accordproject.decoratorcommands@0.4.0.Command",
       "decorator": Object {
         "$class": "concerto.metamodel@1.0.0.Decorator",
         "arguments": Array [
@@ -508,14 +508,14 @@ Object {
         "name": "Term",
       },
       "target": Object {
-        "$class": "org.accordproject.decoratorcommands@0.3.0.CommandTarget",
+        "$class": "org.accordproject.decoratorcommands@0.4.0.CommandTarget",
         "declaration": "Thing",
         "namespace": "org.accordproject@1.0.0",
       },
       "type": "UPSERT",
     },
     Object {
-      "$class": "org.accordproject.decoratorcommands@0.3.0.Command",
+      "$class": "org.accordproject.decoratorcommands@0.4.0.Command",
       "decorator": Object {
         "$class": "concerto.metamodel@1.0.0.Decorator",
         "arguments": Array [
@@ -527,7 +527,7 @@ Object {
         "name": "Term",
       },
       "target": Object {
-        "$class": "org.accordproject.decoratorcommands@0.3.0.CommandTarget",
+        "$class": "org.accordproject.decoratorcommands@0.4.0.CommandTarget",
         "declaration": "Thing",
         "namespace": "org.accordproject@1.0.0",
         "property": "name",


### PR DESCRIPTION
<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #<CORRESPONDING ISSUE NUMBER>
Expose migrateTo and canMigrate methods from DecoratorManager. These were previously private methods.

### Screenshots or Video
<!--- Provide an easily accessible demonstration of the changes, if applicable -->

### Related Issues
- Issue #<NUMBER>
- Pull Request #<NUMBER>

### Author Checklist
- [ ] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [ ] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ ] Merging to `main` from `fork:branchname`
