### PR TITLE
feat(*): release map types and aliasing

### DIFF
--- a/packages/concerto-analysis/test/unit/compare.test.ts
+++ b/packages/concerto-analysis/test/unit/compare.test.ts
@@ -15,9 +15,8 @@ async function getModelFile(modelManager: ModelManager, fileName: string) {
 async function getModelFiles(
     aFileName: string,
     bFileName: string,
-    importAliasing = false
 ): Promise<[a: ModelFile, b: ModelFile]> {
-    const modelManager = new ModelManager({ strict: true, importAliasing: importAliasing });
+    const modelManager = new ModelManager({ strict: true });
     const a = await getModelFile(modelManager, aFileName);
     const b = await getModelFile(modelManager, bFileName);
     return [a, b];
@@ -72,7 +71,6 @@ test('should detect a change of namespace', async () => {
 
 ['asset', 'concept', 'enum', 'event', 'participant', 'transaction', 'map', 'scalar'].forEach(type => {
     test(`should detect a ${type} being added`, async () => {
-        process.env.ENABLE_MAP_TYPE = 'true'; // TODO Remove on release of MapType
         const [a, b] = await getModelFiles('empty.cto', `${type}-added.cto`);
         const results = new Compare().compare(a, b);
         expect(results.findings).toEqual(expect.arrayContaining([
@@ -269,7 +267,6 @@ test('should detect a field local type name change', async () => {
 });
 
 test('should detect a map key type changing from x to y', async () => {
-    process.env.ENABLE_MAP_TYPE = 'true'; // TODO Remove on release of MapType
     const [a, b] = await getModelFiles('map-added.cto', 'map-changed-key.cto');
     const results = new Compare().compare(a, b);
     expect(results.findings).toEqual(expect.arrayContaining([
@@ -283,7 +280,6 @@ test('should detect a map key type changing from x to y', async () => {
 });
 
 test('should detect a map value type changing from x to y', async () => {
-    process.env.ENABLE_MAP_TYPE = 'true'; // TODO Remove on release of MapType
     const [a, b] = await getModelFiles('map-added.cto', 'map-changed-value.cto');
     const results = new Compare().compare(a, b);
     expect(results.findings).toEqual(expect.arrayContaining([

--- a/packages/concerto-core/api.txt
+++ b/packages/concerto-core/api.txt
@@ -2,7 +2,7 @@ class AstModelManager extends BaseModelManager {
    + void constructor(object?) 
 }
 class BaseModelManager {
-   + void constructor(object?,boolean?,Object?,boolean?,boolean?,boolean?,boolean?,object?,string?,string?,processFile?) 
+   + void constructor(object?,boolean?,Object?,boolean?,boolean?,object?,string?,string?,processFile?) 
    + boolean isModelManager() 
    + boolean isStrict() 
    + boolean isAliasedTypeEnabled() 

--- a/packages/concerto-core/changelog.txt
+++ b/packages/concerto-core/changelog.txt
@@ -23,6 +23,8 @@
 #
 # Note that the latest public API is documented using JSDocs and is available in api.txt.
 #
+Version 3.21.0 {f5cd054bfe8de6f9367fb74f517271cf} 2025-05-20
+- Remove Import Aliasing and Map Type feature flags
 
 Version 3.20.5 {3be18f4d17eb0e65e9a9ffc369231bf6} 2025-02-03
 - vocabulary support for namespace scoped decorators

--- a/packages/concerto-core/lib/basemodelmanager.js
+++ b/packages/concerto-core/lib/basemodelmanager.js
@@ -92,8 +92,6 @@ class BaseModelManager {
      * @param {Object} [options.regExp] - An alternative regular expression engine.
      * @param {boolean} [options.metamodelValidation] - When true, modelfiles will be validated
      * @param {boolean} [options.addMetamodel] - When true, the Concerto metamodel is added to the model manager
-     * @param {boolean} [options.enableMapType] - When true, the Concerto Map Type feature is enabled
-     * @param {boolean} [options.importAliasing] - When true, the Concerto Aliasing feature is enabled
      * @param {object} [options.decoratorValidation] - the decorator validation configuration
      * @param {string} [options.decoratorValidation.missingDecorator] - the validation log level for missingDecorator decorators: off, warning, error
      * @param {string} [options.decoratorValidation.invalidDecorator] - the validation log level for invalidDecorator decorators: off, warning, error
@@ -110,11 +108,6 @@ class BaseModelManager {
         this.addDecoratorModel();
         this.addRootModel();
         this.decoratorValidation = options?.decoratorValidation ? options?.decoratorValidation : DEFAULT_DECORATOR_VALIDATION;
-
-        // TODO Remove on release of MapType
-        // Supports both env var and property based flag
-        this.enableMapType = !!options?.enableMapType;
-        this.importAliasing = process?.env?.IMPORT_ALIASING === 'true' || !!options?.importAliasing;
 
         // Cache a copy of the Metamodel ModelFile for use when validating the structure of ModelFiles later.
         this.metamodelModelFile = new ModelFile(this, MetaModelUtil.metaModelAst, undefined, MetaModelNamespace);
@@ -145,7 +138,7 @@ class BaseModelManager {
      * @returns {boolean} true if the importAliasing has been set
      */
     isAliasedTypeEnabled() {
-        return this.importAliasing;
+        return true;
     }
 
     /**

--- a/packages/concerto-core/lib/decoratormanager.js
+++ b/packages/concerto-core/lib/decoratormanager.js
@@ -318,13 +318,10 @@ class DecoratorManager {
         }
 
         if (shouldValidate) {
-            const enableMapType = modelManager?.enableMapType ? true : false;
             const validationModelManager = new ModelManager({
                 strict: true,
                 metamodelValidation: true,
                 addMetamodel: true,
-                enableMapType,
-                importAliasing: modelManager.isAliasedTypeEnabled(),
             });
             validationModelManager.addModelFiles(modelManager.getModelFiles());
             validationModelManager.addCTOModel(
@@ -447,11 +444,8 @@ class DecoratorManager {
             });
         });
 
-        const enableMapType = modelManager?.enableMapType ? true : false;
         const newModelManager = new ModelManager({
             strict: modelManager.isStrict(),
-            enableMapType,
-            importAliasing: modelManager.isAliasedTypeEnabled(),
             decoratorValidation: modelManager.getDecoratorValidation()});
         newModelManager.fromAst(decoratedAst);
         return newModelManager;

--- a/packages/concerto-core/lib/introspect/mapdeclaration.js
+++ b/packages/concerto-core/lib/introspect/mapdeclaration.js
@@ -44,12 +44,6 @@ class MapDeclaration extends Declaration {
      * @throws {IllegalModelException}
      */
     constructor(modelFile, ast) {
-        // TODO remove on full release.
-        const mm = modelFile.getModelManager();
-        if(process.env.ENABLE_MAP_TYPE !== 'true' && !mm.enableMapType) {
-            throw new Error('MapType feature is not enabled. Please set the environment variable "ENABLE_MAP_TYPE=true", or add {enableMapType: true} to the ModelManger options, to access this functionality.');
-        }
-
         super(modelFile, ast);
         this.modelFile = modelFile;
         this.process();

--- a/packages/concerto-core/lib/introspect/modelfile.js
+++ b/packages/concerto-core/lib/introspect/modelfile.js
@@ -788,9 +788,6 @@ class ModelFile extends Decorated {
                             )
                     );
                 } else {
-                    if (imp.aliasedTypes) {
-                        throw new Error('Aliasing disabled, set importAliasing to true');
-                    }
                     imp.types.forEach((type) => {
                         this.importShortNames.set(type,`${imp.namespace}.${type}`);
                     });

--- a/packages/concerto-core/test/decoratormanager.js
+++ b/packages/concerto-core/test/decoratormanager.js
@@ -29,13 +29,6 @@ chai.use(require('chai-as-promised'));
 
 describe('DecoratorManager', () => {
 
-    beforeEach(() => {
-        process.env.ENABLE_MAP_TYPE = 'true'; // TODO Remove on release of MapType
-    });
-
-    afterEach(() => {
-    });
-
     describe('#falsyOrEqual', function() {
         it('should match null', async function() {
             DecoratorManager.falsyOrEqual( null, ['one']).should.be.true;

--- a/packages/concerto-core/test/introspect/classdeclaration.js
+++ b/packages/concerto-core/test/introspect/classdeclaration.js
@@ -496,7 +496,7 @@ describe('ClassDeclaration - Test for declarations using Import Aliasing', () =>
     let resolvedModelManager;
 
     beforeEach(() => {
-        modelManager = new ModelManager({ strict: true, importAliasing: true, enableMapType: true});
+        modelManager = new ModelManager({ strict: true });
 
         const childModelCTO = fs.readFileSync(path.resolve(__dirname, '../data/aliasing/child.cto'), 'utf8');
         const parentModelCTO = fs.readFileSync(path.resolve(__dirname, '../data/aliasing/parent.cto'), 'utf8');
@@ -505,7 +505,7 @@ describe('ClassDeclaration - Test for declarations using Import Aliasing', () =>
         modelManager.addCTOModel(parentModelCTO, 'parent@1.0.0.cto');
         const resolvedMetamodelChild = modelManager.resolveMetaModel(modelManager.getAst().models[0]);
         const resolvedMetamodelParent = modelManager.resolveMetaModel(modelManager.getAst().models[1]);
-        resolvedModelManager = new ModelManager({ strict: true, importAliasing: true, enableMapType: true});
+        resolvedModelManager = new ModelManager({ strict: true });
         const resolvedModelFileChild = new ModelFile(resolvedModelManager, resolvedMetamodelChild, 'child@1.0.0.cto');
         const resolvedModelFileParent = new ModelFile(resolvedModelManager, resolvedMetamodelParent, 'parent@1.0.0.cto');
         resolvedModelManager.addModelFiles([resolvedModelFileChild, resolvedModelFileParent], ['child@1.0.0.cto', 'parent@1.0.0.cto']);

--- a/packages/concerto-core/test/introspect/decorator.js
+++ b/packages/concerto-core/test/introspect/decorator.js
@@ -89,7 +89,7 @@ describe('Decorator - Test for Decorator arguments using Import Aliasing', () =>
     let resolvedModelManager;
 
     beforeEach(() => {
-        modelManager = new ModelManager({ strict: true, importAliasing: true, enableMapType: true});
+        modelManager = new ModelManager({ strict: true });
 
         const childModelCTO = fs.readFileSync(path.resolve(__dirname, '../data/aliasing/child.cto'), 'utf8');
         const parentModelCTO = fs.readFileSync(path.resolve(__dirname, '../data/aliasing/parent.cto'), 'utf8');
@@ -98,7 +98,7 @@ describe('Decorator - Test for Decorator arguments using Import Aliasing', () =>
         modelManager.addCTOModel(parentModelCTO, 'parent@1.0.0.cto');
         const resolvedMetamodelChild = modelManager.resolveMetaModel(modelManager.getAst().models[0]);
         const resolvedMetamodelParent = modelManager.resolveMetaModel(modelManager.getAst().models[1]);
-        resolvedModelManager = new ModelManager({ strict: true, importAliasing: true, enableMapType: true});
+        resolvedModelManager = new ModelManager({ strict: true });
         const resolvedModelFileChild = new ModelFile(resolvedModelManager, resolvedMetamodelChild, 'child@1.0.0.cto');
         const resolvedModelFileParent = new ModelFile(resolvedModelManager, resolvedMetamodelParent, 'parent@1.0.0.cto');
         resolvedModelManager.addModelFiles([resolvedModelFileChild, resolvedModelFileParent], ['child@1.0.0.cto', 'parent@1.0.0.cto']);

--- a/packages/concerto-core/test/introspect/mapdeclaration.js
+++ b/packages/concerto-core/test/introspect/mapdeclaration.js
@@ -44,7 +44,6 @@ describe('MapDeclaration', () => {
         Util.addComposerModel(modelManager);
         introspectUtils = new IntrospectUtils(modelManager);
         modelFile = ParserUtil.newModelFile(modelManager, 'namespace com.test', 'mapdeclaration.cto');
-        process.env.ENABLE_MAP_TYPE = 'true'; // TODO Remove on release of MapType.
     });
 
     describe('#constructor', () => {
@@ -73,38 +72,8 @@ describe('MapDeclaration', () => {
             }).should.throw(IllegalModelException);
         });
 
-        it('should throw if no feature flag', () => {
-            process.env.ENABLE_MAP_TYPE = 'false';
-            (() =>
-            {
-                new MapDeclaration(modelFile, {
-                    $class: 'concerto.metamodel@1.0.0.MapDeclaration',
-                    name: 'MapPermutation1',
-                    key: {
-                        $class: 'concerto.metamodel@1.0.0.StringMapKeyType'
-                    },
-                    value: {
-                        $class: 'concerto.metamodel@1.0.0.StringMapValueType'
-                    }
-                });
-            }).should.throw(/MapType feature is not enabled. Please set the environment variable "ENABLE_MAP_TYPE=true", or add {enableMapType: true} to the ModelManger options, to access this functionality/);
-            process.env.ENABLE_MAP_TYPE = 'true'; // enable after the test run. This is necessary to ensure functioning of other tests.
-        });
-
-        it('should throw if Map Type not enabled in ModelManager options', () => {
-            process.env.ENABLE_MAP_TYPE = 'false';
-            const mm = new ModelManager({enableMapType: false});
-            Util.addComposerModel(mm);
-            const introspectUtils = new IntrospectUtils(mm);
-            try {
-                introspectUtils.loadLastDeclaration('test/data/parser/mapdeclaration/mapdeclaration.goodkey.primitive.datetime.cto', MapDeclaration);
-            } catch (error) {
-                expect(error.message).to.equal('MapType feature is not enabled. Please set the environment variable "ENABLE_MAP_TYPE=true", or add {enableMapType: true} to the ModelManger options, to access this functionality.');
-            }
-        });
-
         it('should not throw if Map Type is enabled in ModelManager options', () => {
-            const mm = new ModelManager({enableMapType: true});
+            const mm = new ModelManager();
             Util.addComposerModel(mm);
             const introspectUtils = new IntrospectUtils(mm);
             let decl = introspectUtils.loadLastDeclaration('test/data/parser/mapdeclaration/mapdeclaration.goodkey.primitive.datetime.cto', MapDeclaration);
@@ -796,7 +765,7 @@ describe('MapDeclration - Test for MapDeclrations using Import Aliasing', () => 
     let resolvedModelManager;
 
     beforeEach(() => {
-        modelManager = new ModelManager({ strict: true, importAliasing: true, enableMapType: true});
+        modelManager = new ModelManager({ strict: true });
 
         const childModelCTO = fs.readFileSync(path.resolve(__dirname, '../data/aliasing/child.cto'), 'utf8');
         const parentModelCTO = fs.readFileSync(path.resolve(__dirname, '../data/aliasing/parent.cto'), 'utf8');
@@ -805,7 +774,7 @@ describe('MapDeclration - Test for MapDeclrations using Import Aliasing', () => 
         modelManager.addCTOModel(parentModelCTO, 'parent@1.0.0.cto');
         const resolvedMetamodelChild = modelManager.resolveMetaModel(modelManager.getAst().models[0]);
         const resolvedMetamodelParent = modelManager.resolveMetaModel(modelManager.getAst().models[1]);
-        resolvedModelManager = new ModelManager({ strict: true, importAliasing: true, enableMapType: true});
+        resolvedModelManager = new ModelManager({ strict: true });
         const resolvedModelFileChild = new ModelFile(resolvedModelManager, resolvedMetamodelChild, 'child@1.0.0.cto');
         const resolvedModelFileParent = new ModelFile(resolvedModelManager, resolvedMetamodelParent, 'parent@1.0.0.cto');
         resolvedModelManager.addModelFiles([resolvedModelFileChild, resolvedModelFileParent], ['child@1.0.0.cto', 'parent@1.0.0.cto']);

--- a/packages/concerto-core/test/introspect/metamodel.js
+++ b/packages/concerto-core/test/introspect/metamodel.js
@@ -220,19 +220,19 @@ describe('MetaModel (Parent - Child (Import Aliasing))', () => {
         });
 
         it('should convert and validate a ModelFile to its metamodel', () => {
-            const modelManager1 = new ModelManager({ importAliasing: true, enableMapType: true });
+            const modelManager1 = new ModelManager();
             const mf1 = ParserUtil.newModelFile(modelManager1, parentModel);
             const mm1 = mf1.getAst();
             mm1.should.deep.equal(parentMetaModel);
             const model2 = Printer.toCTO(mm1);
-            const modelManager2 = new ModelManager({ importAliasing: true, enableMapType: true });
+            const modelManager2 = new ModelManager();
             const mf2 = ParserUtil.newModelFile(modelManager2, model2);
             const mm2 = mf2.getAst();
             mm2.should.deep.equal(parentMetaModel);
         });
 
         it('should accpet a cto model with its dependency, resolve the types and build back the cto', () => {
-            const modelManager = new ModelManager({ importAliasing: true, enableMapType: true });
+            const modelManager = new ModelManager();
             const mf1 = ParserUtil.newModelFile(modelManager, childModel);
             const mf2 = ParserUtil.newModelFile(modelManager, parentModel);
             modelManager.addModelFiles([mf1, mf2], ['child.cto', 'parent.cto']);

--- a/packages/concerto-core/test/introspect/modelfile.js
+++ b/packages/concerto-core/test/introspect/modelfile.js
@@ -610,9 +610,6 @@ describe('ModelFile', () => {
 
     describe('#aliasedImport', () => {
 
-        beforeEach(()=>{
-            modelManager.importAliasing=true;
-        });
         it('should resolve aliased name of import type', () => {
             const model = `
             namespace org.acme

--- a/packages/concerto-core/test/introspect/property.js
+++ b/packages/concerto-core/test/introspect/property.js
@@ -123,7 +123,7 @@ describe('Property - Test for property types using Import Aliasing', () => {
     let resolvedModelManager;
 
     beforeEach(() => {
-        modelManager = new ModelManager({ strict: true, importAliasing: true, enableMapType: true});
+        modelManager = new ModelManager({ strict: true });
 
         const childModelCTO = fs.readFileSync(path.resolve(__dirname, '../data/aliasing/child.cto'), 'utf8');
         const parentModelCTO = fs.readFileSync(path.resolve(__dirname, '../data/aliasing/parent.cto'), 'utf8');
@@ -132,7 +132,7 @@ describe('Property - Test for property types using Import Aliasing', () => {
         modelManager.addCTOModel(parentModelCTO, 'parent@1.0.0.cto');
         const resolvedMetamodelChild = modelManager.resolveMetaModel(modelManager.getAst().models[0]);
         const resolvedMetamodelParent = modelManager.resolveMetaModel(modelManager.getAst().models[1]);
-        resolvedModelManager = new ModelManager({ strict: true, importAliasing: true, enableMapType: true});
+        resolvedModelManager = new ModelManager({ strict: true });
         const resolvedModelFileChild = new ModelFile(resolvedModelManager, resolvedMetamodelChild, 'child@1.0.0.cto');
         const resolvedModelFileParent = new ModelFile(resolvedModelManager, resolvedMetamodelParent, 'parent@1.0.0.cto');
         resolvedModelManager.addModelFiles([resolvedModelFileChild, resolvedModelFileParent], ['child@1.0.0.cto', 'parent@1.0.0.cto']);

--- a/packages/concerto-core/types/lib/basemodelmanager.d.ts
+++ b/packages/concerto-core/types/lib/basemodelmanager.d.ts
@@ -23,8 +23,6 @@ declare class BaseModelManager {
      * @param {Object} [options.regExp] - An alternative regular expression engine.
      * @param {boolean} [options.metamodelValidation] - When true, modelfiles will be validated
      * @param {boolean} [options.addMetamodel] - When true, the Concerto metamodel is added to the model manager
-     * @param {boolean} [options.enableMapType] - When true, the Concerto Map Type feature is enabled
-     * @param {boolean} [options.importAliasing] - When true, the Concerto Aliasing feature is enabled
      * @param {object} [options.decoratorValidation] - the decorator validation configuration
      * @param {string} [options.decoratorValidation.missingDecorator] - the validation log level for missingDecorator decorators: off, warning, error
      * @param {string} [options.decoratorValidation.invalidDecorator] - the validation log level for invalidDecorator decorators: off, warning, error
@@ -35,8 +33,6 @@ declare class BaseModelManager {
         regExp?: any;
         metamodelValidation?: boolean;
         addMetamodel?: boolean;
-        enableMapType?: boolean;
-        importAliasing?: boolean;
         decoratorValidation?: {
             missingDecorator?: string;
             invalidDecorator?: string;
@@ -53,8 +49,6 @@ declare class BaseModelManager {
         regExp?: any;
         metamodelValidation?: boolean;
         addMetamodel?: boolean;
-        enableMapType?: boolean;
-        importAliasing?: boolean;
         decoratorValidation?: {
             missingDecorator?: string;
             invalidDecorator?: string;
@@ -67,8 +61,6 @@ declare class BaseModelManager {
         missingDecorator?: string;
         invalidDecorator?: string;
     };
-    enableMapType: boolean;
-    importAliasing: boolean;
     metamodelModelFile: ModelFile;
     /**
      * Returns true


### PR DESCRIPTION
<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes 
<!--- Provide an overall summary of the pull request -->

### Changes
Makes Map Type and Import Aliasing features available by default without client applications needing to set environment variables or configuration options.

To do 
- [ ] review documentation
- [ ] similar changes to concerto-metamodel, concerto-cli, concerto-codegen

### Flags
<!--- Provide context or concerns a reviewer should be aware of -->
- <ONE>
- <TWO>

### Screenshots or Video
<!--- Provide an easily accessible demonstration of the changes, if applicable -->

### Related Issues
- Issue #<NUMBER>
- Pull Request #<NUMBER>

### Author Checklist
- [ ] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [ ] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ ] Merging to `main` from `fork:branchname`
