### PR TITLE
feat(linter): refactor lintModel output shape & add namespace filtering

### DIFF
--- a/packages/concerto-linter/jest.config.js
+++ b/packages/concerto-linter/jest.config.js
@@ -4,4 +4,8 @@ module.exports = {
     transform: {
         '^.+.tsx?$': ['ts-jest', {}],
     },
+    testPathIgnorePatterns: [
+        './default-ruleset',
+    ],
+
 };

--- a/packages/concerto-linter/src/config-loader.ts
+++ b/packages/concerto-linter/src/config-loader.ts
@@ -36,13 +36,13 @@ async function findLocalRuleset(): Promise<string | null> {
 
 /**
  * Resolves the Spectral ruleset location based on user input or directory search
- * @param {string} [rulesetOption] - User-provided ruleset path or 'default'
+ * @param {string} [customPath] User-provided ruleset path
  * @returns {Promise<string | null>} Path to custom ruleset, null for default ruleset
  */
-export async function resolveRulesetPath(rulesetOption?: string): Promise<string | null> {
-    if (!rulesetOption) {
+export async function resolveRulesetPath(customPath?: string): Promise<string | null> {
+    if (!customPath) {
         return await findLocalRuleset();
     }
 
-    return rulesetOption === 'default' ? null : rulesetOption;
+    return customPath;
 }

--- a/packages/concerto-linter/test/unit/configLoader.test.ts
+++ b/packages/concerto-linter/test/unit/configLoader.test.ts
@@ -1,0 +1,76 @@
+import { resolveRulesetPath } from '../../src/config-loader';
+import findUp from 'find-up';
+
+// Mock the find-up module
+jest.mock('find-up');
+const mockFindUp = findUp as jest.MockedFunction<typeof findUp>;
+
+describe('resolveRulesetPath', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockFindUp.mockReset();
+    });
+
+
+    it('should return the provided path when rulesetOption is a custom path', async () => {
+        const customPath = '/path/to/custom/ruleset.yaml';
+        const result = await resolveRulesetPath(customPath);
+        expect(result).toBe(customPath);
+        expect(mockFindUp).not.toHaveBeenCalled();
+    });
+
+    it('should search for local ruleset when no rulesetOption is provided', async () => {
+        const foundPath = '/project/.spectral.yaml';
+        mockFindUp
+            .mockResolvedValueOnce(foundPath) // First file found
+            .mockResolvedValueOnce(undefined) // Subsequent calls return undefined
+            .mockResolvedValueOnce(undefined)
+            .mockResolvedValueOnce(undefined);
+
+        const result = await resolveRulesetPath();
+
+        expect(result).toBe(foundPath);
+        expect(mockFindUp).toHaveBeenCalledWith('.spectral.yaml');
+        expect(mockFindUp).toHaveBeenCalledTimes(1);
+    });
+
+    it('should try all ruleset files in order when searching locally', async () => {
+        const foundPath = '/project/.spectral.json';
+        mockFindUp
+            .mockResolvedValueOnce(undefined) // .spectral.yaml not found
+            .mockResolvedValueOnce(undefined) // .spectral.yml not found
+            .mockResolvedValueOnce(foundPath)  // .spectral.json found
+            .mockResolvedValueOnce(undefined); // .spectral.js not called
+
+        const result = await resolveRulesetPath();
+
+        expect(result).toBe(foundPath);
+        expect(mockFindUp).toHaveBeenCalledWith('.spectral.yaml');
+        expect(mockFindUp).toHaveBeenCalledWith('.spectral.yml');
+        expect(mockFindUp).toHaveBeenCalledWith('.spectral.json');
+        expect(mockFindUp).toHaveBeenCalledTimes(3);
+    });
+
+    it('should return null when no local ruleset files are found', async () => {
+        mockFindUp.mockResolvedValue(undefined);
+
+        const result = await resolveRulesetPath();
+
+        expect(result).toBeNull();
+        expect(mockFindUp).toHaveBeenCalledTimes(4); // All 4 files checked
+        expect(mockFindUp).toHaveBeenCalledWith('.spectral.yaml');
+        expect(mockFindUp).toHaveBeenCalledWith('.spectral.yml');
+        expect(mockFindUp).toHaveBeenCalledWith('.spectral.json');
+        expect(mockFindUp).toHaveBeenCalledWith('.spectral.js');
+    });
+
+    it('should handle empty string as rulesetOption', async () => {
+        const foundPath = '/project/.spectral.yaml';
+        mockFindUp.mockResolvedValueOnce(foundPath);
+
+        const result = await resolveRulesetPath('');
+
+        expect(result).toBe(foundPath);
+        expect(mockFindUp).toHaveBeenCalledWith('.spectral.yaml');
+    });
+});

--- a/packages/concerto-linter/test/unit/formatResults.test.ts
+++ b/packages/concerto-linter/test/unit/formatResults.test.ts
@@ -1,0 +1,149 @@
+// tests/unit/index.test.ts
+import { jest } from '@jest/globals';
+import { lintModel } from '../../src/index';
+import * as configLoader from '../../src/config-loader';
+
+// Only mock our own functions when needed
+jest.mock('../../src/config-loader');
+
+const mockedConfigLoader = configLoader as jest.Mocked<typeof configLoader>;
+
+
+describe('formatResults', () => {
+    test('should format spectral results correctly', async () => {
+    // Create a model that will likely trigger some linting results
+        const modelWithIssues = `
+      namespace com.example
+      
+      concept class {  // 'class' is a reserved keyword
+        o String value
+      }
+    `;
+
+        mockedConfigLoader.resolveRulesetPath.mockResolvedValue(null);
+
+        const results = await lintModel(modelWithIssues, {
+            ruleset: 'default',
+            excludeNamespaces: [] // Don't exclude anything to see all results
+        });
+
+        if (results.length > 0) {
+            const result = results[0];
+            expect(result).toHaveProperty('code');
+            expect(result).toHaveProperty('message');
+            expect(result).toHaveProperty('severity');
+            expect(result).toHaveProperty('path');
+            expect(result).toHaveProperty('namespace');
+            expect(typeof result.code).toBe('string');
+            expect(typeof result.message).toBe('string');
+            expect(['error', 'warning', 'info', 'hint']).toContain(result.severity);
+            expect(Array.isArray(result.path)).toBe(true);
+            expect(typeof result.namespace).toBe('string');
+        }
+    });
+
+    test('should exclude specified namespaces', async () => {
+        const modelWithMultipleNamespaces = `
+      namespace concerto.test
+      
+      concept TestConcept {
+        o String value
+      }
+    `;
+
+        mockedConfigLoader.resolveRulesetPath.mockResolvedValue(null);
+
+        const results = await lintModel(modelWithMultipleNamespaces, {
+            ruleset: 'default',
+            excludeNamespaces: ['concerto.*']
+        });
+
+        // All results should be filtered out due to namespace exclusion
+        results.forEach(result => {
+            expect(result.namespace).not.toMatch(/^concerto\./);
+        });
+    });
+
+    test('should handle wildcard exclusion patterns', async () => {
+        const model = `
+      namespace org.accordproject.test
+      
+      concept TestConcept {
+        o String value
+      }
+    `;
+
+        mockedConfigLoader.resolveRulesetPath.mockResolvedValue(null);
+
+        const results = await lintModel(model, {
+            ruleset: 'default',
+            excludeNamespaces: ['org.accordproject.*']
+        });
+
+        results.forEach(result => {
+            expect(result.namespace).not.toMatch(/^org\.accordproject\./);
+        });
+    });
+
+    test('should handle exact namespace exclusion', async () => {
+        const model = `
+      namespace exact.match
+      
+      concept TestConcept {
+        o String value
+      }
+    `;
+
+        mockedConfigLoader.resolveRulesetPath.mockResolvedValue(null);
+
+        const results = await lintModel(model, {
+            ruleset: 'default',
+            excludeNamespaces: ['exact.match']
+        });
+
+        results.forEach(result => {
+            expect(result.namespace).not.toBe('exact.match');
+        });
+    });
+
+    test('should handle string exclusion pattern', async () => {
+        const model = `
+      namespace test.namespace
+      
+      concept TestConcept {
+        o String value
+      }
+    `;
+
+        mockedConfigLoader.resolveRulesetPath.mockResolvedValue(null);
+
+        const results = await lintModel(model, {
+            ruleset: 'default',
+            excludeNamespaces: 'test.*'
+        });
+
+        results.forEach(result => {
+            expect(result.namespace).not.toMatch(/^test\./);
+        });
+    });
+
+    test('should use default exclusion patterns when none specified', async () => {
+        const concertoModel = `
+      namespace concerto.test
+      
+      concept TestConcept {
+        o String value
+      }
+    `;
+
+        mockedConfigLoader.resolveRulesetPath.mockResolvedValue(null);
+
+        const results = await lintModel(concertoModel, { ruleset: 'default' });
+
+        // Default exclusions should filter out concerto.* namespaces
+        results.forEach(result => {
+            expect(result.namespace).not.toMatch(/^concerto\./);
+            expect(result.namespace).not.toMatch(/^org\.accordproject\./);
+        });
+    });
+});

--- a/packages/concerto-linter/test/unit/lintModel.test.ts
+++ b/packages/concerto-linter/test/unit/lintModel.test.ts
@@ -1,0 +1,84 @@
+// tests/unit/index.test.ts
+import { jest } from '@jest/globals';
+import { lintModel } from '../../src/index';
+import * as configLoader from '../../src/config-loader';
+
+// Only mock our own functions when needed
+jest.mock('../../src/config-loader');
+
+const mockedConfigLoader = configLoader as jest.Mocked<typeof configLoader>;
+
+describe('lintModel', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    test('should lint a valid model successfully', async () => {
+        const validModel = `
+      namespace com.example
+      
+      concept Person {
+        o String firstName
+        o String lastName
+        o Integer age
+      }
+    `;
+
+        mockedConfigLoader.resolveRulesetPath.mockResolvedValue(null);
+
+        const result = await lintModel(validModel, { ruleset: 'default' });
+
+        expect(Array.isArray(result)).toBe(true);
+    // A valid model might still have some warnings, but shouldn't throw errors
+    });
+
+    test('should detect violations in problematic model', async () => {
+        const problematicModel = `
+      namespace com.example
+      
+      concept class {  // Reserved keyword as concept name
+        o String private  // Reserved keyword as property name
+      }
+    `;
+
+        mockedConfigLoader.resolveRulesetPath.mockResolvedValue(null);
+
+        const results = await lintModel(problematicModel, {
+            ruleset: 'default',
+            excludeNamespaces: []
+        });
+
+        // Should detect at least some violations
+        expect(Array.isArray(results)).toBe(true);
+    });
+
+    test('should handle malformed model', async () => {
+        const malformedModel = 'namespace invalid syntax }}}';
+
+        mockedConfigLoader.resolveRulesetPath.mockResolvedValue(null);
+
+        await expect(lintModel(malformedModel)).rejects.toThrow('Linting process failed');
+    });
+
+    test('should work with all configuration options', async () => {
+        const model = `
+      namespace com.example.test
+      
+      concept ValidConcept {
+        o String validProperty
+      }
+    `;
+
+        mockedConfigLoader.resolveRulesetPath.mockResolvedValue(null);
+
+        const config = {
+            ruleset: 'default',
+            excludeNamespaces: ['concerto.*', 'org.accordproject.*']
+        };
+
+        const results = await lintModel(model, config);
+
+        expect(Array.isArray(results)).toBe(true);
+    });
+
+});

--- a/packages/concerto-linter/test/unit/loadRuleset.test.ts
+++ b/packages/concerto-linter/test/unit/loadRuleset.test.ts
@@ -1,0 +1,64 @@
+import { jest } from '@jest/globals';
+import { lintModel } from '../../src/index';
+import * as configLoader from '../../src/config-loader';
+
+jest.mock('../../src/config-loader');
+
+const mockedConfigLoader = configLoader as jest.Mocked<typeof configLoader>;
+
+describe('loadRuleset', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    test('should use default ruleset when "default" is specified', async () => {
+        mockedConfigLoader.resolveRulesetPath.mockResolvedValue(null);
+
+        const validModel = `
+      namespace com.example
+      concept Test {
+        o String value
+      }
+    `;
+
+        const result = await lintModel(validModel, { ruleset: 'default' });
+        expect(Array.isArray(result)).toBe(true);
+        expect(mockedConfigLoader.resolveRulesetPath).not.toHaveBeenCalled();
+    });
+
+    test('should handle custom ruleset path', async () => {
+        const customRulesetPath = '/path/to/custom/ruleset.yaml';
+        mockedConfigLoader.resolveRulesetPath.mockResolvedValue(customRulesetPath);
+
+        const validModel = `
+      namespace com.example
+      concept Test {
+        o String value
+      }
+    `;
+
+        // This will fail in actual execution due to non-existent file,
+        // but we can test that the path resolution is called correctly
+        try {
+            await lintModel(validModel, { ruleset: customRulesetPath });
+        } catch {
+            // Expected to fail since file doesn't exist
+            expect(mockedConfigLoader.resolveRulesetPath).toHaveBeenCalledWith(customRulesetPath);
+        }
+    });
+
+    test('should handle undefined ruleset (use auto-discovery)', async () => {
+        mockedConfigLoader.resolveRulesetPath.mockResolvedValue(null);
+
+        const validModel = `
+      namespace com.example
+      concept Test {
+        o String value
+      }
+    `;
+
+        const result = await lintModel(validModel);
+        expect(Array.isArray(result)).toBe(true);
+        expect(mockedConfigLoader.resolveRulesetPath).toHaveBeenCalledWith(undefined);
+    });
+});


### PR DESCRIPTION
<!--- Provide a formatted commit message describing this PR in the Title above -->

<!--- See our DEVELOPERS guide below: -->

<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->

# Closes #1050

<!--- Provide an overall summary of the pull request -->

## Description

At this PR:

* The refactor of the linter output to follow the JSON format that was suggested at #1050.
* Enable the filtering for the results of the linter by namespace to control it; by default the exclusion list will be \[`concerto.*`, `org.accordproject.*`] and it will be configurable.

This was achieved by editing the `lintModel` parameters to receive an option object where you can pass the `excludeNamespaces` if you want to override the default one.

```ts
/**
 * Lints Concerto models using Spectral and Concerto rules.
 *
 * @param {string | object} model - The Concerto model to lint, either as a CTO string or a parsed AST object.
 * @param {options} [config] - Linting configuration options.
 * @param {string} [config.ruleset] - Path to a custom Spectral ruleset or 'default' to use the built-in ruleset.
 * @param {string | string[]} [config.excludeNamespaces] - One or more namespaces to exclude from linting results. Defaults to excluding 'concerto.*' and 'org.accord.*'.
 * @returns {Promise<lintResult[]>} Promise resolving to an array of formatted linting results as an JSON object.
 * @throws {Error} Throws if linting or model conversion fails.
 */
export async function lintModel(model: string | object, config?: options): Promise<lintResult[]> {
    // implementation
}
```

Additionally, I implemented unit tests covering all exported functions in the concerto-linter module to ensure behaviour, edge cases and the new namespace filtering logic are exercised.

### Changes

<!--- More detailed and granular description of changes -->

<!--- These should likely be gathered from commit message summaries -->

* Refactor linter output format to the JSON structure requested in #1050 
* Add configurable `excludeNamespaces` option to `lintModel` and default to excluding `concerto.*` and `org.accordproject.*`.
* Update internal linter model signature to accept an options object (previously positional params).
* Implement namespace-based filtering logic during result formatting.
* Add/Update unit tests: implemented unit tests for all functions in the concerto-linter (covering filtering, formatting and rule behaviour).


### Author Checklist

* [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
* [x] Vital features and changes captured in unit and/or integration tests.
* [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
* [x] Merging to `main` from `Ahmed-Gaper/i1050/linter-output-namespace-filter`.
