### PR TITLE
refactor: add missing $class fields in dcs json

### DIFF
--- a/packages/concerto-core/test/dcsconverter.js
+++ b/packages/concerto-core/test/dcsconverter.js
@@ -45,17 +45,20 @@ describe('DCS Converter', function(){
                 "version": "1.0.0",
                 "commands": [
                     {
+                        "$class": "org.accordproject.decoratorcommands@0.4.0.Command",
                         "type": "UPSERT",
                         "target": {
                             "$class": "org.accordproject.decoratorcommands@0.4.0.CommandTarget",
                             "namespace": "test@1.0.0"
                         },
                         "decorator": {
+                            "$class": "concerto.metamodel@1.0.0.Decorator",
                             "name": "exampleDecorator",
                             "arguments": [
                                 {
                                     "$class": "concerto.metamodel@1.0.0.DecoratorTypeReference",
                                     "type": {
+                                        "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
                                         "name": "Info",
                                         "namespace": "test@1.0.0"
                                     },
@@ -98,17 +101,20 @@ commands:
                 "version": "1.0.0",
                 "commands": [
                     {
+                        "$class": "org.accordproject.decoratorcommands@0.4.0.Command",
                         "type": "UPSERT",
                         "target": {
                             "$class": "org.accordproject.decoratorcommands@0.4.0.CommandTarget",
                             "namespace": "test@1.0.0"
                         },
                         "decorator": {
+                            "$class": "concerto.metamodel@1.0.0.Decorator",
                             "name": "exampleDecorator",
                             "arguments": [
                                 {
                                     "$class": "concerto.metamodel@1.0.0.DecoratorTypeReference",
                                     "type": {
+                                        "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
                                         "name": "Info",
                                         "namespace": "test@1.0.0",
                                         "resolvedName": "Data"
@@ -153,17 +159,20 @@ commands:
                 "version": "1.0.0",
                 "commands": [
                     {
+                        "$class": "org.accordproject.decoratorcommands@0.4.0.Command",
                         "type": "UPSERT",
                         "target": {
                             "$class": "org.accordproject.decoratorcommands@0.4.0.CommandTarget",
                             "namespace": "test@1.0.0"
                         },
                         "decorator": {
+                            "$class": "concerto.metamodel@1.0.0.Decorator",
                             "name": "exampleDecorator",
                             "arguments": [
                                 {
                                     "$class": "concerto.metamodel@1.0.0.DecoratorTypeReference",
                                     "type": {
+                                        "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
                                         "name": "Info"
                                     },
                                     "isArray": false


### PR DESCRIPTION
<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
<!--- Provide an overall summary of the pull request -->

This PR fixes an issue in `test/dcsconverter.js` where $class fields were unintentionally omitted during the initial implementation of the JSON to YAML feature.

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)