### PR TITLE
feat(linter): Add configurable linter support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12100,7 +12100,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -15503,7 +15502,8 @@
         "@stoplight/spectral-cli": "6.15.0",
         "@stoplight/spectral-core": "1.20.0",
         "@stoplight/spectral-functions": "1.10.1",
-        "@stoplight/spectral-parsers": "1.0.5"
+        "@stoplight/spectral-parsers": "1.0.5",
+        "find-up": "5.0.0"
       },
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "8.16.0",
@@ -15589,6 +15589,67 @@
         }
       }
     },
+    "packages/concerto-linter/node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/concerto-linter/node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/concerto-linter/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/concerto-linter/node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "packages/concerto-linter/node_modules/rimraf": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.0.1.tgz",
@@ -15620,6 +15681,18 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/esm/bin/uuid"
+      }
+    },
+    "packages/concerto-linter/node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "packages/concerto-types": {

--- a/packages/concerto-linter/README.md
+++ b/packages/concerto-linter/README.md
@@ -1,4 +1,81 @@
+# lintModel Function
 
-## License <a name="license"></a>
-Accord Project source code files are made available under the Apache License, Version 2.0 (Apache-2.0), located in the LICENSE file. Accord Project documentation files are made available under the Creative Commons Attribution 4.0 International License (CC-BY-4.0), available at http://creativecommons.org/licenses/by/4.0/.
+The lintModel function provides a robust and efficient solution for linting Concerto models using Spectral. It ensures your models adhere to predefined or custom rulesets, promoting consistency, quality, and maintainability in your codebase.
 
+## Features
+
+- **Versatile Model Input**: Supports Concerto models provided as either a CTO string or a parsed Abstract Syntax Tree (AST) object.
+
+- **Automatic Ruleset Discovery**: Automatically detects Spectral ruleset files (e.g., .spectral.yaml, .spectral.yml, .spectral.json, .spectral.js) in the current or parent directories when no explicit ruleset is specified.
+
+- **Custom Ruleset Flexibility**: Enables the use of a custom Spectral ruleset by allowing you to specify its file path for tailored linting rules.
+
+## How to Use
+
+### Installation
+Install the package via npm:
+```bash
+npm install @accordproject/concerto-linter
+```
+
+### Providing the Concerto Model
+The lintModel function accepts your Concerto model in one of two formats:
+
+#### As a CTO String
+```javascript
+const model = `
+namespace org.example
+asset MyProduct {
+  o String ProductId
+}
+`;
+```
+
+#### As a Parsed AST Object
+```javascript
+import { ModelManager } from '@accordproject/concerto-core';
+
+const modelManager = new ModelManager();
+const model = `
+namespace org.example
+asset MyProduct {
+  o String ProductId
+}
+`;
+modelManager.addCTOModel(model);
+const ast = modelManager.getAst();
+```
+
+### Linting with Automatic Ruleset Discovery
+To lint your model using the default behavior, simply call lintModel without specifying a ruleset path. It will search for ruleset files in the following order: .spectral.yaml, .spectral.yml, .spectral.json, .spectral.js. If none are found, it defaults to the @accordproject/concerto-linter-default-ruleset.
+```javascript
+import { lintModel } from '@accordproject/concerto-linter';
+
+const results = lintModel(ast); // Pass the AST object
+// OR
+const results = lintModel(model); // Pass the CTO string directly
+```
+
+### Linting with a Custom Ruleset
+For custom linting rules, provide the path to your Spectral ruleset file:
+```javascript
+const results = lintModel(ast, "D:\\linter-test\\my-ruleset.yaml");
+```
+
+## Resolution Priority
+
+1. **Explicit Path**: Custom ruleset file specified as parameter
+2. **Project Detection**: Automatic discovery in current and parent directories
+3. **Default Fallback**: `@accordproject/concerto-linter-default-ruleset`
+
+## Creating Custom Rulesets
+
+To develop your own validation rules for Concerto models, you can extend the default ruleset or create entirely custom rules.
+
+> **📖 Complete Guide Coming Soon**: Detailed instructions on how to extend rulesets and create your own custom validation rules will be provided in the `@accordproject/concerto-linter-default-ruleset` README documentation after the package is published.
+
+
+
+## License
+
+Accord Project source code files are made available under the Apache License, Version 2.0 (Apache-2.0), located in the LICENSE file. Accord Project documentation files are made available under the Creative Commons Attribution 4.0 International License (CC-BY-4.0).

--- a/packages/concerto-linter/package.json
+++ b/packages/concerto-linter/package.json
@@ -36,7 +36,8 @@
         "@stoplight/spectral-cli": "6.15.0",
         "@stoplight/spectral-core": "1.20.0",
         "@stoplight/spectral-functions": "1.10.1",
-        "@stoplight/spectral-parsers": "1.0.5"
+        "@stoplight/spectral-parsers": "1.0.5",
+        "find-up": "5.0.0"
     },
     "devDependencies": {
         "eslint": "8.57.1",

--- a/packages/concerto-linter/src/config-loader.ts
+++ b/packages/concerto-linter/src/config-loader.ts
@@ -1,0 +1,48 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import findUp from 'find-up';
+
+// Valid Spectral ruleset filenames in priority order
+const SPECTRAL_RULESET_FILES = [
+    '.spectral.yaml',
+    '.spectral.yml',
+    '.spectral.json',
+    '.spectral.js',
+];
+
+/**
+ * Searches for a Spectral ruleset configuration file in the current and parent directories.
+ * @returns {Promise<string | null>} Path to found ruleset file or null if none exists
+ */
+async function findLocalRuleset(): Promise<string | null> {
+    for (const fileName of SPECTRAL_RULESET_FILES) {
+        const foundPath = await findUp(fileName);
+        if (foundPath) {return foundPath;}
+    }
+    return null;
+}
+
+/**
+ * Resolves the Spectral ruleset location based on user input or directory search
+ * @param {string} [rulesetOption] - User-provided ruleset path or 'default'
+ * @returns {Promise<string | null>} Path to custom ruleset, null for default ruleset
+ */
+export async function resolveRulesetPath(rulesetOption?: string): Promise<string | null> {
+    if (!rulesetOption) {
+        return await findLocalRuleset();
+    }
+
+    return rulesetOption === 'default' ? null : rulesetOption;
+}

--- a/packages/concerto-linter/src/index.ts
+++ b/packages/concerto-linter/src/index.ts
@@ -12,27 +12,64 @@
  * limitations under the License.
  */
 
-import { Spectral, Document } from '@stoplight/spectral-core';
+import { Spectral, Document, IRuleResult, RulesetDefinition, Ruleset } from '@stoplight/spectral-core';
 import { Json as JsonParsers } from '@stoplight/spectral-parsers';
+import { resolveRulesetPath } from './config-loader';
+import { getRuleset } from '@stoplight/spectral-cli/dist/services/linter/utils/getRuleset';
 import { concertoRuleset } from './rulesets/core-ruleset';
+import { ModelManager } from '@accordproject/concerto-core';
 
 /**
- * Lints a Concerto model's JSON AST using the defined rulesets
- * @param ast - The JSON AST generated from a Concerto model.
- * @returns An array on linting results (e.g., errors or warnings).
+ * Converts Concerto model to JSON AST representation
+ * @param {string | object} model - Concerto model as string or parsed object
+ * @returns {string} JSON string of the AST
+ * @throws {Error} For invalid model inputs
  */
-
-export function lintAST(ast: string) {
-
-    const spectral = new Spectral();
-
-    spectral.setRuleset(concertoRuleset);
-
-    const document = new Document(ast,JsonParsers,'/virtual/concerto-ast.json');
-
-    const results = spectral.run(document);
-    return results;
-
+function convertToJsonAST(model: string | object): string {
+    try {
+        if (typeof model === 'string') {
+            const manager = new ModelManager();
+            manager.addCTOModel(model);
+            return JSON.stringify(manager.getAst());
+        }
+        return JSON.stringify(model);
+    } catch (error) {
+        throw new Error(`Model conversion failed: ${error instanceof Error ? error.message : error}`);
+    }
 }
 
-export { concertoRuleset } from './rulesets/core-ruleset';
+/**
+ * Loads Spectral ruleset based on configuration options
+ * @param {string} [rulesetOption] - Custom ruleset path or 'default'
+ * @returns {Promise<Ruleset | RulesetDefinition>} Loaded ruleset
+ */
+async function loadRuleset(rulesetOption?: string): Promise<Ruleset | RulesetDefinition> {
+    try {
+        const rulesetPath = await resolveRulesetPath(rulesetOption);
+        return rulesetPath ? await getRuleset(rulesetPath) : concertoRuleset;
+    } catch (error) {
+        throw new Error(`Ruleset loading failed: ${error instanceof Error ? error.message : error}`);
+    }
+}
+
+/**
+ * Lints Concerto models using Spectral and Concerto rules
+ * @param {string | object} model - Model to lint (string CTO or parsed AST)
+ * @param {string} [rulesetOption] - Path to custom ruleset or 'default'
+ * @returns {Promise<IRuleResult[]>} Linting results
+ * @throws {Error} For critical processing failures
+ */
+export async function lintModel(model: string | object, rulesetOption?: string): Promise<IRuleResult[]> {
+    try {
+        const jsonAST = convertToJsonAST(model);
+        const ruleset = await loadRuleset(rulesetOption);
+
+        const spectral = new Spectral();
+        spectral.setRuleset(ruleset);
+
+        const document = new Document(jsonAST, JsonParsers);
+        return await spectral.run(document);
+    } catch (error) {
+        throw new Error(`Linting process failed: ${error instanceof Error ? error.message : error}`);
+    }
+}

--- a/packages/concerto-linter/test/rules/naming-ruleset.test.ts
+++ b/packages/concerto-linter/test/rules/naming-ruleset.test.ts
@@ -1,5 +1,4 @@
-import { lintAST } from '../../src/index';
-import { ModelManager } from '@accordproject/concerto-core';
+import { lintModel } from '../../src/index';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 
@@ -7,14 +6,7 @@ async function getModelAST(fileName: string)
 {
     const filePath = path.resolve(__dirname,'../fixtures/',fileName);
     const model = await fs.readFile(filePath, 'utf-8');
-    const modelManager = new ModelManager();
-    modelManager.addCTOModel(model);
-
-    const ast = modelManager.getAst();
-    const jsonString = JSON.stringify(ast);
-
-    const results = await lintAST(jsonString);
-
+    const results = await lintModel(model);
     return results;
 }
 


### PR DESCRIPTION
# Closes #1028 

## Changes

- **Updated linter API**  
  - Accepts CTO models as both strings and plain AST objects

- **Implemented extensible ruleset configuration**  
  - Supports `.yaml`, `.yml`, `.json`, and `.js` files

- **Added capabilities to:**
  - Enable/disable individual rules
  - Define custom rules
  - Modify rule severity levels
  - Extend base ruleset

- **Automated ruleset discovery**  
  Searches the project directory for:

  ```js
  const SPECTRAL_RULESET_FILES = [
    '.spectral.yaml',
    '.spectral.yml',
    '.spectral.json',
    '.spectral.js'
  ];
- **Path Override Support**
  - Explicit ruleset path can be passed to the `lint()` function.
> For more information, refer to the **README** file.
## Upcoming Integration

- A default ruleset will be published as a `concerto-linter-default-ruleset` subpackage 
- Users can extend the core rules using the `extends` field in their custom rulesets.





---


### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.  
- [x] Vital features and changes captured in unit and/or integration tests  
- [x] Merging to `main` from `Ahmed-Gaper/i1028/configurable-linter`  
