### PR TITLE
fix(analysis): detect changes for various model modifications

### DIFF
--- a/packages/concerto-analysis/src/compare-config.ts
+++ b/packages/concerto-analysis/src/compare-config.ts
@@ -53,6 +53,8 @@ export const defaultCompareConfig: CompareConfig = {
         'optional-property-added': CompareResult.PATCH,
         'required-property-removed': CompareResult.MAJOR,
         'optional-property-removed': CompareResult.MAJOR,
+        'optional-to-required-property': CompareResult.MAJOR,
+        'required-to-optional-property': CompareResult.PATCH,
         'namespace-changed': CompareResult.ERROR,
         'enum-value-added': CompareResult.PATCH,
         'enum-value-removed': CompareResult.MAJOR,

--- a/packages/concerto-analysis/src/compare-config.ts
+++ b/packages/concerto-analysis/src/compare-config.ts
@@ -72,6 +72,9 @@ export const defaultCompareConfig: CompareConfig = {
         'scalar-default-value-added': CompareResult.PATCH,
         'scalar-default-value-removed': CompareResult.MAJOR,
         'scalar-default-value-changed': CompareResult.MAJOR,
+        'property-default-value-added': CompareResult.PATCH,
+        'property-default-value-removed': CompareResult.MAJOR,
+        'property-default-value-changed': CompareResult.MAJOR,
     },
 };
 
@@ -177,3 +180,6 @@ export class CompareConfigBuilder {
         return this;
     }
 }
+
+export const DEFAULT_COMPARER_FACTORIES_COUNT = defaultCompareConfig.comparerFactories.length;
+export const DEFAULT_RULES_COUNT = Object.keys(defaultCompareConfig.rules).length;

--- a/packages/concerto-analysis/src/compare-config.ts
+++ b/packages/concerto-analysis/src/compare-config.ts
@@ -69,6 +69,9 @@ export const defaultCompareConfig: CompareConfig = {
         'scalar-validator-added': CompareResult.MAJOR,
         'scalar-validator-removed': CompareResult.PATCH,
         'scalar-validator-changed': CompareResult.MAJOR,
+        'scalar-default-value-added': CompareResult.PATCH,
+        'scalar-default-value-removed': CompareResult.MAJOR,
+        'scalar-default-value-changed': CompareResult.MAJOR,
     },
 };
 

--- a/packages/concerto-analysis/src/compare-config.ts
+++ b/packages/concerto-analysis/src/compare-config.ts
@@ -69,12 +69,12 @@ export const defaultCompareConfig: CompareConfig = {
         'scalar-validator-added': CompareResult.MAJOR,
         'scalar-validator-removed': CompareResult.PATCH,
         'scalar-validator-changed': CompareResult.MAJOR,
-        'scalar-default-value-added': CompareResult.PATCH,
+        'scalar-default-value-added': CompareResult.MINOR,
         'scalar-default-value-removed': CompareResult.MAJOR,
-        'scalar-default-value-changed': CompareResult.MAJOR,
-        'property-default-value-added': CompareResult.PATCH,
+        'scalar-default-value-changed': CompareResult.PATCH,
+        'property-default-value-added': CompareResult.MINOR,
         'property-default-value-removed': CompareResult.MAJOR,
-        'property-default-value-changed': CompareResult.MAJOR,
+        'property-default-value-changed': CompareResult.PATCH,
     },
 };
 

--- a/packages/concerto-analysis/src/comparers/properties.ts
+++ b/packages/concerto-analysis/src/comparers/properties.ts
@@ -236,4 +236,36 @@ const propertyValidatorChanged: ComparerFactory = (context) => ({
     }
 });
 
-export const propertyComparerFactories = [propertyAdded, propertyRemoved, propertyTypeChanged, propertyValidatorChanged];
+const propertyOptionalChanged: ComparerFactory = (context) => ({
+    compareProperty: (a, b) => {
+        if (!a || !b) {
+            return;
+        }
+        const aIsOptional = a.isOptional();
+        const bIsOptional = b.isOptional();
+        if (aIsOptional === bIsOptional) {
+            return;
+        }
+        if(aIsOptional && !bIsOptional) {
+            const classDeclarationType = getDeclarationType(a.getParent());
+            const type = getPropertyType(a);
+            context.report({
+                key: 'optional-to-required-property',
+                message: `The optional ${type} "${a.getName()}" was changed to be required in the ${classDeclarationType} "${a.getParent().getName()}"`,
+                element: a,
+            });
+            return;
+        }else{
+            const classDeclarationType = getDeclarationType(a.getParent());
+            const type = getPropertyType(a);
+            context.report({
+                key: 'required-to-optional-property',
+                message: `The required ${type} "${a.getName()}" was changed to be optional in the ${classDeclarationType} "${a.getParent().getName()}"`,
+                element: a,
+            });
+            return;
+        }
+    }
+});
+
+export const propertyComparerFactories = [propertyAdded, propertyRemoved, propertyTypeChanged, propertyValidatorChanged, propertyOptionalChanged];

--- a/packages/concerto-analysis/src/comparers/properties.ts
+++ b/packages/concerto-analysis/src/comparers/properties.ts
@@ -268,4 +268,28 @@ const propertyOptionalChanged: ComparerFactory = (context) => ({
     }
 });
 
-export const propertyComparerFactories = [propertyAdded, propertyRemoved, propertyTypeChanged, propertyValidatorChanged, propertyOptionalChanged];
+const propertyDefaultChanged: ComparerFactory = (context) => ({
+    compareProperty: (a, b) => {
+        if (!a || !b) {return;}
+
+        const aAST = JSON.parse(JSON.stringify(a.ast));
+        const bAST = JSON.parse(JSON.stringify(b.ast));
+        const aDefaultValue = aAST.defaultValue ?? null;
+        const bDefaultValue = bAST.defaultValue ?? null;
+
+        if (aDefaultValue === bDefaultValue) {return;}
+
+        const changeType = !aDefaultValue ? 'added'
+            : !bDefaultValue ? 'removed' : 'changed';
+        const classDeclarationType = getDeclarationType(a.getParent());
+        context.report({
+            key: `property-default-value-${changeType}`,
+            message: changeType === 'added' ? `Default value "${bDefaultValue}" added to property "${a.getName()}" in the ${classDeclarationType} "${a.getParent().getName()}"`
+                : changeType === 'removed' ? `Default value "${aDefaultValue}" removed from property "${a.getName()}" in the ${classDeclarationType} "${a.getParent().getName()}"`
+                    : `Default value changed from "${aDefaultValue}" to "${bDefaultValue}" in property "${a.getName()}" in the ${classDeclarationType} "${a.getParent().getName()}"`,
+            element: a.getName()
+        });
+    }
+});
+
+export const propertyComparerFactories = [propertyAdded, propertyRemoved, propertyTypeChanged, propertyValidatorChanged, propertyOptionalChanged, propertyDefaultChanged];

--- a/packages/concerto-analysis/src/comparers/scalar-declarations.ts
+++ b/packages/concerto-analysis/src/comparers/scalar-declarations.ts
@@ -69,4 +69,35 @@ const scalarValidatorChanged: ComparerFactory = (context) => ({
     }
 });
 
-export const scalarDeclarationComparerFactories = [scalarDeclarationExtendsChanged, scalarValidatorChanged];
+const scalarDefaultValueChanged: ComparerFactory = (context) => ({
+    compareScalarDeclaration: (a, b) => {
+        if (!a || !b) {return;}
+
+        const aDefaultValue = a.getDefaultValue() ?? null;
+        const bDefaultValue = b.getDefaultValue() ?? null;
+
+        if (aDefaultValue === bDefaultValue) {return;}
+
+        if (!aDefaultValue && bDefaultValue) {
+            context.report({
+                key: 'scalar-default-value-added',
+                message: `Default value "${bDefaultValue}" added to scalar "${a.getName()}"`,
+                element: a.getName()
+            });
+        } else if (aDefaultValue && !bDefaultValue) {
+            context.report({
+                key: 'scalar-default-value-removed',
+                message: `Default value "${aDefaultValue}" removed from scalar "${a.getName()}"`,
+                element: a.getName()
+            });
+        } else {
+            context.report({
+                key: 'scalar-default-value-changed',
+                message: `Default value changed from "${aDefaultValue}" to "${bDefaultValue}" in scalar "${a.getName()}"`,
+                element: a.getName()
+            });
+        }
+    }
+});
+
+export const scalarDeclarationComparerFactories = [scalarDeclarationExtendsChanged, scalarValidatorChanged, scalarDefaultValueChanged];

--- a/packages/concerto-analysis/test/fixtures/optional-to-required-a.cto
+++ b/packages/concerto-analysis/test/fixtures/optional-to-required-a.cto
@@ -1,0 +1,5 @@
+namespace org.accordproject.concerto.test@1.2.3
+
+concept Thing {
+  o String value optional
+}

--- a/packages/concerto-analysis/test/fixtures/optional-to-required-b.cto
+++ b/packages/concerto-analysis/test/fixtures/optional-to-required-b.cto
@@ -1,0 +1,5 @@
+namespace org.accordproject.concerto.test@1.2.3
+
+concept Thing {
+  o String value // Changed to required
+}

--- a/packages/concerto-analysis/test/fixtures/property-added.cto
+++ b/packages/concerto-analysis/test/fixtures/property-added.cto
@@ -1,0 +1,5 @@
+namespace org.accordproject.concerto.test@1.2.3
+
+concept Thing {
+  o String name
+}

--- a/packages/concerto-analysis/test/fixtures/property-default-value-added.cto
+++ b/packages/concerto-analysis/test/fixtures/property-default-value-added.cto
@@ -1,0 +1,5 @@
+namespace org.accordproject.concerto.test@1.2.3
+
+concept Thing {
+  o String name default="Fred"
+}

--- a/packages/concerto-analysis/test/fixtures/property-default-value-changed.cto
+++ b/packages/concerto-analysis/test/fixtures/property-default-value-changed.cto
@@ -1,0 +1,5 @@
+namespace org.accordproject.concerto.test@1.2.3
+
+concept Thing {
+  o String name default="NotFred"
+}

--- a/packages/concerto-analysis/test/fixtures/required-to-optional-a.cto
+++ b/packages/concerto-analysis/test/fixtures/required-to-optional-a.cto
@@ -1,0 +1,5 @@
+namespace org.accordproject.concerto.test@1.2.3
+
+concept Thing {
+  o String value // Required property
+}

--- a/packages/concerto-analysis/test/fixtures/required-to-optional-b.cto
+++ b/packages/concerto-analysis/test/fixtures/required-to-optional-b.cto
@@ -1,0 +1,5 @@
+namespace org.accordproject.concerto.test@1.2.3
+
+concept Thing {
+  o String value optional // Changed to optional
+}

--- a/packages/concerto-analysis/test/fixtures/scalar-default-value-added.cto
+++ b/packages/concerto-analysis/test/fixtures/scalar-default-value-added.cto
@@ -1,0 +1,3 @@
+namespace org.accordproject.concerto.test@1.2.3
+
+scalar Thing extends String default="hello"

--- a/packages/concerto-analysis/test/fixtures/scalar-default-value-changed.cto
+++ b/packages/concerto-analysis/test/fixtures/scalar-default-value-changed.cto
@@ -1,0 +1,3 @@
+namespace org.accordproject.concerto.test@1.2.3
+
+scalar Thing extends String default="bye"

--- a/packages/concerto-analysis/test/unit/compare-config.test.ts
+++ b/packages/concerto-analysis/test/unit/compare-config.test.ts
@@ -14,9 +14,8 @@ describe('CompareConfigBuilder', () => {
         const builder = new CompareConfigBuilder();
 
         const actual = builder.default().build();
-
-        expect(actual.comparerFactories.length).toEqual(11);
-        expect(Object.keys(actual.rules).length).toEqual(21);
+        expect(actual.comparerFactories.length).toEqual(14);
+        expect(Object.keys(actual.rules).length).toEqual(29);
         expect(actual.rules['class-declaration-added']).toEqual(CompareResult.MINOR);
         expect(actual.rules['optional-property-added']).toEqual(CompareResult.PATCH);
         expect(actual.rules['map-value-type-changed']).toEqual(CompareResult.MAJOR);
@@ -36,8 +35,8 @@ describe('CompareConfigBuilder', () => {
 
         const actual = builder.default().extend(toExtend).build();
 
-        expect(actual.comparerFactories.length).toEqual(12);
-        expect(Object.keys(actual.rules).length).toEqual(22);
+        expect(actual.comparerFactories.length).toEqual(15);
+        expect(Object.keys(actual.rules).length).toEqual(30);
         expect(actual.rules['a-new-rule']).toEqual(CompareResult.MAJOR);
     });
 
@@ -46,8 +45,8 @@ describe('CompareConfigBuilder', () => {
 
         const actual = builder.default().addComparerFactory(() => ({})).build();
 
-        expect(actual.comparerFactories.length).toEqual(12);
-        expect(Object.keys(actual.rules).length).toEqual(21);
+        expect(actual.comparerFactories.length).toEqual(15);
+        expect(Object.keys(actual.rules).length).toEqual(29);
     });
 
     it('Should add a new rule', () => {
@@ -55,8 +54,8 @@ describe('CompareConfigBuilder', () => {
 
         const actual = builder.default().addRule('a-new-rule', CompareResult.MAJOR).build();
 
-        expect(actual.comparerFactories.length).toEqual(11);
-        expect(Object.keys(actual.rules).length).toEqual(22);
+        expect(actual.comparerFactories.length).toEqual(14);
+        expect(Object.keys(actual.rules).length).toEqual(30);
         expect(actual.rules['a-new-rule']).toEqual(CompareResult.MAJOR);
     });
 
@@ -65,8 +64,8 @@ describe('CompareConfigBuilder', () => {
 
         const actual = builder.default().removeRule('optional-property-added').build();
 
-        expect(actual.comparerFactories.length).toEqual(11);
-        expect(Object.keys(actual.rules).length).toEqual(20);
+        expect(actual.comparerFactories.length).toEqual(14);
+        expect(Object.keys(actual.rules).length).toEqual(28);
         expect(actual.rules['optional-property-added']).toBeFalsy();
     });
 

--- a/packages/concerto-analysis/test/unit/compare.test.ts
+++ b/packages/concerto-analysis/test/unit/compare.test.ts
@@ -695,3 +695,35 @@ test('should give a MAJOR CompareResult for Map Type compare config rules)', asy
     expect(defaultCompareConfig.rules['map-key-type-changed']).toBe(CompareResult.MAJOR);
     expect(defaultCompareConfig.rules['map-value-type-changed']).toBe(CompareResult.MAJOR);
 });
+
+test('should detect a required property changed to optional', async () => {
+    const [a, b] = await getModelFiles('required-to-optional-a.cto', 'required-to-optional-b.cto');
+    const results = new Compare().compare(a, b);
+    const findings = results.findings.map(finding => ({
+        key: finding.key,
+        message: finding.message,
+    }));
+    expect(findings).toEqual(expect.arrayContaining([
+        expect.objectContaining({
+            key: 'required-to-optional-property',
+            message: 'The required field "value" was changed to be optional in the concept "Thing"',
+        }),
+    ]));
+    expect(results.result).toBe(CompareResult.PATCH);
+});
+
+test('should detect an optional property changed to required', async () => {
+    const [a, b] = await getModelFiles('optional-to-required-a.cto', 'optional-to-required-b.cto');
+    const results = new Compare().compare(a, b);
+    const findings = results.findings.map(finding => ({
+        key: finding.key,
+        message: finding.message,
+    }));
+    expect(findings).toEqual(expect.arrayContaining([
+        expect.objectContaining({
+            key: 'optional-to-required-property',
+            message: 'The optional field "value" was changed to be required in the concept "Thing"',
+        }),
+    ]));
+    expect(results.result).toBe(CompareResult.MAJOR);
+});

--- a/packages/concerto-analysis/test/unit/compare.test.ts
+++ b/packages/concerto-analysis/test/unit/compare.test.ts
@@ -775,3 +775,51 @@ test('should detect a default value being removed from a scalar', async () => {
     ]));
     expect(results.result).toBe(CompareResult.MAJOR);
 });
+
+test('should detect a default value being added to a property', async () => {
+    const [a, b] = await getModelFiles('property-added.cto', 'property-default-value-added.cto');
+    const results = new Compare().compare(a, b);
+    const findings = results.findings.map(finding => ({
+        key: finding.key,
+        message: finding.message,
+    }));
+    expect(findings).toEqual(expect.arrayContaining([
+        expect.objectContaining({
+            key: 'property-default-value-added',
+            message: 'Default value "Fred" added to property "name" in the concept "Thing"',
+        }),
+    ]));
+    expect(results.result).toBe(CompareResult.PATCH);
+});
+
+test('should detect a default value being removed from a property', async () => {
+    const [a, b] = await getModelFiles('property-default-value-added.cto','property-added.cto');
+    const results = new Compare().compare(a, b);
+    const findings = results.findings.map(finding => ({
+        key: finding.key,
+        message: finding.message,
+    }));
+    expect(findings).toEqual(expect.arrayContaining([
+        expect.objectContaining({
+            key: 'property-default-value-removed',
+            message: 'Default value "Fred" removed from property "name" in the concept "Thing"',
+        }),
+    ]));
+    expect(results.result).toBe(CompareResult.MAJOR);
+});
+
+test('should detect a default value being removed from a scalar', async () => {
+    const [a, b] = await getModelFiles('property-default-value-added.cto','property-default-value-changed.cto');
+    const results = new Compare().compare(a, b);
+    const findings = results.findings.map(finding => ({
+        key: finding.key,
+        message: finding.message,
+    }));
+    expect(findings).toEqual(expect.arrayContaining([
+        expect.objectContaining({
+            key: 'property-default-value-changed',
+            message: 'Default value changed from "Fred" to "NotFred" in property "name" in the concept "Thing"',
+        }),
+    ]));
+    expect(results.result).toBe(CompareResult.MAJOR);
+});

--- a/packages/concerto-analysis/test/unit/compare.test.ts
+++ b/packages/concerto-analysis/test/unit/compare.test.ts
@@ -741,7 +741,7 @@ test('should detect a default value being added to a scalar', async () => {
             message: 'Default value "hello" added to scalar "Thing"',
         }),
     ]));
-    expect(results.result).toBe(CompareResult.PATCH);
+    expect(results.result).toBe(CompareResult.MINOR);
 });
 
 test('should detect a default value being removed from a scalar', async () => {
@@ -773,7 +773,7 @@ test('should detect a default value being removed from a scalar', async () => {
             message: 'Default value changed from "hello" to "bye" in scalar "Thing"',
         }),
     ]));
-    expect(results.result).toBe(CompareResult.MAJOR);
+    expect(results.result).toBe(CompareResult.PATCH);
 });
 
 test('should detect a default value being added to a property', async () => {
@@ -789,7 +789,7 @@ test('should detect a default value being added to a property', async () => {
             message: 'Default value "Fred" added to property "name" in the concept "Thing"',
         }),
     ]));
-    expect(results.result).toBe(CompareResult.PATCH);
+    expect(results.result).toBe(CompareResult.MINOR);
 });
 
 test('should detect a default value being removed from a property', async () => {
@@ -808,7 +808,7 @@ test('should detect a default value being removed from a property', async () => 
     expect(results.result).toBe(CompareResult.MAJOR);
 });
 
-test('should detect a default value being removed from a scalar', async () => {
+test('should detect a default value being removed from a property', async () => {
     const [a, b] = await getModelFiles('property-default-value-added.cto','property-default-value-changed.cto');
     const results = new Compare().compare(a, b);
     const findings = results.findings.map(finding => ({
@@ -821,5 +821,5 @@ test('should detect a default value being removed from a scalar', async () => {
             message: 'Default value changed from "Fred" to "NotFred" in property "name" in the concept "Thing"',
         }),
     ]));
-    expect(results.result).toBe(CompareResult.MAJOR);
+    expect(results.result).toBe(CompareResult.PATCH);
 });

--- a/packages/concerto-analysis/test/unit/compare.test.ts
+++ b/packages/concerto-analysis/test/unit/compare.test.ts
@@ -727,3 +727,51 @@ test('should detect an optional property changed to required', async () => {
     ]));
     expect(results.result).toBe(CompareResult.MAJOR);
 });
+
+test('should detect a default value being added to a scalar', async () => {
+    const [a, b] = await getModelFiles('scalar-added.cto', 'scalar-default-value-added.cto');
+    const results = new Compare().compare(a, b);
+    const findings = results.findings.map(finding => ({
+        key: finding.key,
+        message: finding.message,
+    }));
+    expect(findings).toEqual(expect.arrayContaining([
+        expect.objectContaining({
+            key: 'scalar-default-value-added',
+            message: 'Default value "hello" added to scalar "Thing"',
+        }),
+    ]));
+    expect(results.result).toBe(CompareResult.PATCH);
+});
+
+test('should detect a default value being removed from a scalar', async () => {
+    const [a, b] = await getModelFiles('scalar-default-value-added.cto','scalar-added.cto');
+    const results = new Compare().compare(a, b);
+    const findings = results.findings.map(finding => ({
+        key: finding.key,
+        message: finding.message,
+    }));
+    expect(findings).toEqual(expect.arrayContaining([
+        expect.objectContaining({
+            key: 'scalar-default-value-removed',
+            message: 'Default value "hello" removed from scalar "Thing"',
+        }),
+    ]));
+    expect(results.result).toBe(CompareResult.MAJOR);
+});
+
+test('should detect a default value being removed from a scalar', async () => {
+    const [a, b] = await getModelFiles('scalar-default-value-added.cto','scalar-default-value-changed.cto');
+    const results = new Compare().compare(a, b);
+    const findings = results.findings.map(finding => ({
+        key: finding.key,
+        message: finding.message,
+    }));
+    expect(findings).toEqual(expect.arrayContaining([
+        expect.objectContaining({
+            key: 'scalar-default-value-changed',
+            message: 'Default value changed from "hello" to "bye" in scalar "Thing"',
+        }),
+    ]));
+    expect(results.result).toBe(CompareResult.MAJOR);
+});


### PR DESCRIPTION
<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
 # Closes #719
<!--- Provide an overall summary of the pull request -->

### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
This PR addresses issue #719 by adding logic to detect changes in the following scenarios:
- [x] Adding/removing `optional ` from a property
- [x] Adding/removing default values from a property
- [x]  Changing the value of default values for properties
- [x] Adding/removing default values from scalars
- [x] Changing the value of default values for scalars


Each change is covered by **unit tests** to ensure correctness. This ensures that the `concerto-analysis` package correctly identifies and reports these changes, improving the accuracy of model comparisons.

---

### **Testing**
- All new changes are covered by unit tests.
- Verified against sample `.cto` files to ensure accurate detection of changes.

---
### Flags
<!--- Provide context or concerns a reviewer should be aware of -->
NA



### Screenshots or Video
NA

### Related Issues
- Issue #719 

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [x] Extend the documentation, if necessary
- [x] Merging to `main` from `fork:khaledGadelhaQ/issue-719/fix-analysis-changes-detection`
