### PR TITLE
Fix: Print YAML key duplication in decorator extraction

### DIFF
--- a/packages/concerto-vocabulary/lib/vocabularymanager.js
+++ b/packages/concerto-vocabulary/lib/vocabularymanager.js
@@ -333,7 +333,7 @@ class VocabularyManager {
                                 }
                             });
                         }
-                        else if(term.localeCompare('properties')) {
+                        else if(term === 'properties') {
                             decoratorCommandSet.commands.push({
                                 '$class': `${DC_NAMESPACE}.Command`,
                                 'type': 'UPSERT',


### PR DESCRIPTION
Ensure that property decorators are correctly named using Term_<locale> format, 
and prevent incorrect or duplicate application of decorators like 'Term_properties'. 
This resolves rendering issues during vocabulary decoration due to malformed 
decorator names.

Signed-off-by: Abhijeet SIngh Parihar <abhijeetsinghparihar756@gmail.com>

Closes: #982 