### PR TITLE
fix(scalar): add validation for scalar declarations

### DIFF
--- a/packages/concerto-core/lib/introspect/scalardeclaration.js
+++ b/packages/concerto-core/lib/introspect/scalardeclaration.js
@@ -20,7 +20,8 @@ const Declaration = require('./declaration');
 const NumberValidator = require('./numbervalidator');
 const StringValidator = require('./stringvalidator');
 const Util = require('@accordproject/concerto-util').NullUtil;
-
+const IllegalModelException = require('../../lib/introspect/illegalmodelexception');
+const ModelUtil = require('../modelutil');
 // Types needed for TypeScript generation.
 /* eslint-disable no-unused-vars */
 /* istanbul ignore next */
@@ -51,6 +52,13 @@ class ScalarDeclaration extends Declaration {
     process() {
         super.process();
 
+        const scalarName = this.getName(); // Get the local name of the scalar
+        if (ModelUtil.isPrimitiveType(scalarName)) {
+            throw new IllegalModelException(
+                `Invalid scalar name '${scalarName}'. Name conflicts with primitive type.`,
+                this.ast.name.location // Directly use the AST node's location
+            );
+        }
         this.superType = null;
         this.superTypeDeclaration = null;
         this.idField = null;

--- a/packages/concerto-core/test/introspect/scalardeclaration.js
+++ b/packages/concerto-core/test/introspect/scalardeclaration.js
@@ -15,11 +15,13 @@
 'use strict';
 
 const ScalarDeclaration = require('../../lib/introspect/scalardeclaration');
+const IllegalModelException = require('../../lib/introspect/illegalmodelexception'); // ADDED MISSING IMPORT
 const IntrospectUtils = require('./introspectutils');
 const ParserUtil = require('./parserutility');
 
 const ModelManager = require('../../lib/modelmanager');
 const Util = require('../composer/composermodelutility');
+const { MetaModelNamespace } = require('@accordproject/concerto-metamodel');
 
 const should = require('chai').should();
 const sinon = require('sinon');
@@ -36,7 +38,28 @@ describe('ScalarDeclaration', () => {
         introspectUtils = new IntrospectUtils(modelManager);
         modelFile = ParserUtil.newModelFile(modelManager, 'namespace com.hyperledger.testing', 'org.acme.cto');
     });
+    describe('Primitive type name conflict', () => {
+        it('should throw an error when scalar name is a primitive type', () => {
+            const primitives = ['String', 'Integer', 'Boolean', 'DateTime', 'Double', 'Long'];
+            primitives.forEach(primitive => {
+                (() => {
+                    new ScalarDeclaration(modelFile, {
+                        name: primitive,
+                        $class: `${MetaModelNamespace}.StringScalar`
+                    });
+                }).should.throw(IllegalModelException, `Invalid scalar name '${primitive}'. Name conflicts with primitive type.`);
+            });
+        });
 
+        it('should not throw when scalar name is valid', () => {
+            (() => {
+                new ScalarDeclaration(modelFile, {
+                    name: 'ValidScalar',
+                    $class: `${MetaModelNamespace}.StringScalar`
+                });
+            }).should.not.throw();
+        });
+    });
     describe('#accept', () => {
         it('should call the visitor', () => {
             let clz = new ScalarDeclaration(modelFile, {


### PR DESCRIPTION
## **Prevent primitive type names in Scalar declarations**
Closes #994 
### **Changes**
- Added validation to reject scalar declarations using primitive type names
- Implemented unit tests for scalar name validation
- Updated error messaging with proper source location

### **Validation Error Demonstration**
*Reproduction of issue #994 scenario: Error when using `String` as scalar name in test model from original report*
![Screenshot 2025-03-15 210241](https://github.com/user-attachments/assets/369f0781-fa53-4686-9719-83a327d09f53)

### **Unit Test Evidence**
![Screenshot 2025-03-15 213532](https://github.com/user-attachments/assets/fe8aa8fc-99e4-47e8-8911-c43615a8a532)

### **Notes**
- Fixes potential namespace collisions with primitive types
- Maintains backward compatibility (no breaking changes)
- Console warnings in test output are pre-existing issues

### Author Checklist
- [x] DCO sign-off provided (`git commit -s`)
- [x] Unit tests added for primitive type validation
- [x] Commit messages follow AP format
- [x] No documentation changes needed (validation errors are self-explanatory).
- [x] Branch follows `fork:issue-purpose` naming (`Ahmed-Gaper/i994/scalar-validation-fix`)
