### PR TITLE
Fix: Resolve default-ruleset Publish Failure

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15504,7 +15504,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@accordproject/concerto-core": "3.21.0",
-        "@accordproject/concerto-linter-default-ruleset": "1.0.0",
+        "@accordproject/concerto-linter-default-ruleset": "file:./default-ruleset",
         "@stoplight/spectral-cli": "6.15.0",
         "@stoplight/spectral-core": "1.20.0",
         "@stoplight/spectral-parsers": "1.0.5",
@@ -15531,7 +15531,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@accordproject/concerto-core": "3.21.0",
-        "@accordproject/concerto-linter": "1.0.0",
         "@stoplight/spectral-core": "1.20.0",
         "@stoplight/spectral-functions": "1.10.1",
         "@stoplight/spectral-parsers": "1.0.5"

--- a/packages/concerto-linter/default-ruleset/package.json
+++ b/packages/concerto-linter/default-ruleset/package.json
@@ -34,7 +34,6 @@
     "license": "Apache-2.0",
     "dependencies": {
         "@accordproject/concerto-core": "3.21.0",
-        "@accordproject/concerto-linter": "1.0.0",
         "@stoplight/spectral-core": "1.20.0",
         "@stoplight/spectral-functions": "1.10.1",
         "@stoplight/spectral-parsers": "1.0.5"

--- a/packages/concerto-linter/default-ruleset/test/rules/naming-ruleset.test.ts
+++ b/packages/concerto-linter/default-ruleset/test/rules/naming-ruleset.test.ts
@@ -1,13 +1,24 @@
-import { lintModel } from '@accordproject/concerto-linter';
 import * as fs from 'fs/promises';
 import * as path from 'path';
+import { ModelManager } from '@accordproject/concerto-core';
+import { Json as JsonParsers } from '@stoplight/spectral-parsers';
+import { default as namingRules } from '../../src/naming-ruleset';
+import { Spectral, Document } from '@stoplight/spectral-core';
 
 async function getModelAST(fileName: string)
 {
     const filePath = path.resolve(__dirname,'../fixtures/',fileName);
     const model = await fs.readFile(filePath, 'utf-8');
-    const results = await lintModel(model);
-    return results;
+
+    const manager = new ModelManager();
+    manager.addCTOModel(model);
+    const jsonAST = JSON.stringify(manager.getAst());
+
+    const spectral = new Spectral();
+    spectral.setRuleset(namingRules);
+
+    const document = new Document(jsonAST, JsonParsers);
+    return await spectral.run(document);
 }
 
 describe ('Naming Convention Linting Rules' , () => {

--- a/packages/concerto-linter/package.json
+++ b/packages/concerto-linter/package.json
@@ -33,7 +33,7 @@
     "license": "Apache-2.0",
     "dependencies": {
         "@accordproject/concerto-core": "3.21.0",
-        "@accordproject/concerto-linter-default-ruleset": "1.0.0",
+        "@accordproject/concerto-linter-default-ruleset": "file:./default-ruleset",
         "find-up": "5.0.0",
         "@stoplight/spectral-cli": "6.15.0",
         "@stoplight/spectral-core": "1.20.0",

--- a/scripts/bump_version.js
+++ b/scripts/bump_version.js
@@ -27,19 +27,23 @@ const glob = require('glob');
  * node ./script/bump_version.js <tag>
  */
 
-const workspacesPattern = 'packages/*/package.json'; // Adjust this pattern based on your workspace setup
+const workspacesPattern = 'packages/**/package.json'; // Adjust this pattern based on your workspace setup
 const packageNames = [
     "@accordproject/concerto-analysis",
     "@accordproject/concerto-core",
     "@accordproject/concerto-cto",
     "@accordproject/concerto-types",
     "@accordproject/concerto-util",
-    "@accordproject/concerto-vocabulary"
+    "@accordproject/concerto-vocabulary",
+    "@accordproject/concerto-linter",
+    "@accordproject/concerto-linter-default-ruleset",
 ];
 
 function bumpDependencies() {
     const targetPackageVersion = process.argv[2].replace(/^v/, '');
-    const workspacePackages = glob.sync(workspacesPattern);
+    const workspacePackages = glob.sync(workspacesPattern, {
+        ignore: ['**/node_modules/**', '**/test/**'],
+    });
 
     workspacePackages.forEach((packagePath) => {
         const packageJson = JSON.parse(fs.readFileSync(packagePath, 'utf8'));


### PR DESCRIPTION

This PR addresses the recent failure of the `concerto-linter` package to publish to npm. The root cause was an incorrect dependency declaration for `@accordproject/concerto-linter-default-ruleset`.

Previously, `concerto-linter` attempted to depend on `@accordproject/concerto-linter-default-ruleset` with a fixed version (`"1.0.0"`). This created a circular dependency issue where the linter couldn't publish because its dependency wasn't yet available on npm.

The solution involves two key changes:

1.  **Update Dependency Path:** The `concerto-linter-default-ruleset` dependency in `package.json` has been updated to use a **local file path**:

    ```json
    "@accordproject/concerto-linter-default-ruleset": "file:./default-ruleset"
    ```
    This ensures that `default-ruleset` is always included directly within `concerto-linter`, resolving the immediate publish blockage.

2.  **Automate Release Versioning:** The `scripts/bump_version.js` file has been modified. This script will now automatically **replace the `file:` path with the correct stable version** of `concerto-linter-default-ruleset` during future stable releases. This maintains the correct dependency structure for published versions while allowing for local development and build processes.

Additionally, to improve modularity and prevent similar issues in the future:

* **Decoupled Default Ruleset Unit Tests:** The unit tests within `default-ruleset` have been refactored to be **loosely coupled**, removing their direct dependency on `concerto-linter`. This makes the `default-ruleset` more independent and robust.

These changes collectively ensure that `concerto-linter` can publish successfully and that its dependencies are handled correctly both during development and in production releases.

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Merging to `main` from `Ahmed-Gaper/ruleset-publish-failure`
