### PR TITLE
Update the ModelManager to handle multiple metamodel versions.

### DIFF
--- a/packages/concerto-core/lib/modelmanager.js
+++ b/packages/concerto-core/lib/modelmanager.js
@@ -70,6 +70,7 @@ class ModelManager extends BaseModelManager {
      */
     constructor(options) {
         super(options, ctoProcessFile(options));
+        this.metamodelVersions = ['1.0.0', '1.1.0']; // Add supported metamodel versions here
     }
 
     /**
@@ -88,6 +89,30 @@ class ModelManager extends BaseModelManager {
         return this.addModel(cto, cto, fileName, disableValidation);
     }
 
+    /**
+     * Validates the metamodel version.
+     * @param {string} version - The metamodel version to validate.
+     * @throws {Error} If the version is not supported.
+     */
+    validateMetamodelVersion(version) {
+        if (!this.metamodelVersions.includes(version)) {
+            throw new Error(`Unsupported metamodel version: ${version}`);
+        }
+    }
+
+    /**
+     * Adds a model in AST format to the ModelManager.
+     * @param {object} ast - The AST of the model.
+     * @param {string} [fileName] - An optional file name to associate with the model file.
+     * @param {boolean} [disableValidation] - If true then the model files are not validated.
+     * @throws {IllegalModelException}
+     * @return {ModelFile} The newly added model file (internal).
+     */
+    addModel(ast, cto, fileName, disableValidation) {
+        const version = ast.$class.split('@')[1];
+        this.validateMetamodelVersion(version);
+        return super.addModel(ast, cto, fileName, disableValidation);
+    }
 }
 
 module.exports = ModelManager;

--- a/packages/concerto-core/test/modelmanager.js
+++ b/packages/concerto-core/test/modelmanager.js
@@ -302,6 +302,18 @@ describe('ModelManager', () => {
                 basemodelmanager.addModel(ast, undefined, 'origFile');
             }).should.throw('Model file version 99.0.0 does not match metamodel version 1.0.0');
         });
+
+        it('should throw when using an unknown metamodel version', () => {
+            const basemodelmanager = new BaseModelManager({ strict: true, metamodelValidation: true });
+            const ast = {
+                $class: 'concerto.metamodel@99.0.0.Model',
+                namespace: 'org.acme@1.0.0',
+                undeclared: []
+            };
+            (() => {
+                basemodelmanager.addModel(ast, undefined, 'origFile');
+            }).should.throw('Model file version 99.0.0 does not match metamodel version 1.0.0');
+        });
     });
 
     describe('#addModelFiles', () => {


### PR DESCRIPTION

# Closes #556 

- This PR adds metamodel versioning support to the Concerto codebase, allowing for the validation and processing of multiple metamodel versions (1.0.0 and 1.1.0). It introduces a dynamic versioning strategy to ensure backward compatibility and prepare for future versions.  

### Changes

- Added metamodelVersions array to ModelManager to store supported metamodel versions.
- Implemented validateMetamodelVersion method to check the version before adding a model.
- Refactored addModel to extract the version from ast.$class and validate it.
- Enhanced error messages for unsupported versions.

### Flags

- Future versions (2.x) will require a separate strategy to ensure backward compatibility.
- This PR only supports 1.0.0 and 1.1.0 for now

### Related Issues
- Issue #556 
