### PR TITLE
feat(linter): Add string length, PascalCase decorators, reserved keywords rules

### DIFF
--- a/packages/concerto-linter/default-ruleset/src/functions/check-length-validator.ts
+++ b/packages/concerto-linter/default-ruleset/src/functions/check-length-validator.ts
@@ -1,0 +1,52 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { IFunction, IFunctionResult } from '@stoplight/spectral-core';
+
+interface StringLengthValidator {
+  $class: 'concerto.metamodel@1.0.0.StringLengthValidator';
+  minLength: number;
+  maxLength: number;
+}
+
+interface StringObject {
+  name: string;
+  lengthValidator?: StringLengthValidator;
+}
+
+/**
+ * Checks if a String object has a length validator.
+ *
+ * @param {unknown} targetVal The AST node to check, expected to be a StringProperty or StringScalar object.
+ * @returns {IFunctionResult[] | void} An array of results indicating declarations that lack a length validator.
+ * @throws {Error} If the input is not a valid object.
+ */
+export const checkLengthValidator: IFunction = (targetVal): IFunctionResult[] => {
+    // Validate that targetVal is a non-null object
+    if (targetVal === null || typeof targetVal !== 'object') {
+        throw new Error('Input must be a valid String AST object.');
+    }
+
+    const stringObject = targetVal as StringObject;
+    const results: IFunctionResult[] = [];
+
+    // Check for missing length validator
+    if (!stringObject.lengthValidator) {
+        results.push({
+            message: `String '${stringObject.name}' must have a length validator.`,
+        });
+    }
+
+    return results;
+};

--- a/packages/concerto-linter/default-ruleset/src/pascal-case-decorators.ts
+++ b/packages/concerto-linter/default-ruleset/src/pascal-case-decorators.ts
@@ -1,0 +1,34 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { casing } from '@stoplight/spectral-functions';
+
+/**
+ * Rule: Pascal Case Decorators
+ * ------------------------------
+ * Ensures that decorator names follow PascalCase naming convention (e.g., 'MyDecorator').
+ * This promotes consistency and readability across model decorators.
+ */
+export default {
+    description: 'Decorators names should be PascalCase.',
+    given: '$.models[*].declarations[*].decorators[*].name',
+    message: 'Decorator \'{{value}}\' should be PascalCase (e.g. \'MyDecorator\')',
+    severity: 0, // 0 = error, 1 = warning, 2 = info, 3 = hint
+    then: {
+        function: casing,
+        functionOptions: {
+            type: 'pascal',
+        },
+    },
+};

--- a/packages/concerto-linter/default-ruleset/src/property-string-length.ts
+++ b/packages/concerto-linter/default-ruleset/src/property-string-length.ts
@@ -1,0 +1,28 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { checkLengthValidator } from './functions/check-length-validator';
+/**
+ * Rule: Property String Length
+ * ---------------------------
+ * Ensures that all string properties within the data model have a length validator applied.
+ * Which helps  prevent inconsistent data length and ensure proper storage."
+ */
+export default {
+    given: '$.models[*].declarations[*].properties[?(@.$class=="concerto.metamodel@1.0.0.StringProperty")]',
+    severity: 0, // 0 = error, 1 = warning, 2 = info, 3 = hint
+    then: {
+        function: checkLengthValidator,
+    },
+};

--- a/packages/concerto-linter/default-ruleset/src/ruleset-main.ts
+++ b/packages/concerto-linter/default-ruleset/src/ruleset-main.ts
@@ -18,16 +18,22 @@ import namespaceVersion from './namespace-version';
 import pascalCaseDeclarations from './pascal-case-declarations';
 import camelCaseProperties from './camel-case-properties';
 import upperSnakeCaseEnumConst from './upper-snake-case-enum-const';
+import pascalCaseDecorators from './pascal-case-decorators';
+import propertyStringLength from './property-string-length';
+import scalarStringLength from './scalar-string-length';
 import noEmptyDeclarations from './no-empty-declarations';
 import abstractMustSubclassed from './abstract-must-subclassed';
 
 const concertoRuleset: RulesetDefinition = {
     rules: {
         'namespace-version': namespaceVersion,
-        'no-empty-declarations': noEmptyDeclarations,
         'pascal-case-declarations': pascalCaseDeclarations,
         'camel-case-properties': camelCaseProperties,
         'upper-snake-case-enum-constants': upperSnakeCaseEnumConst,
+        'pascal-case-decorators': pascalCaseDecorators,
+        'property-string-length': propertyStringLength,
+        'scalar-string-length': scalarStringLength,
+        'no-empty-declarations': noEmptyDeclarations,
         'abstract-must-subclassed': abstractMustSubclassed,
     }
 };

--- a/packages/concerto-linter/default-ruleset/src/scalar-string-length.ts
+++ b/packages/concerto-linter/default-ruleset/src/scalar-string-length.ts
@@ -1,0 +1,28 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { checkLengthValidator } from './functions/check-length-validator';
+/**
+ * Rule: Scalar String Length
+ * ---------------------------
+ * Ensures that all scalar string types within the data model must have a length validator applied.
+ * Which helps  prevent inconsistent data length and ensure proper storage."
+ */
+export default {
+    given: '$.models[*].declarations[?(@.$class=="concerto.metamodel@1.0.0.StringScalar")]',
+    severity: 0, // 0 = error, 1 = warning, 2 = info, 3 = hint
+    then: {
+        function: checkLengthValidator,
+    },
+};


### PR DESCRIPTION
# Closes #1051 

## Description
This PR adds **three new default rulesets** to our linter based on the discussion at the WG for #1051  and the subsequent approval.

### New Default Rulesets
1. **String Length**  
   - All `String` fields, whether **properties** or **scalar values**, must have a defined length validator.  
   - This ensures better data validation and consistency.

2. **Decorator Names Should Follow PascalCase**  

3. **Reserved Keywords Used as Names**  
   - Prevents using reserved Concerto model keywords as declaration or property or decorator names.  
   - Reserved keywords include:  
     ```
     String, Double, Integer, Long, DateTime, Boolean, scalar, concept, enum, asset, participant, transaction, event, map
     ```
---

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Merging to `main` from `Ahmed-Gaper/i1051/stringLength-reservedKeywords-rules`
