### PR TITLE
Fixing Default Values Ignoring Meta properties.

### DIFF
--- a/packages/concerto-core/lib/introspect/numbervalidator.js
+++ b/packages/concerto-core/lib/introspect/numbervalidator.js
@@ -65,6 +65,17 @@ class NumberValidator extends Validator{
                 this.reportError(null, 'Lower bound must be less than or equal to upper bound.');
             }
         }
+
+        if(this.field?.ast?.defaultValue !== undefined) {
+            let value = this.field.ast.defaultValue;
+            if(this.lowerBound !== null && value < this.lowerBound) {
+                this.reportError(null, `Value ${value} is outside lower bound ${this.lowerBound}`);
+            }
+
+            if(this.upperBound !== null && value > this.upperBound) {
+                this.reportError(null, `Value ${value} is outside upper bound ${this.upperBound}`);
+            }
+        }
     }
 
     /**

--- a/packages/concerto-core/lib/introspect/stringvalidator.js
+++ b/packages/concerto-core/lib/introspect/stringvalidator.js
@@ -74,6 +74,10 @@ class StringValidator extends Validator{
                 this.reportError(field.getName(), exception.message, ErrorCodes.REGEX_VALIDATOR_EXCEPTION);
             }
         }
+
+        if(this.field?.ast?.defaultValue) {
+            this.validate(field.getName(), this.field.ast.defaultValue);
+        }
     }
 
     /**

--- a/packages/concerto-core/test/data/model/dependencies/base/base.cto
+++ b/packages/concerto-core/test/data/model/dependencies/base/base.cto
@@ -68,4 +68,4 @@ concept Address {
   o String postOfficeBoxNumber optional
 }
 
-scalar SSN extends String default="000-00-0000" regex=/\d{3}-\d{2}-\{4}+/
+scalar SSN extends String default="000-00-0000" regex= /\d{3}-\d{2}-\d{4}/

--- a/packages/concerto-core/test/data/parser/classdeclaration.scalararray.cto
+++ b/packages/concerto-core/test/data/parser/classdeclaration.scalararray.cto
@@ -14,7 +14,7 @@
 
 namespace com.testing
 
-scalar SSN extends String default="000-00-0000" regex=/\d{3}-\d{2}-\{4}+/
+scalar SSN extends String default="000-00-0000" regex= /\d{3}-\d{2}-\d{4}/
 
 concept Persons {
     o SSN[] ssnArray

--- a/packages/concerto-core/test/data/parser/classdeclaration.scalaridentifier.cto
+++ b/packages/concerto-core/test/data/parser/classdeclaration.scalaridentifier.cto
@@ -14,7 +14,7 @@
 
 namespace com.testing
 
-scalar SSN extends String default="000-00-0000" regex=/\d{3}-\d{2}-\{4}+/
+scalar SSN extends String default="000-00-0000" regex=/\d{3}-\d{2}-\d{4}/
 
 concept Person identified by ssn {
     o SSN ssn

--- a/packages/concerto-core/test/data/parser/scalardeclaration.ssn.cto
+++ b/packages/concerto-core/test/data/parser/scalardeclaration.ssn.cto
@@ -14,5 +14,5 @@
 
 namespace com.testing
 
-scalar SSN extends String default="000-00-0000" regex=/\d{3}-\d{2}-\{4}+/
+scalar SSN extends String default="000-00-0000" regex= /\d{3}-\d{2}-\d{4}/
 scalar BoolWithDefault extends Boolean default=false

--- a/packages/concerto-core/test/introspect/numbervalidator.js
+++ b/packages/concerto-core/test/introspect/numbervalidator.js
@@ -71,6 +71,41 @@ describe('NumberValidator', () => {
                 new NumberValidator(mockField, LOWER_IS_HIGHER_THAN_UPPER);
             }).should.throw(/Lower bound must be less than or equal to upper bound./);
         });
+
+        it('should use default value if input is null and within range', () => {
+            mockField.ast = { defaultValue: 50 };
+            (() => {
+                new NumberValidator(mockField, { lower: 0, upper: 100 });
+            }).should.not.throw();
+        });
+
+        it('should throw an error if default value is outside the lower bound', () => {
+            mockField.ast = { defaultValue: 5 };
+            (() => {
+                new NumberValidator(mockField, { lower: 10, upper: 100 });
+            }).should.throw(/Value 5 is outside lower bound 10/);
+        });
+
+        it('should throw an error if default value is outside the upper bound', () => {
+            mockField.ast = { defaultValue: 60 };
+            (() => {
+                new NumberValidator(mockField, { lower: 0, upper: 50 });
+            }).should.throw(/Value 60 is outside upper bound 50/);
+        });
+
+        it('should not throw an error if default value is exactly at the lower bound', () => {
+            mockField.ast = { defaultValue: 10 };
+            (() => {
+                new NumberValidator(mockField, { lower: 10, upper: 100 });
+            }).should.not.throw();
+        });
+
+        it('should not throw an error if default value is exactly at the upper bound', () => {
+            mockField.ast = { defaultValue: 50 };
+            (() => {
+                new NumberValidator(mockField, { lower: 0, upper: 50 });
+            }).should.not.throw();
+        });
     });
 
     describe('#validate', () => {

--- a/packages/concerto-core/test/introspect/scalardeclaration.js
+++ b/packages/concerto-core/test/introspect/scalardeclaration.js
@@ -144,7 +144,7 @@ describe('ScalarDeclaration', () => {
         });
         it('should return the validator', () => {
             const testClass = modelManager.getType('com.testing.SSN');
-            should.equal(testClass.getValidator().validator.pattern, '\\d{3}-\\d{2}-\\{4}+');
+            should.equal(testClass.getValidator().validator.pattern, '\\d{3}-\\d{2}-\\d{4}');
         });
     });
 

--- a/packages/concerto-core/test/introspect/stringvalidator.js
+++ b/packages/concerto-core/test/introspect/stringvalidator.js
@@ -81,6 +81,36 @@ describe('StringValidator', () => {
                 new StringValidator(mockField, null, NEGETIVE_LENGTH);
             }).should.throw(/minLength and-or maxLength must be positive integers/);
         });
+
+        it('should throw when defaultValue length is less than minLength', () => {
+            mockField.ast = { defaultValue: 'abc' };
+            (() => {
+                new StringValidator(mockField, null, {
+                    minLength: 5,
+                    maxLength: 10,
+                });
+            }).should.throw(/The string length of 'abc' should be at least 5 characters./);
+        });
+
+        it('should throw when defaultValue length is greater than maxLength', () => {
+            mockField.ast = { defaultValue: 'abcdefgh' };
+            (() => {
+                new StringValidator(mockField, null, {
+                    minLength: 2,
+                    maxLength: 5,
+                });
+            }).should.throw(/The string length of 'abcdefgh' should not exceed 5 characters./);
+        });
+
+        it('should accept valid defaultValue that matches length and pattern constraints', () => {
+            mockField.ast = { defaultValue: 'ABC' };
+            (()=>{
+                new StringValidator(mockField,
+                    { pattern: '^[A-Z]{3,5}$' },
+                    { minLength: 3, maxLength: 5 },
+                );
+            }).should.not.throw();
+        });
     });
 
     describe('#validate', () => {

--- a/packages/concerto-cto/test/cto/scalar.cto
+++ b/packages/concerto-cto/test/cto/scalar.cto
@@ -69,7 +69,7 @@ concept ScalarsWithFieldMetaProperties {
   o StringScalarWithDefaultAndRegex[] stringScalarWithDefaultAndRegexOptionalArray optional
 }
 
-scalar SSN extends String default="000-00-0000" regex=/\d{3}-\d{2}-\{4}+/ length=[1,100]
+scalar SSN extends String default="000-00-0000" regex= /\d{3}-\d{2}-\d{4}/ length=[1,100]
 
 concept Person identified by ssn {
   o SSN ssn

--- a/packages/concerto-cto/test/cto/scalar.cto
+++ b/packages/concerto-cto/test/cto/scalar.cto
@@ -69,7 +69,7 @@ concept ScalarsWithFieldMetaProperties {
   o StringScalarWithDefaultAndRegex[] stringScalarWithDefaultAndRegexOptionalArray optional
 }
 
-scalar SSN extends String default="000-00-0000" regex= /\d{3}-\d{2}-\d{4}/ length=[1,100]
+scalar SSN extends String default="000-00-0000" regex=/\d{3}-\d{2}-\d{4}/ length=[1,100]
 
 concept Person identified by ssn {
   o SSN ssn

--- a/packages/concerto-cto/test/cto/scalar.json
+++ b/packages/concerto-cto/test/cto/scalar.json
@@ -384,7 +384,7 @@
             "defaultValue": "000-00-0000",
             "validator": {
                 "$class": "concerto.metamodel@1.0.0.StringRegexValidator",
-                "pattern": "\\d{3}-\\d{2}-\\{4}+",
+                "pattern": "\\d{3}-\\d{2}-\\d{4}",
                 "flags": ""
             },
             "lengthValidator": {


### PR DESCRIPTION
<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #1010<CORRESPONDING ISSUE NUMBER>
<!--- Provide an overall summary of the pull request -->
Fixed default values not validated against meta model properties (E.g., Regex, Length, Range)
### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
- <ONE> Validating `String` properties with default values against the `length` and `regex` meta properties.
- <TWO> Validating `Integer`, `Double` and `Long` properties with default Values against the `range` meta property.

### Flags
<!--- Provide context or concerns a reviewer should be aware of -->
- <ONE> There was an invalid Regex expression in the data files used for testing, I changed it to a correct one.

### Screenshots or Video
<!--- Provide an easily accessible demonstration of the changes, if applicable -->
NA
### Related Issues
- Issue #1010
- Pull Request #<NUMBER>

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [x] Merging to `main` from `fork:branchname`
