### PR TITLE
feat(concerto-core): implement YAML to JSON conversion for DCS

### DIFF
--- a/packages/concerto-core/api.txt
+++ b/packages/concerto-core/api.txt
@@ -61,6 +61,10 @@ class Concerto {
    + object handleDecorator() 
    + object handleCommands() 
    + string jsonToYaml() throws Error
+   + object restoreArguments() 
+   + object restoreDecorator() 
+   + object restoreCommands() 
+   + object yamlToJson() 
 class DecoratorManager {
    + ModelManager validate(decoratorCommandSet,ModelFile[]) throws Error
    + object migrateTo(decoratorCommandSet,string) 
@@ -76,6 +80,7 @@ class DecoratorManager {
    + void executePropertyCommand(property,command) 
    + Boolean isNamespaceTargetEnabled(boolean?) 
    + string jsonToYaml(object) 
+   + object yamlToJson(string) 
 }
    + string[] intersect() 
    + boolean isUnversionedNamespaceEqual() 

--- a/packages/concerto-core/api.txt
+++ b/packages/concerto-core/api.txt
@@ -56,14 +56,7 @@ class Concerto {
    + string getNamespace(obj) 
 }
    + object setCurrentTime() 
-   + object handleTarget() 
-   + object handleArguments() 
-   + object handleDecorator() 
-   + object handleCommands() 
-   + string jsonToYaml() throws Error
-   + object restoreArguments() 
-   + object restoreDecorator() 
-   + object restoreCommands() 
+   + string jsonToYaml() 
    + object yamlToJson() 
 class DecoratorManager {
    + ModelManager validate(decoratorCommandSet,ModelFile[]) throws Error

--- a/packages/concerto-core/changelog.txt
+++ b/packages/concerto-core/changelog.txt
@@ -24,8 +24,9 @@
 # Note that the latest public API is documented using JSDocs and is available in api.txt.
 #
 
-Version 3.22.0 {59de1f67703a76ab4a0f0c986775e889} 2025-07-12
+Version 3.22.0 {f9906fecbb071af456002ae2f8e006bc} 2025-07-26
 - added jsonToYaml method in DecoratorManager
+- added yamlToJson method in DecoratorManager
 
 Version 3.20.5 {a18e77c836e19a4badcbe83d6c7e7c1e} 2025-02-03
 - vocabulary support for namespace scoped decorators

--- a/packages/concerto-core/changelog.txt
+++ b/packages/concerto-core/changelog.txt
@@ -24,7 +24,7 @@
 # Note that the latest public API is documented using JSDocs and is available in api.txt.
 #
 
-Version 3.22.0 {f9906fecbb071af456002ae2f8e006bc} 2025-07-26
+Version 3.22.0 {677eac41f1ef471977d3e301e46ef480} 2025-07-26
 - added jsonToYaml method in DecoratorManager
 - added yamlToJson method in DecoratorManager
 

--- a/packages/concerto-core/lib/dcsconverter.js
+++ b/packages/concerto-core/lib/dcsconverter.js
@@ -22,6 +22,7 @@ const { MetaModelNamespace } = require('@accordproject/concerto-metamodel');
  * handles the target field of a command
  * @param {object} target the value of target
  * @returns {object} the simplified target object
+ * @private
  */
 function handleTarget(target){
     const targetKeys = Object.keys(target);
@@ -43,6 +44,7 @@ function handleTarget(target){
  * @param {object} [argument.type] the type identifier for type reference arguments
  * @param {boolean} [argument.isArray] whether the type reference is an array
  * @returns {object} simplified argument object
+ * @private
  */
 function handleArguments(argument){
     const mapClassToType = {
@@ -72,6 +74,7 @@ function handleArguments(argument){
  * @param {string} decorator.name the name of the decorator
  * @param {object[]} [decorator.arguments] the list of arguments
  * @returns {object} simplified decorator object with name and arguments
+ * @private
  */
 function handleDecorator(decorator){
     return {
@@ -89,6 +92,7 @@ function handleDecorator(decorator){
  * @param {object} command.target the target to apply decorator to
  * @param {object} command.decorator the decorator to apply
  * @returns {object} simplified commands object
+ * @private
  */
 function handleCommands(command){
     return {
@@ -102,7 +106,6 @@ function handleCommands(command){
  * converts DCS JSON to YAML string
  * @param {object} dcsJson the DCS JSON as parsed object
  * @returns {string} the DCS YAML string
- * @throws {Error} if the input is not a valid DCS JSON
  */
 function jsonToYaml(dcsJson){
     const dcsNamespace = ModelUtil.getNamespace(dcsJson.$class);
@@ -132,6 +135,7 @@ function jsonToYaml(dcsJson){
  * @param {*} [argument.value] - the argument value
  * @param {object} [argument.typeReference] - the type reference object for complex types
  * @returns {object} - the fully qualified argument object after restoring required fields
+ * @private
  */
 function restoreArguments(MetaModelNamespace, argument){
     const mapTypeToClass = {
@@ -162,6 +166,7 @@ function restoreArguments(MetaModelNamespace, argument){
  * handles the decorator of each command for yaml to json
  * @param {object} decorator - the decorator to convert
  * @returns {object} - the decorator object after restoring required fields
+ * @private
  */
 function restoreDecorator(decorator){
     return {
@@ -177,6 +182,7 @@ function restoreDecorator(decorator){
  * @param {string} dcsNamespace - the namespace of the DCS
  * @param {object} command - the command to convert
  * @returns {object} - the command object after restoring required fields
+ * @private
  */
 function restoreCommands(dcsNamespace, command){
     return {

--- a/packages/concerto-core/lib/decoratormanager.js
+++ b/packages/concerto-core/lib/decoratormanager.js
@@ -28,7 +28,7 @@ const rfdc = require('rfdc')({
     proto: false,
 });
 
-const { jsonToYaml } = require('./dcsconverter');
+const { jsonToYaml, yamlToJson } = require('./dcsconverter');
 
 // Types needed for TypeScript generation.
 /* eslint-disable no-unused-vars */
@@ -864,6 +864,19 @@ class DecoratorManager {
         this.validate(jsonInput);
         return jsonToYaml(jsonInput);
     }
+
+    /**
+     * converts DCS YAML string into JSON object
+     * validates the output DCS JSON against the DCS model
+     * @param {string} yamlInput the DCS JSON as parsed object
+     * @return {object} the corresponding JSON object
+     */
+    static yamlToJson(yamlInput){
+        const jsonOutput = yamlToJson(yamlInput);
+        this.validate(jsonOutput);
+        return jsonOutput;
+    }
+
 }
 
 module.exports = DecoratorManager;

--- a/packages/concerto-core/test/dcsconverter.js
+++ b/packages/concerto-core/test/dcsconverter.js
@@ -21,7 +21,7 @@ const yaml = require('yaml');
 const chai = require('chai');
 chai.should();
 
-const { jsonToYaml } = require('../lib/dcsconverter');
+const { jsonToYaml, yamlToJson } = require('../lib/dcsconverter');
 
 describe('DCS Converter', function(){
 
@@ -204,6 +204,180 @@ commands:
             const parsedExpectedYaml = yaml.parse(expectedYaml);
             parsedYaml.should.deep.equal(parsedExpectedYaml);
             outputYaml.should.equal(expectedYaml);
+        });
+
+    });
+
+
+    describe('#yamlToJson', function(){
+        const yamlFilePath = path.resolve(__dirname, 'data/decoratorcommands/possible-decorator-command-targets.yaml' );
+        const yamlString = fs.readFileSync(yamlFilePath, 'utf8');
+
+        it('should convert YAML formatted DCS to expected JSON format', function(){
+            const outputJson = yamlToJson(yamlString);
+            const expectedJson = fs.readFileSync(path.resolve(__dirname, 'data/decoratorcommands/possible-decorator-command-targets.json'), 'utf8');
+            const parsedExpectedJson = JSON.parse(expectedJson);
+            outputJson.should.deep.equal(parsedExpectedJson);
+        });
+
+        it('should handle resolved but unalised DecoratorTypeReference properly', function(){
+            const inputYaml =
+`decoratorCommandsVersion: 0.4.0
+name: exampleDCS
+version: 1.0.0
+commands:
+  - action: UPSERT
+    target:
+      namespace: test@1.0.0
+    decorator:
+      name: exampleDecorator
+      arguments:
+        - typeReference:
+            name: Info
+            namespace: test@1.0.0
+            isArray: false
+`;
+
+            const expectedDcsJson = `{
+                "$class": "org.accordproject.decoratorcommands@0.4.0.DecoratorCommandSet",
+                "name": "exampleDCS",
+                "version": "1.0.0",
+                "commands": [
+                    {
+                        "$class": "org.accordproject.decoratorcommands@0.4.0.Command",
+                        "type": "UPSERT",
+                        "target": {
+                            "$class": "org.accordproject.decoratorcommands@0.4.0.CommandTarget",
+                            "namespace": "test@1.0.0"
+                        },
+                        "decorator": {
+                            "$class": "concerto.metamodel@1.0.0.Decorator",
+                            "name": "exampleDecorator",
+                            "arguments": [
+                                {
+                                    "$class": "concerto.metamodel@1.0.0.DecoratorTypeReference",
+                                    "type": {
+                                        "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                                        "name": "Info",
+                                        "namespace": "test@1.0.0"
+                                    },
+                                    "isArray": false
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }`;
+
+            const outputJson = yamlToJson(inputYaml);
+            outputJson.should.deep.equal(JSON.parse(expectedDcsJson));
+        });
+
+        it('should handle resolved and alised DecoratorTypeReference properly', function(){
+            const inputYaml =
+`decoratorCommandsVersion: 0.4.0
+name: exampleDCS
+version: 1.0.0
+commands:
+  - action: UPSERT
+    target:
+      namespace: test@1.0.0
+    decorator:
+      name: exampleDecorator
+      arguments:
+        - typeReference:
+            name: Info
+            namespace: test@1.0.0
+            resolvedName: Data
+            isArray: false
+`;
+
+            const expectedDcsJson = `{
+                "$class": "org.accordproject.decoratorcommands@0.4.0.DecoratorCommandSet",
+                "name": "exampleDCS",
+                "version": "1.0.0",
+                "commands": [
+                    {
+                        "$class": "org.accordproject.decoratorcommands@0.4.0.Command",
+                        "type": "UPSERT",
+                        "target": {
+                            "$class": "org.accordproject.decoratorcommands@0.4.0.CommandTarget",
+                            "namespace": "test@1.0.0"
+                        },
+                        "decorator": {
+                            "$class": "concerto.metamodel@1.0.0.Decorator",
+                            "name": "exampleDecorator",
+                            "arguments": [
+                                {
+                                    "$class": "concerto.metamodel@1.0.0.DecoratorTypeReference",
+                                    "type": {
+                                        "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                                        "name": "Info",
+                                        "namespace": "test@1.0.0",
+                                        "resolvedName": "Data"
+                                    },
+                                    "isArray": false
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }`;
+
+            const outputJson = yamlToJson(inputYaml);
+            outputJson.should.deep.equal(JSON.parse(expectedDcsJson));
+
+        });
+
+        it('should handle unresolved and unalised DecoratorTypeReference properly', function(){
+            const inputYaml =
+`decoratorCommandsVersion: 0.4.0
+name: exampleDCS
+version: 1.0.0
+commands:
+  - action: UPSERT
+    target:
+      namespace: test@1.0.0
+    decorator:
+      name: exampleDecorator
+      arguments:
+        - typeReference:
+            name: Info
+            isArray: false
+`;
+
+            const expectedDcsJson = `{
+                "$class": "org.accordproject.decoratorcommands@0.4.0.DecoratorCommandSet",
+                "name": "exampleDCS",
+                "version": "1.0.0",
+                "commands": [
+                    {
+                        "$class": "org.accordproject.decoratorcommands@0.4.0.Command",
+                        "type": "UPSERT",
+                        "target": {
+                            "$class": "org.accordproject.decoratorcommands@0.4.0.CommandTarget",
+                            "namespace": "test@1.0.0"
+                        },
+                        "decorator": {
+                            "$class": "concerto.metamodel@1.0.0.Decorator",
+                            "name": "exampleDecorator",
+                            "arguments": [
+                                {
+                                    "$class": "concerto.metamodel@1.0.0.DecoratorTypeReference",
+                                    "type": {
+                                        "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                                        "name": "Info"
+                                    },
+                                    "isArray": false
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }`;
+
+            const outputJson = yamlToJson(inputYaml);
+            outputJson.should.deep.equal(JSON.parse(expectedDcsJson));
         });
 
     });

--- a/packages/concerto-core/test/decoratormanager.js
+++ b/packages/concerto-core/test/decoratormanager.js
@@ -1021,4 +1021,27 @@ describe('DecoratorManager', () => {
         });
     });
 
+    describe('#yamlToJson', function(){
+        it('should convert YAML formatted DCS to JSON via DecoratorManager', function(){
+            const dcsYaml = fs.readFileSync(path.resolve(__dirname, 'data/decoratorcommands/possible-decorator-command-targets.yaml'), 'utf8');
+            const outputJson = DecoratorManager.yamlToJson(dcsYaml);
+            const expectedJson = fs.readFileSync(path.resolve(__dirname, 'data/decoratorcommands/possible-decorator-command-targets.json'), 'utf8');
+            outputJson.should.deep.equal(JSON.parse(expectedJson));
+        });
+
+        it('should throw error if input is not valid DCS YAML', function(){
+            const invalidDcsYaml = [
+                'decoratorCommandsVersion: 0.4.0\ncommands: []',
+                'decoratorCommandsVersion: 0.4.0\nname: test\ncommands: []',
+                'name: test\nversion: 1.0.0\ncommands: []'
+            ];
+            invalidDcsYaml.forEach((value) => {
+                (() => {
+                    DecoratorManager.yamlToJson(value);
+                }).should.throw();
+            });
+        });
+    });
+
+
 });

--- a/packages/concerto-core/types/lib/dcsconverter.d.ts
+++ b/packages/concerto-core/types/lib/dcsconverter.d.ts
@@ -2,7 +2,6 @@
  * converts DCS JSON to YAML string
  * @param {object} dcsJson the DCS JSON as parsed object
  * @returns {string} the DCS YAML string
- * @throws {Error} if the input is not a valid DCS JSON
  */
 export function jsonToYaml(dcsJson: object): string;
 /**

--- a/packages/concerto-core/types/lib/dcsconverter.d.ts
+++ b/packages/concerto-core/types/lib/dcsconverter.d.ts
@@ -5,3 +5,9 @@
  * @throws {Error} if the input is not a valid DCS JSON
  */
 export function jsonToYaml(dcsJson: object): string;
+/**
+ * converts DCS YAML string to JSON format
+ * @param {string} yamlString the YAML string to convert
+ * @returns {object} the DCS JSON
+ */
+export function yamlToJson(yamlString: string): object;

--- a/packages/concerto-core/types/lib/decoratormanager.d.ts
+++ b/packages/concerto-core/types/lib/decoratormanager.d.ts
@@ -279,6 +279,13 @@ declare class DecoratorManager {
      * @return {string} the corresponding YAML string
      */
     static jsonToYaml(jsonInput: object): string;
+    /**
+     * converts DCS YAML string into JSON object
+     * validates the output DCS JSON against the DCS model
+     * @param {string} yamlInput the DCS JSON as parsed object
+     * @return {object} the corresponding JSON object
+     */
+    static yamlToJson(yamlInput: string): object;
 }
 import ModelFile = require("./introspect/modelfile");
 import ModelManager = require("./modelmanager");


### PR DESCRIPTION
# Closes #1040

This PR implements YAML to JSON conversion support for Decorator Command Sets (DCS), completing the bidirectional transformation feature.

- Implemented `yamlToJson()` function in `lib/dcsconverter.js` for converting simplified YAML DCS into JSON
- Exposed `yamlToJson()` via `DecoratorManager`
- Type definitions updated in `dcsconverter.d.ts` and `decoratormanager.d.ts`
- Comprehensive unit tests in `test/dcsconverter.js` and `test/decoratormanager.js`

---

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commit messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [x] Extend the documentation, if necessary
- [x] Merging to `main` from `fuyalasmit:gsoc/#1040`
