### PR TITLE
feat(decorators): added support for multiple decorators

### DIFF
--- a/packages/concerto-core/lib/decoratorextractor.js
+++ b/packages/concerto-core/lib/decoratorextractor.js
@@ -190,7 +190,7 @@ class DecoratorExtractor {
      * @private
      */
     parseNonVocabularyDecorators(dcsObjects, dcs, DCS_VERSION, target){
-        const decotatorObj = {
+        const decoratorObj = {
             '$class': 'concerto.metamodel@1.0.0.Decorator',
             'name': dcs.name,
         };
@@ -201,15 +201,29 @@ class DecoratorExtractor {
                     'value':arg.value
                 };
             });
-            decotatorObj.arguments = args;
+            decoratorObj.arguments = args;
         }
-        let dcsObject = {
-            '$class': `org.accordproject.decoratorcommands@${DCS_VERSION}.Command`,
-            'type': 'UPSERT',
-            'target': target,
-            'decorator': decotatorObj,
-        };
-        dcsObjects.push(dcsObject);
+
+        // Check if we already have a command with the same target
+        const existingCommandIndex = dcsObjects.findIndex(command => {
+            return JSON.stringify(command.target) === JSON.stringify(target);
+        });
+
+        if (existingCommandIndex !== -1) {
+            // If the command already exists, add the decorator to the decorators array
+            const existingCommand = dcsObjects[existingCommandIndex];
+            existingCommand.decorators.push(decoratorObj);
+        } else {
+            // If the command doesn't exist, create a new one with the decorator in the decorators array
+            let dcsObject = {
+                '$class': `org.accordproject.decoratorcommands@${DCS_VERSION}.Command`,
+                'type': 'UPSERT',
+                'target': target,
+                'decorators': [decoratorObj]
+            };
+            dcsObjects.push(dcsObject);
+        }
+
         return dcsObjects;
     }
     /**

--- a/packages/concerto-core/lib/decoratormanager.js
+++ b/packages/concerto-core/lib/decoratormanager.js
@@ -77,11 +77,11 @@ enum MapElement {
 }
 
 /**
- * Applies a decorator to a given target
+ * Applies decorators to a given target
  */
 concept Command {
     o CommandTarget target
-    o Decorator decorator
+    o Decorator[] decorators
     o CommandType type
     o String decoratorNamespace optional
 }
@@ -687,11 +687,15 @@ class DecoratorManager {
      * @param {*} command the Command object from the dcs
      */
     static executeNamespaceCommand(model, command) {
-        const { target, decorator, type } = command;
+        const { target, decorators, type } = command;
         if (Object.keys(target).length === 2 && target.namespace) {
             const { name } = ModelUtil.parseNamespace( model.namespace );
             if(this.falsyOrEqual(target.namespace, [model.namespace, name])) {
-                this.applyDecorator(model, type, decorator);
+                if (decorators && decorators.length > 0) {
+                    decorators.forEach(dec => {
+                        this.applyDecorator(model, type, dec);
+                    });
+                }
             }
         }
     }
@@ -708,7 +712,7 @@ class DecoratorManager {
      * org.accordproject.decoratorcommands model
      */
     static executeCommand(namespace, declaration, command, property, options) {
-        const { target, decorator, type } = command;
+        const { target, decorators, type } = command;
         const { name } = ModelUtil.parseNamespace( namespace );
         if (this.falsyOrEqual(target.namespace, [namespace,name]) &&
             this.falsyOrEqual(target.declaration, [declaration.name])) {
@@ -718,25 +722,49 @@ class DecoratorManager {
                     switch (target.mapElement) {
                     case 'KEY':
                     case 'VALUE':
-                        this.applyDecoratorForMapElement(target.mapElement, target, declaration, type, decorator);
+                        if (decorators && decorators.length > 0) {
+                            decorators.forEach(dec => {
+                                this.applyDecoratorForMapElement(target.mapElement, target, declaration, type, dec);
+                            });
+                        }
                         break;
                     case 'KEY_VALUE':
-                        this.applyDecoratorForMapElement('KEY', target, declaration, type, decorator);
-                        this.applyDecoratorForMapElement('VALUE', target, declaration, type, decorator);
+                        if (decorators && decorators.length > 0) {
+                            decorators.forEach(dec => {
+                                this.applyDecoratorForMapElement('KEY', target, declaration, type, dec);
+                                this.applyDecoratorForMapElement('VALUE', target, declaration, type, dec);
+                            });
+                        }
                         break;
                     }
                 } else if (target.type) {
                     if (this.falsyOrEqual(target.type, declaration.key.$class)) {
-                        this.applyDecorator(declaration.key, type, decorator);
+                        if (decorators && decorators.length > 0) {
+                            decorators.forEach(dec => {
+                                this.applyDecorator(declaration.key, type, dec);
+                            });
+                        }
                     }
                     if (this.falsyOrEqual(target.type, declaration.value.$class)) {
-                        this.applyDecorator(declaration.value, type, decorator);
+                        if (decorators && decorators.length > 0) {
+                            decorators.forEach(dec => {
+                                this.applyDecorator(declaration.value, type, dec);
+                            });
+                        }
                     }
                 } else {
-                    this.checkForNamespaceTargetAndApplyDecorator(declaration, type, decorator, target, options?.enableDcsNamespaceTarget);
+                    if (decorators && decorators.length > 0) {
+                        decorators.forEach(dec => {
+                            this.checkForNamespaceTargetAndApplyDecorator(declaration, type, dec, target, options?.enableDcsNamespaceTarget);
+                        });
+                    }
                 }
             } else if (!(target.property || target.properties || target.type)) {
-                this.checkForNamespaceTargetAndApplyDecorator(declaration, type, decorator, target, options?.enableDcsNamespaceTarget);
+                if (decorators && decorators.length > 0) {
+                    decorators.forEach(dec => {
+                        this.checkForNamespaceTargetAndApplyDecorator(declaration, type, dec, target, options?.enableDcsNamespaceTarget);
+                    });
+                }
             } else {
                 if(property) {
                     this.executePropertyCommand(property, command);
@@ -753,7 +781,7 @@ class DecoratorManager {
      * org.accordproject.decoratorcommands model
      */
     static executePropertyCommand(property, command) {
-        const { target, decorator, type } = command;
+        const { target, decorators, type } = command;
         if(target.properties || target.property || target.type) {
             if (
                 this.falsyOrEqual(
@@ -762,7 +790,11 @@ class DecoratorManager {
                 ) &&
                 this.falsyOrEqual(target.type, [property.$class])
             ) {
-                this.applyDecorator(property, type, decorator);
+                if (decorators && decorators.length > 0) {
+                    decorators.forEach(dec => {
+                        this.applyDecorator(property, type, dec);
+                    });
+                }
             }
         }
     }

--- a/packages/concerto-vocabulary/lib/vocabularymanager.js
+++ b/packages/concerto-vocabulary/lib/vocabularymanager.js
@@ -300,7 +300,7 @@ class VocabularyManager {
         const getPropertyNames = (declaration) => {
             if (declaration.getProperties) {
                 return declaration.getProperties().map(property => property.getName());
-            } else if(declaration.isMapDeclaration?.()) {
+            } else if (declaration.isMapDeclaration?.()) {
                 return ['KEY', 'VALUE'];
             } else {
                 return [];
@@ -311,102 +311,64 @@ class VocabularyManager {
             model.getAllDeclarations().forEach(decl => {
                 const terms = this.resolveTerms(modelManager, model.getNamespace(), locale, decl.getName());
                 if (terms) {
-                    Object.keys(terms).forEach( term => {
-                        if(term === decl.getName()) {
-                            decoratorCommandSet.commands.push({
-                                '$class': `${DC_NAMESPACE}.Command`,
-                                'type': 'UPSERT',
-                                'target': {
-                                    '$class': `${DC_NAMESPACE}.CommandTarget`,
-                                    'namespace': model.getNamespace(),
-                                    'declaration': decl.getName(),
+                    const decorators = [];
+
+                    Object.keys(terms).forEach(term => {
+                        const decoratorName = term === decl.getName() ? 'Term' : `Term_${term}`;
+                        const decoratorObj = {
+                            '$class': `${MetaModelNamespace}.Decorator`,
+                            'name': decoratorName,
+                            'arguments': [
+                                {
+                                    '$class': `${MetaModelNamespace}.DecoratorString`,
+                                    'value': terms[term]
                                 },
-                                'decorator': {
-                                    '$class': `${MetaModelNamespace}.Decorator`,
-                                    'name': 'Term',
-                                    'arguments': [
-                                        {
-                                            '$class': `${MetaModelNamespace}.DecoratorString`,
-                                            'value': terms[term]
-                                        },
-                                    ]
-                                }
-                            });
-                        }
-                        else if(term.localeCompare('properties')) {
-                            decoratorCommandSet.commands.push({
-                                '$class': `${DC_NAMESPACE}.Command`,
-                                'type': 'UPSERT',
-                                'target': {
-                                    '$class': `${DC_NAMESPACE}.CommandTarget`,
-                                    'namespace': model.getNamespace(),
-                                    'declaration': decl.getName(),
-                                },
-                                'decorator': {
-                                    '$class': `${MetaModelNamespace}.Decorator`,
-                                    'name': `Term_${term}`,
-                                    'arguments': [
-                                        {
-                                            '$class': `${MetaModelNamespace}.DecoratorString`,
-                                            'value': terms[term]
-                                        },
-                                    ]
-                                }
-                            });
-                        }
+                            ]
+                        };
+                        decorators.push(decoratorObj);
+                    });
+                    decoratorCommandSet.commands.push({
+                        '$class': `${DC_NAMESPACE}.Command`,
+                        'type': 'UPSERT',
+                        'target': {
+                            '$class': `${DC_NAMESPACE}.CommandTarget`,
+                            'namespace': model.getNamespace(),
+                            'declaration': decl.getName(),
+                        },
+                        'decorators': decorators
                     });
                 }
-
                 const propertyNames = getPropertyNames(decl);
                 propertyNames.forEach(propertyName => {
                     const propertyTerms = this.resolveTerms(modelManager, model.getNamespace(), locale, decl.getName(), propertyName);
                     if (propertyTerms) {
-                        Object.keys(propertyTerms).forEach( term => {
-                            const propertyType = propertyName === 'KEY' || propertyName === 'VALUE'  ? 'mapElement' : 'property';
-                            if(term === propertyName) {
-                                decoratorCommandSet.commands.push({
-                                    '$class': `${DC_NAMESPACE}.Command`,
-                                    'type': 'UPSERT',
-                                    'target': {
-                                        '$class': `${DC_NAMESPACE}.CommandTarget`,
-                                        'namespace': model.getNamespace(),
-                                        'declaration': decl.getName(),
-                                        [propertyType]: propertyName
+                        const decorators = [];
+
+                        Object.keys(propertyTerms).forEach(term => {
+                            const propertyType = propertyName === 'KEY' || propertyName === 'VALUE' ? 'mapElement' : 'property';
+                            const decoratorName = term === propertyName ? 'Term' : `Term_${term}`;
+                            const decoratorObj = {
+                                '$class': `${MetaModelNamespace}.Decorator`,
+                                'name': decoratorName,
+                                'arguments': [
+                                    {
+                                        '$class': `${MetaModelNamespace}.DecoratorString`,
+                                        'value': propertyTerms[term]
                                     },
-                                    'decorator': {
-                                        '$class': `${MetaModelNamespace}.Decorator`,
-                                        'name': 'Term',
-                                        'arguments': [
-                                            {
-                                                '$class': `${MetaModelNamespace}.DecoratorString`,
-                                                'value': propertyTerms[term]
-                                            },
-                                        ]
-                                    }
-                                });
-                            }
-                            else {
-                                decoratorCommandSet.commands.push({
-                                    '$class': `${DC_NAMESPACE}.Command`,
-                                    'type': 'UPSERT',
-                                    'target': {
-                                        '$class': `${DC_NAMESPACE}.CommandTarget`,
-                                        'namespace': model.getNamespace(),
-                                        'declaration': decl.getName(),
-                                        [propertyType]: propertyName
-                                    },
-                                    'decorator': {
-                                        '$class': `${MetaModelNamespace}.Decorator`,
-                                        'name': `Term_${term}`,
-                                        'arguments': [
-                                            {
-                                                '$class': `${MetaModelNamespace}.DecoratorString`,
-                                                'value': propertyTerms[term]
-                                            },
-                                        ]
-                                    }
-                                });
-                            }
+                                ]
+                            };
+                            decorators.push(decoratorObj);
+                        });
+                        decoratorCommandSet.commands.push({
+                            '$class': `${DC_NAMESPACE}.Command`,
+                            'type': 'UPSERT',
+                            'target': {
+                                '$class': `${DC_NAMESPACE}.CommandTarget`,
+                                'namespace': model.getNamespace(),
+                                'declaration': decl.getName(),
+                                [propertyType]: propertyName
+                            },
+                            'decorators': decorators
                         });
                     }
                 });


### PR DESCRIPTION
<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->

# Closes #992

<!--- Provide an overall summary of the pull request -->
This PR adds support for handling multiple decorators per target in Concerto models. Currently, only single decorators are handled, and this enhancement allows parsing and processing of multiple decorators

### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
- Modified `DecoratorManager.js`, `DecoratorExtractor.js`, and `VocabularyManager.js` to support parsing and processing of multiple decorators.
- Updated related functions to handle decorator arrays instead of single instances.

### Flags
<!--- Provide context or concerns a reviewer should be aware of -->
- Need to add additional test coverage based on maintainers' input.

### Screenshots or Video
<!--- Provide an easily accessible demonstration of the changes, if applicable -->

### Related Issues
- Issue #992 

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [x] Merging to `main` from `fork:branchname`
