### PR TITLE
fix(metamodel): remove namespace from ScalarDeclaration AST

### DIFF
--- a/packages/concerto-core/lib/introspect/scalardeclaration.js
+++ b/packages/concerto-core/lib/introspect/scalardeclaration.js
@@ -265,7 +265,11 @@ class ScalarDeclaration extends Declaration {
     isConcept() {
         return false;
     }
-
+  toJSON() {
+    const json = super.toJSON();
+    delete json.namespace; // scalars should not include namespace
+    return json;
+}
 }
 
 module.exports = ScalarDeclaration;


### PR DESCRIPTION
This PR removes the `namespace` property from the ScalarDeclaration AST JSON output as part of the metamodel fix.
Modified ScalarDeclaration.toJSON to exclude namespace

