### PR TITLE
fix(parser): collect errors without halting and include file IDs

### DIFF
--- a/packages/concerto-cto/test/parserMain.js
+++ b/packages/concerto-cto/test/parserMain.js
@@ -61,8 +61,23 @@ describe('parser', () => {
             {
                 $class: 'concerto.metamodel@1.0.0.Models',
                 models: getCTOFiles().map(({ ast }) => JSON.parse(ast)),
+                errors: [],
             }
         );
+    });
+
+    it('Should handle errors in multiple files', () => {
+        const files = [
+            getCTOFiles()[0].content, // Valid (file_0)
+            'namespace invalid\nconcept Bad { o String bad', // Invalid (file_1)
+            getCTOFiles()[1].content, // Valid (file_2)
+        ];
+        const mm = Parser.parseModels(files, { skipLocationNodes: true });
+        mm.models.length.should.equal(2);
+        mm.errors.length.should.equal(1);
+        mm.errors[0].file.should.equal('file_1');
+        mm.errors[0].message.should.match(/Expected .+ but/);
+        mm.errors[0].location.should.exist; // Now correctly checks `fileLocation`
     });
 
     describe('maps', () => {


### PR DESCRIPTION
<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #999 
<!--- Provide an overall summary of the pull request -->
#### Improves error handling in `parseModels` to collect all errors and include file identifiers.

### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
- Modified `parseModels` to collect errors in an array instead of throwing immediately
- Added file identifiers (`file_${index}` or explicit `fileName`) to error messages

### Flags
<!--- Provide context or concerns a reviewer should be aware of -->
- **File Identification:**  
  Errors use generated `file_${index}` IDs (e.g., `file_1`) instead of actual filenames.  
  This is because the input `files` array may contain raw CTO strings (legacy) without filenames.  

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [x] Extend the documentation, if necessary
- [x] Merging to `main` from `fuyal:asmit/999`
