### PR TITLE
docs(linter): update READMEs and add unit tests for all rules

### DIFF
--- a/packages/concerto-linter/README.md
+++ b/packages/concerto-linter/README.md
@@ -1,24 +1,62 @@
-# lintModel Function
+# concerto linter
 
-The lintModel function provides a robust and efficient solution for linting Concerto models using Spectral. It ensures your models adhere to predefined or custom rulesets, promoting consistency, quality, and maintainability in your codebase.
+The linter provide the lintModel function which provides a robust and efficient solution for linting Concerto models using Spectral. It ensures your models adhere to predefined or custom rulesets, promoting consistency, quality, and maintainability in your codebase.
 
+## Table of contents
+- [concerto linter](#concerto-linter)
+  - [Table of contents](#table-of-contents)
+  - [Features](#features)
+    - [Model Input](#model-input)
+    - [Ruleset Discovery](#ruleset-discovery)
+    - [Ruleset Flexibility](#ruleset-flexibility)
+    - [Namespace Filtering](#namespace-filtering)
+    - [JSON Output](#json-output)
+  - [Getting Started](#getting-started)
+  - [Installation](#installation)
+    - [Providing the concerto Model](#providing-the-concerto-model)
+      - [As a CTO String](#as-a-cto-string)
+      - [As a Parsed AST Object](#as-a-parsed-ast-object)
+  - [Ruleset Configuration](#ruleset-configuration)
+    - [Default Ruleset](#default-ruleset)
+    - [Custom Rulesets](#custom-rulesets)
+    - [Automatic Ruleset Discovery](#automatic-ruleset-discovery)
+    - [Creating Custom Rulesets](#creating-custom-rulesets)
+  - [The linter output](#the-linter-output)
+    - [Namespace Filtering](#namespace-filtering-1)
+  - [License](#license)
+
+<!-- tocstop -->
 ## Features
 
-- **Versatile Model Input**: Supports Concerto models provided as either a CTO string or a parsed Abstract Syntax Tree (AST) object.
+### Model Input
+
+- **Versatile Model Input**: Supports concerto models provided as either a CTO string or a parsed Abstract Syntax Tree (AST) object.
+
+### Ruleset Discovery
 
 - **Automatic Ruleset Discovery**: Automatically detects Spectral ruleset files (e.g., .spectral.yaml, .spectral.yml, .spectral.json, .spectral.js) in the current or parent directories when no explicit ruleset is specified.
 
+### Ruleset Flexibility
+
 - **Custom Ruleset Flexibility**: Enables the use of a custom Spectral ruleset by allowing you to specify its file path for tailored linting rules.
 
-## How to Use
+### Namespace Filtering
 
-### Installation
+- **Namespace Filtering**: Filters linting results by namespace, with configurable exclusion patterns. By default, excludes `'concerto.*'` and `'org.accordproject.*'` namespaces.
+
+### JSON Output
+
+- **Structured JSON Output**: Returns linting results in a consistent JSON format for easier integration with other tools and workflows.
+
+## Getting Started
+The linter is highly customizable. By default, it will lint any Concerto model using the @accordproject/concerto-linter-default-ruleset, but you can also extend it or create your own custom ruleset.
+
+## Installation
 Install the package via npm:
 ```bash
 npm install @accordproject/concerto-linter
 ```
-
-### Providing the Concerto Model
+### Providing the concerto Model
 The lintModel function accepts your Concerto model in one of two formats:
 
 #### As a CTO String
@@ -45,42 +83,125 @@ asset MyProduct {
 modelManager.addCTOModel(model);
 const ast = modelManager.getAst();
 ```
+## Ruleset Configuration
 
-### Linting with Automatic Ruleset Discovery
-To lint your model using the default behavior, simply call lintModel without specifying a ruleset path. It will search for ruleset files in the following order: `.spectral.yaml`, `.spectral.yml`, `.spectral.json`, or `.spectral.js` If none are found, it defaults to the @accordproject/concerto-linter-default-ruleset.
+The concerto Linter provides flexible `ruleset` configuration options to suit your project needs.
+
+### Default Ruleset
+
+By default, the linter uses `@accordproject/concerto-linter-default-ruleset`, which provides a comprehensive set of rules for concerto models. This ruleset is automatically applied when no custom ruleset is specified.
+
+### Custom Rulesets
+
+You can customize the linting rules in several ways:
+
+1. **Create a ruleset file** in your project directory using any of these supported formats:
+   - `.spectral.yaml`
+   - `.spectral.yml`
+   - `.spectral.json`
+   - `.spectral.js`
+
+2. **Specify a ruleset path** explicitly when calling the linter:
+   ```javascript
+   const results = await lintModel(ast, {ruleset: 'path/to/your/custom-ruleset.yaml'});
+   ```
+
+3. **Force the default ruleset** 
+   ```javascript
+   const results = await lintModel(ast, {ruleset: 'default'});
+   ```
+
+### Automatic Ruleset Discovery
+
+When you call `lintModel` without specifying a ruleset, the linter will automatically search for ruleset files in the following order:
+
+1. `.spectral.yaml`
+2. `.spectral.yml`
+3. `.spectral.json`
+4. `.spectral.js`
+
+If you want to **force** the linter to use the built-in default ruleset even when custom ruleset files are present in the project, pass `ruleset: 'default'` in the options:
+
 ```javascript
 import { lintModel } from '@accordproject/concerto-linter';
 
-const results = lintModel(ast); // Pass the AST object
+const results = await lintModel(ast, { ruleset: 'default' });
+```
+If none of these files are found in the current or parent directories, the linter will fall back to using the default ruleset (`@accordproject/concerto-linter-default-ruleset`).
+
+```javascript
+import { lintModel } from '@accordproject/concerto-linter';
+
+// The linter will automatically detect ruleset files in your project
+const results = await lintModel(ast); // Pass the AST object
 // OR
-const results = lintModel(model); // Pass the CTO string directly
+const results = await lintModel(model); // Pass the CTO string directly
 ```
 
-### Linting with a Custom Ruleset
+### Creating Custom Rulesets
 
-First, you will have to create your own custom ruleset. For guidance on how to create them, follow this -> [link to the README of default-ruleset](../concerto-linter-default-ruleset/README.md).
+You can create your own custom ruleset to enforce specific rules for your Concerto models. For detailed guidance on creating custom rulesets, refer to the [default-ruleset documentation](./default-ruleset/README.md).
 
-After that, our linter will be able to detect if there are any `.spectral.yaml`, `.spectral.yml`, `.spectral.json`, or `.spectral.js` files and pick them up automatically. You can also pass the path for this ruleset file directly to the lint function if you want to specify a particular one.
+Custom rulesets follow the Spectral ruleset format and can be created in YAML, JSON, or JavaScript. Once created, the linter will automatically detect your ruleset file if it uses one of the standard names, or you can explicitly specify its path as shown in the examples above.
 
-**Example with automatic detection:**
+## The linter output
+
+The lintModel function returns a Promise that resolves to an array of linting results in JSON format:
+
+Each lint issue is represented as a flat JSON object:
+
+```ts
+interface ILintResult {
+  /** Unique rule identifier (e.g. 'no-unused-concept') */
+  code: string;
+
+  /** Human-readable description of the violation */
+  message: string;
+
+  /** Severity level ('error' | 'warning' | 'info' | 'hint') */
+  severity: string;
+
+  /**
+   * JSONPath-style pointer as an array of keys/indices
+   * (e.g. ['declarations', 3])
+   */
+  path: Array<string | number>;
+
+  /** Namespace where the violation occurred (e.g. 'org.accordproject') */
+  namespace: string;
+
+}
+```
+Example Output :
+
+```json
+[
+  {
+    "code": "camel-case-properties",
+    "message": "Property 'FirstVal' should be camelCase (e.g. 'myProperty').",
+    "severity": "warning",
+    "path": ["declarations", 3],
+    "namespace": "org.example.model",
+    "source": "concerto-lintr"
+  }
+```
+
+### Namespace Filtering
+
+By default, results from namespaces matching `'concerto.*'` and `'org.accordproject.*'` are excluded from the output. You can customize this behavior using the `excludeNamespaces` option.
+
 ```javascript
-// The linter will automatically find and use ruleset files in your project
-const results = lintModel(ast);
+// Override default namespace exclusions
+const results = await lintModel(ast, { 
+  excludeNamespaces: ['org.example.*', 'com.acme.*'] 
+});
+
+// Combine custom ruleset and namespace filtering
+const results = await lintModel(ast, {
+  ruleset: "D:\\linter-test\\my-ruleset.yaml",
+  excludeNamespaces: ['org.example.*']
+});
 ```
-
-**Example with explicit path:**
-```javascript
-// Specify a custom ruleset file path
-const results = lintModel(ast, "D:\\linter-test\\my-ruleset.yaml");
-```
-
-## Resolution Priority
-
-1. **Explicit Path**: Custom ruleset file specified as parameter
-2. **Project Detection**: Automatic discovery in current and parent directories
-3. **Default Fallback**: `@accordproject/concerto-linter-default-ruleset`
-
-
 ## License
 
 Accord Project source code files are made available under the Apache License, Version 2.0 (Apache-2.0), located in the LICENSE file. Accord Project documentation files are made available under the Creative Commons Attribution 4.0 International License (CC-BY-4.0).

--- a/packages/concerto-linter/default-ruleset/README.md
+++ b/packages/concerto-linter/default-ruleset/README.md
@@ -1,6 +1,79 @@
 # Concerto Linter Default Ruleset
 
-This sub-package is part of the `@accordproject/concerto-linter` package. Read the [concerto-linter README](../README.md) if you want to know how to use this ruleset with Concerto models.
+A comprehensive set of linting rules designed to validate concerto models against industry best practices and consistent naming conventions. This default ruleset helps maintain high-quality, readable, and maintainable concerto models across your projects. It is fully configurable - you can extend it, add new rules, disable existing ones, or create an entirely new ruleset without extending this one.
+
+This sub-package is part of the `@accordproject/concerto-linter` package. Read the [concerto-linter README](https://github.com/accordproject/concerto/tree/main/packages/concerto-linter) if you want to know how to use this ruleset with concerto models.
+
+## Table of Contents
+
+- [Concerto Linter Default Ruleset](#concerto-linter-default-ruleset)
+  - [Table of Contents](#table-of-contents)
+  - [Key Benefits](#key-benefits)
+  - [Available Rules](#available-rules)
+  - [Installation](#installation)
+  - [Usage](#usage)
+  - [Customization](#customization)
+    - [Extending the Default Ruleset](#extending-the-default-ruleset)
+    - [Disabling Specific Rules](#disabling-specific-rules)
+      - [Available Rule IDs](#available-rule-ids)
+    - [Enabling Specific Rules](#enabling-specific-rules)
+    - [Adjusting Rule Severity](#adjusting-rule-severity)
+  - [Creating Custom Rules](#creating-custom-rules)
+  - [License](#license)
+
+## Key Benefits
+
+- **Consistent Code Style**: Enforce uniform naming conventions across your concerto models
+- **Error Prevention**: Catch common modeling mistakes before they cause issues
+- **Best Practices**: Apply industry-standard modeling practices automatically
+- **Customizable**: Easily extend or modify rules to match your project's specific needs
+- **Integration Ready**: Works seamlessly with the concerto Linter and your development workflow
+
+## Available Rules
+
+The following table provides an overview of the available linting rules in the default ruleset:
+
+<table>
+<tr>
+<th>Rule Id</th><th>Description</th>
+</tr>
+<tr>
+<td><a href="#namespace-version">namespace-version</a></td>
+<td>Ensures that the namespace declaration in the model includes a version number. This rule enforces semantic versioning in namespaces, promoting clarity and compatibility management.</td>
+</tr>
+<tr>
+<td><a href="#no-reserved-keywords">no-reserved-keywords</a></td>
+<td>Enforces that names used for declarations, properties, and decorators in concerto models do not use reserved keywords. Reserved keywords are language-specific terms that may cause conflicts or unexpected behavior if used as identifiers.</td>
+</tr>
+<tr>
+<td><a href="#pascal-case-declarations">pascal-case-declarations</a></td>
+<td>Ensures that declaration names (scalar, enum, concept, asset, participant, transaction, event) follow PascalCase naming convention (e.g., 'MyDeclaration'). This promotes consistency and readability across model declarations.</td>
+</tr>
+<tr>
+<td><a href="#camel-case-properties">camel-case-properties</a></td>
+<td>Ensures that properties of type String, Double, Integer, Long, DateTime, and Boolean are named using camelCase. This promotes consistency and readability in property naming conventions across the model.</td>
+</tr>
+<tr>
+<td><a href="#upper-snake-case-enum-constants">upper-snake-case-enum-constants</a></td>
+<td>Enforces that all enum constant names follow the UPPER_SNAKE_CASE convention. This rule checks each enum property name and reports an error if it does not match the required pattern. Ensures consistency and readability in enum naming across the model.</td>
+</tr>
+<tr>
+<td><a href="#pascal-case-decorators">pascal-case-decorators</a></td>
+<td>Ensures that decorator names follow PascalCase naming convention (e.g., 'MyDecorator'). This promotes consistency and readability across model decorators.</td>
+</tr>
+<tr>
+<td><a href="#string-length-validator">string-length-validator</a></td>
+<td>Ensures that all string properties within the data model have a length validator applied, which helps prevent inconsistent data length and ensure proper storage.</td>
+</tr>
+<tr>
+<td><a href="#no-empty-declarations">no-empty-declarations</a></td>
+<td>Detects and reports any model declarations that are empty. This rule helps maintain model integrity by ensuring that all declarations contain meaningful content, preventing the inclusion of unused or placeholder declarations in the model.</td>
+</tr>
+<tr>
+<td><a href="#abstract-must-subclassed">abstract-must-subclassed</a></td>
+<td>Ensures that every abstract declaration in the model has at least one concrete subclass. This helps prevent unused or orphaned abstract types, enforcing better model design.</td>
+</tr>
+</table> 
 
 ## Installation
 
@@ -11,6 +84,28 @@ npm install --save-dev @accordproject/concerto-linter-default-ruleset
 ```
 
 ## Usage
+
+Once installed, the default ruleset is automatically used by the concerto Linter when no custom ruleset is specified:
+
+```javascript
+import { lintModel } from '@accordproject/concerto-linter';
+
+// The default ruleset will be used automatically
+const results = await lintModel(modelText);
+console.log(results);
+```
+
+To explicitly specify the default ruleset:
+
+```javascript
+const results = await lintModel(modelText, { ruleset: 'default' });
+```
+
+## Customization
+
+To create your own ruleset that fits your project needs, you can either extend the default ruleset, or create an entirely new ruleset from scratch.
+
+Your ruleset should be defined in one of these file formats: `.spectral.yaml`, `.spectral.yml`, `.spectral.json`, or `.spectral.js`. The concerto Linter will automatically detect and use these files, or you can specify a custom path using the `ruleset` property: `ruleset: "./path/to/my-ruleset.yaml"`. 
 
 ### Extending the Default Ruleset
 
@@ -42,14 +137,31 @@ module.exports = {
 
 ### Disabling Specific Rules
 
-You can disable specific rules by setting them to `'off'`:
+You can disable specific rules that don't match your project's requirements by setting them to `'off'`. The rule identifiers are defined in the `ruleset-main.ts` file located at `concerto/packages/concerto-linter/default-ruleset/src`.
+
+#### Available Rule IDs
+
+Here are all the rule IDs that can be disabled:
+
+| Rule ID | Description |
+|---------|-------------|
+| `namespace-version` | Ensures namespaces include version numbers |
+| `no-reserved-keywords` | Prevents use of reserved keywords |
+| `pascal-case-declarations` | Enforces PascalCase for declarations |
+| `camel-case-properties` | Enforces camelCase for properties |
+| `upper-snake-case-enum-constants` | Enforces UPPER_SNAKE_CASE for enum constants |
+| `pascal-case-decorators` | Enforces PascalCase for decorators |
+| `string-length-validator` | Requires string length validators |
+| `no-empty-declarations` | Prevents empty declarations |
+| `abstract-must-subclassed` | Ensures abstract classes have concrete subclasses |
+
 
 **YAML (.spectral.yaml)**
 ```yaml
 extends: '@accordproject/concerto-linter-default-ruleset'
 rules:
-  camel-case-declarations: 'off'
-  pascal-case-properties: 'off'
+  pascal-case-declarations: 'off'
+  camel-case-properties: 'off'
 ```
 
 ---
@@ -59,13 +171,11 @@ rules:
 {
   "extends": "@accordproject/concerto-linter-default-ruleset",
   "rules": {
-    "camel-case-declarations": "off",
-    "pascal-case-properties": "off"
+    "pascal-case-declarations": "off",
+    "camel-case-properties": "off"
   }
 }
 ```
-
----
 
 **JavaScript (.spectral.js)**
 ```javascript
@@ -73,17 +183,117 @@ const rules = require('@accordproject/concerto-linter-default-ruleset');
 module.exports = {
   extends: rules,
   rules: {
-    'camel-case-declarations': 'off',
-    'pascal-case-properties': 'off'
+    'pascal-case-declarations': off,
+    'namespace-version': off
+  }
+};
+```
+### Enabling Specific Rules
+
+You can selectively start with everything off and enable only specific rules:
+
+**YAML (.spectral.yaml)**
+```yaml
+extends: [['@accordproject/concerto-linter-default-ruleset', 'off']]
+rules:
+  pascal-case-declarations: true
+  namespace-version: true
+```
+
+**JSON (.spectral.json)**
+```json
+{
+  "extends": [["@accordproject/concerto-linter-default-ruleset", "off"]],
+  "rules": {
+    "pascal-case-declarations": true,
+    "namespace-version": true
+  }
+}
+```
+
+**JavaScript (.spectral.js)**
+```javascript
+const rules = require('@accordproject/concerto-linter-default-ruleset');
+module.exports = {
+  extends: [[rules, 'off']],
+  rules: {
+    'pascal-case-declarations': true,
+    'namespace-version': true
+  }
+};
+```
+---
+### Adjusting Rule Severity
+
+You can customize the severity level of each rule to control how violations are reported.  
+- **0** = error (must be fixed)  
+- **1** = warn (should be addressed)  
+- **2** = info (useful information)  
+- **3** = hint (optional suggestion)  
+
+**YAML (.spectral.yaml)**
+```yaml
+extends: '@accordproject/concerto-linter-default-ruleset'
+rules:
+  pascal-case-declarations: 'warn'  # Change from error to warning
+  camel-case-properties: 'info'     # Change to informational
+```
+
+**JSON (.spectral.json)**
+```json
+{
+  "extends": "@accordproject/concerto-linter-default-ruleset",
+  "rules": {
+    "pascal-case-declarations": "warn",
+    "camel-case-properties": "info"
+  }
+}
+```
+
+**JavaScript (.spectral.js)**
+```javascript
+const rules = require('@accordproject/concerto-linter-default-ruleset');
+module.exports = {
+  extends: rules,
+  rules: {
+    'pascal-case-declarations': 'warn',
+    'camel-case-properties': 'info'
   }
 };
 ```
 
-## Available Rules
- In Progress - Implementing the default ruleset.
-
 ## Creating Custom Rules
- TO DO
+
+Whether you want to add new rules to the default ruleset or create an entirely new ruleset, you can follow the Spectral ruleset format. For comprehensive documentation, see the [Spectral ruleset documentation](https://meta.stoplight.io/docs/spectral/e5b9616d6d50c-rulesets).
+
+Here's a simple example of what a custom rule looks like:
+
+```yaml
+# description (optional): Explains what the ruleset is about.
+description: "Declaration names (scalar, enum, concept, asset, participant, transaction, event) should be PascalCase."
+
+# given (required): JSONPath expression that specifies where the rule applies.
+given: "$.models[*].declarations[*].name"
+
+# message (required): The error/warning message shown when the rule is violated.
+message: "Declaration '{{value}}' should be PascalCase (e.g. 'MyDeclaration')"
+
+# severity (optional): The level of violation.
+# 0 = error, 1 = warning, 2 = info, 3 = hint
+severity: 0
+
+# then (required): Defines what function to apply and how.
+then:
+  # function (required): The function that validates the rule.
+  function: casing
+
+  # functionOptions (optional): Extra options for the function.
+  functionOptions:
+    type: pascal
+```
+
+For more complex rules, you can create custom JavaScript functions following [Spectral ruleset documentation](https://meta.stoplight.io/docs/spectral/e5b9616d6d50c-rulesets) and import it into your rule, similar to how the built-in rules work.
+
 
 ## License
 

--- a/packages/concerto-linter/default-ruleset/test/fixtures/abstract-must-subclassed-invalid.cto
+++ b/packages/concerto-linter/default-ruleset/test/fixtures/abstract-must-subclassed-invalid.cto
@@ -1,0 +1,10 @@
+namespace org.example@1.0.0
+
+abstract concept Vehicle {
+  o String make
+  o String model
+}
+
+abstract asset Product {
+  o String productId
+}

--- a/packages/concerto-linter/default-ruleset/test/fixtures/abstract-must-subclassed-valid.cto
+++ b/packages/concerto-linter/default-ruleset/test/fixtures/abstract-must-subclassed-valid.cto
@@ -1,0 +1,18 @@
+namespace org.example@1.0.0
+
+abstract concept Vehicle {
+  o String make
+  o String model
+}
+
+concept Car extends Vehicle {
+  o Integer numberOfDoors
+}
+
+abstract asset Product {
+  o String productId
+}
+
+asset Electronics extends Product {
+  o String brand
+}

--- a/packages/concerto-linter/default-ruleset/test/fixtures/decorators-valid-PascalCase.cto
+++ b/packages/concerto-linter/default-ruleset/test/fixtures/decorators-valid-PascalCase.cto
@@ -1,0 +1,8 @@
+@Hide
+namespace com.example
+
+@Term
+concept Person {
+  @Security
+  o String ssn
+}

--- a/packages/concerto-linter/default-ruleset/test/fixtures/decorators-violate-PascalCase.cto
+++ b/packages/concerto-linter/default-ruleset/test/fixtures/decorators-violate-PascalCase.cto
@@ -1,0 +1,8 @@
+@hide
+namespace com.example
+
+@term
+concept Person {
+  @security
+  o String ssn
+}

--- a/packages/concerto-linter/default-ruleset/test/fixtures/namespace-invalid-version.cto
+++ b/packages/concerto-linter/default-ruleset/test/fixtures/namespace-invalid-version.cto
@@ -1,0 +1,5 @@
+namespace org.example
+
+concept Product {
+  o String name
+}

--- a/packages/concerto-linter/default-ruleset/test/fixtures/namespace-valid-version.cto
+++ b/packages/concerto-linter/default-ruleset/test/fixtures/namespace-valid-version.cto
@@ -1,0 +1,5 @@
+namespace org.example@1.0.0
+
+concept Product {
+  o String name
+}

--- a/packages/concerto-linter/default-ruleset/test/fixtures/no-empty-declarations-invalid.cto
+++ b/packages/concerto-linter/default-ruleset/test/fixtures/no-empty-declarations-invalid.cto
@@ -1,0 +1,10 @@
+namespace org.example@1.0.0
+
+concept EmptyConcept {
+}
+
+asset EmptyAsset {
+}
+
+enum EmptyEnum {
+}

--- a/packages/concerto-linter/default-ruleset/test/fixtures/no-empty-declarations-valid.cto
+++ b/packages/concerto-linter/default-ruleset/test/fixtures/no-empty-declarations-valid.cto
@@ -1,0 +1,16 @@
+namespace org.example@1.0.0
+
+concept Person {
+  o String firstName
+  o String lastName
+}
+
+asset Product {
+  o String productId
+  o Double price
+}
+
+enum Status {
+  o ACTIVE
+  o INACTIVE
+}

--- a/packages/concerto-linter/default-ruleset/test/fixtures/no-reserved-keywords-invalid.cto
+++ b/packages/concerto-linter/default-ruleset/test/fixtures/no-reserved-keywords-invalid.cto
@@ -1,0 +1,16 @@
+namespace org.example@1.0.0
+
+concept String {
+  o String string
+  o Double double
+}
+
+asset Asset {
+  o Integer integer
+  o Boolean boolean
+}
+
+enum DateTime {
+  o EVENT
+  o TRANSACTION
+}

--- a/packages/concerto-linter/default-ruleset/test/fixtures/no-reserved-keywords-valid.cto
+++ b/packages/concerto-linter/default-ruleset/test/fixtures/no-reserved-keywords-valid.cto
@@ -1,0 +1,16 @@
+namespace org.example@1.0.0
+
+concept ValidProduct {
+  o String productId
+  o Double price
+  o Integer quantity
+}
+
+asset ValidAsset {
+  o String assetId
+}
+
+enum ValidEnum {
+  o FIRST_VALUE
+  o SECOND_VALUE
+}

--- a/packages/concerto-linter/default-ruleset/test/fixtures/string-length-validator-invalid.cto
+++ b/packages/concerto-linter/default-ruleset/test/fixtures/string-length-validator-invalid.cto
@@ -1,0 +1,9 @@
+namespace org.example@1.0.0
+
+scalar Email extends String 
+
+concept Person {
+  o String firstName
+  o String lastName
+  o String email
+}

--- a/packages/concerto-linter/default-ruleset/test/fixtures/string-length-validator-valid.cto
+++ b/packages/concerto-linter/default-ruleset/test/fixtures/string-length-validator-valid.cto
@@ -1,0 +1,10 @@
+namespace org.example@1.0.0
+
+scalar Email extends String length=[5, 100]
+
+
+concept Person {
+  o String firstName length=[1, 50]
+  o String lastName length=[1, 50]
+  o String email length=[5, 100]
+}

--- a/packages/concerto-linter/default-ruleset/test/rules/abstract-must-subclassed.test.ts
+++ b/packages/concerto-linter/default-ruleset/test/rules/abstract-must-subclassed.test.ts
@@ -1,0 +1,33 @@
+import { testRules } from '../test-rule';
+import abstractMustSubclassed from '../../src/abstract-must-subclassed';
+
+describe('Abstract Must Be Subclassed Rule', () => {
+    test('should not report any violations when all abstract declarations have concrete subclasses', async () => {
+        const results = await testRules({
+            rules: {
+                'abstract-must-subclassed': abstractMustSubclassed,
+            }
+        }, 'abstract-must-subclassed-valid.cto');
+        expect(results).toHaveLength(0);
+    });
+
+    test('should report violations when abstract declarations have no concrete subclasses', async () => {
+        const results = await testRules({
+            rules: {
+                'abstract-must-subclassed': abstractMustSubclassed,
+            }
+        }, 'abstract-must-subclassed-invalid.cto');
+
+        // We expect multiple violations - one for each abstract declaration without concrete subclass
+        expect(results.length).toBeGreaterThan(0);
+
+        // Check that the rule code is correct
+        results.forEach(result => {
+            expect(result.code).toBe('abstract-must-subclassed');
+        });
+
+        // Check that the message contains the expected text
+        const messageText = results.map(r => r.message).join(' ');
+        expect(messageText).toContain('must have concrete subclasses');
+    });
+});

--- a/packages/concerto-linter/default-ruleset/test/rules/namespace-version.test.ts
+++ b/packages/concerto-linter/default-ruleset/test/rules/namespace-version.test.ts
@@ -1,0 +1,24 @@
+import { testRules } from '../test-rule';
+import namespaceVersion from '../../src/namespace-version';
+
+describe('Namespace Version Rule', () => {
+    test('should not report any violations for namespaces with valid version', async () => {
+        const results = await testRules({
+            rules: {
+                'namespace-version': namespaceVersion,
+            }
+        }, 'namespace-valid-version.cto');
+        expect(results).toHaveLength(0);
+    });
+
+    test('should report a violation for namespaces without version', async () => {
+        const results = await testRules({
+            rules: {
+                'namespace-version': namespaceVersion,
+            }
+        }, 'namespace-invalid-version.cto');
+        expect(results).toHaveLength(1);
+        expect(results[0].code).toBe('namespace-version');
+        expect(results[0].message).toContain('should specify a version');
+    });
+});

--- a/packages/concerto-linter/default-ruleset/test/rules/naming-ruleset.test.ts
+++ b/packages/concerto-linter/default-ruleset/test/rules/naming-ruleset.test.ts
@@ -2,9 +2,10 @@ import { testRules } from '../test-rule';
 import pascalCaseDeclarations from '../../src/pascal-case-declarations';
 import camelCaseProperties from '../../src/camel-case-properties';
 import upperSnakeCaseEnumConst from '../../src/upper-snake-case-enum-const';
+import pascalCaseDecorators from '../../src/pascal-case-decorators';
 
-describe ('Naming Convention Linting Rules' , () => {
-    test ('should not report any PascalCase naming violations for correctly named declarations', async () => {
+describe('PascalCase Declarations Rule', () => {
+    test('should not report any violations for correctly named declarations', async () => {
         const results = await testRules({
             rules: {
                 'pascal-case-declarations': pascalCaseDeclarations,
@@ -13,17 +14,30 @@ describe ('Naming Convention Linting Rules' , () => {
         expect(results).toHaveLength(0);
     });
 
-    test ('should report a PascalCase naming violation for an invalid declaration name', async ()=>
-    {
+    test('should report violations for invalid declaration names', async () => {
         const results = await testRules({
             rules: {
                 'pascal-case-declarations': pascalCaseDeclarations,
             }
         }, 'declarations-violate-PascalCase.cto');
-        expect(results).toHaveLength(7);
-    });
 
-    test ('should not report any camelCase naming violations for correctly named properties', async () => {
+        // Check that we have the expected number of violations
+        expect(results.length).toBeGreaterThan(0);
+        expect(results).toHaveLength(7);
+
+        // Check that the rule code is correct
+        results.forEach(result => {
+            expect(result.code).toBe('pascal-case-declarations');
+        });
+
+        // Check that the message contains the expected text
+        const messageText = results.map(r => r.message).join(' ');
+        expect(messageText).toContain('should be PascalCase');
+    });
+});
+
+describe('CamelCase Properties Rule', () => {
+    test('should not report any violations for correctly named properties', async () => {
         const results = await testRules({
             rules: {
                 'camel-case-properties': camelCaseProperties,
@@ -31,17 +45,31 @@ describe ('Naming Convention Linting Rules' , () => {
         }, 'properties-valid-camelCase.cto');
         expect(results).toHaveLength(0);
     });
-    test ('should report a camelCase naming violation for an invalid property name', async ()=>
-    {
+
+    test('should report violations for invalid property names', async () => {
         const results = await testRules({
             rules: {
                 'camel-case-properties': camelCaseProperties,
             }
         }, 'properties-violate-camelCase.cto');
-        expect(results).toHaveLength(6);
-    });
 
-    test ('should not report any UPPER_SNAKE_CASE naming violations for correctly named enum constants', async () => {
+        // Check that we have the expected number of violations
+        expect(results.length).toBeGreaterThan(0);
+        expect(results).toHaveLength(6);
+
+        // Check that the rule code is correct
+        results.forEach(result => {
+            expect(result.code).toBe('camel-case-properties');
+        });
+
+        // Check that the message contains the expected text
+        const messageText = results.map(r => r.message).join(' ');
+        expect(messageText).toContain('should be camelCase');
+    });
+});
+
+describe('UPPER_SNAKE_CASE Enum Constants Rule', () => {
+    test('should not report any violations for correctly named enum constants', async () => {
         const results = await testRules({
             rules: {
                 'upper-snake-case-enum-constants': upperSnakeCaseEnumConst,
@@ -50,13 +78,56 @@ describe ('Naming Convention Linting Rules' , () => {
         expect(results).toHaveLength(0);
     });
 
-    test ('should report a UPPER_SNAKE_CASE naming violation for an invalid enum constants', async ()=>
-    {
+    test('should report violations for invalid enum constant names', async () => {
         const results = await testRules({
             rules: {
                 'upper-snake-case-enum-constants': upperSnakeCaseEnumConst,
             }
         }, 'ENUM_Constans-invaild.cto');
+
+        // Check that we have the expected number of violations
+        expect(results.length).toBeGreaterThan(0);
         expect(results).toHaveLength(3);
+
+        // Check that the rule code is correct
+        results.forEach(result => {
+            expect(result.code).toBe('upper-snake-case-enum-constants');
+        });
+
+        // Check that the message contains the expected text
+        const messageText = results.map(r => r.message).join(' ');
+        expect(messageText).toContain('should be UPPER_SNAKE_CASE');
+    });
+});
+
+describe('PascalCase Decorators Rule', () => {
+    test('should not report any violations for correctly named decorators', async () => {
+        const results = await testRules({
+            rules: {
+                'pascal-case-decorators': pascalCaseDecorators,
+            }
+        }, 'decorators-valid-PascalCase.cto');
+        expect(results).toHaveLength(0);
+    });
+
+    test('should report violations for invalid decorator names', async () => {
+        const results = await testRules({
+            rules: {
+                'pascal-case-decorators': pascalCaseDecorators,
+            }
+        }, 'decorators-violate-PascalCase.cto');
+
+        // Check that we have the expected number of violations
+        expect(results.length).toBeGreaterThan(0);
+        expect(results).toHaveLength(3);
+
+        // Check that the rule code is correct
+        results.forEach(result => {
+            expect(result.code).toBe('pascal-case-decorators');
+        });
+
+        // Check that the message contains the expected text
+        const messageText = results.map(r => r.message).join(' ');
+        expect(messageText).toContain('should be PascalCase');
     });
 });

--- a/packages/concerto-linter/default-ruleset/test/rules/no-empty-declarations.test.ts
+++ b/packages/concerto-linter/default-ruleset/test/rules/no-empty-declarations.test.ts
@@ -1,0 +1,33 @@
+import { testRules } from '../test-rule';
+import noEmptyDeclarations from '../../src/no-empty-declarations';
+
+describe('No Empty Declarations Rule', () => {
+    test('should not report any violations when all declarations have properties', async () => {
+        const results = await testRules({
+            rules: {
+                'no-empty-declarations': noEmptyDeclarations,
+            }
+        }, 'no-empty-declarations-valid.cto');
+        expect(results).toHaveLength(0);
+    });
+
+    test('should report violations when declarations are empty', async () => {
+        const results = await testRules({
+            rules: {
+                'no-empty-declarations': noEmptyDeclarations,
+            }
+        }, 'no-empty-declarations-invalid.cto');
+
+        // We expect multiple violations - one for each empty declaration
+        expect(results.length).toBeGreaterThan(0);
+
+        // Check that the rule code is correct
+        results.forEach(result => {
+            expect(result.code).toBe('no-empty-declarations');
+        });
+
+        // Check that the message contains the expected text
+        const messageText = results.map(r => r.message).join(' ');
+        expect(messageText).toContain('should not be empty');
+    });
+});

--- a/packages/concerto-linter/default-ruleset/test/rules/no-reserved-keywords.test.ts
+++ b/packages/concerto-linter/default-ruleset/test/rules/no-reserved-keywords.test.ts
@@ -1,0 +1,33 @@
+import { testRules } from '../test-rule';
+import noReservedKeywords from '../../src/no-reserved-keywords';
+
+describe('No Reserved Keywords Rule', () => {
+    test('should not report any violations when no reserved keywords are used', async () => {
+        const results = await testRules({
+            rules: {
+                'no-reserved-keywords': noReservedKeywords,
+            }
+        }, 'no-reserved-keywords-valid.cto');
+        expect(results).toHaveLength(0);
+    });
+
+    test('should report violations when reserved keywords are used', async () => {
+        const results = await testRules({
+            rules: {
+                'no-reserved-keywords': noReservedKeywords,
+            }
+        }, 'no-reserved-keywords-invalid.cto');
+
+        // We expect multiple violations - for declaration names and property names
+        expect(results.length).toBeGreaterThan(0);
+
+        // Check that the rule code is correct
+        results.forEach(result => {
+            expect(result.code).toBe('no-reserved-keywords');
+        });
+
+        // Check that the message contains the expected text
+        const messageText = results.map(r => r.message).join(' ');
+        expect(messageText).toContain('is a reserved keyword');
+    });
+});

--- a/packages/concerto-linter/default-ruleset/test/rules/string-length-validator.test.ts
+++ b/packages/concerto-linter/default-ruleset/test/rules/string-length-validator.test.ts
@@ -1,0 +1,33 @@
+import { testRules } from '../test-rule';
+import stringLengthValidator from '../../src/string-length-validator';
+
+describe('String Length Validator Rule', () => {
+    test('should not report any violations when all strings have length validators', async () => {
+        const results = await testRules({
+            rules: {
+                'string-length-validator': stringLengthValidator,
+            }
+        }, 'string-length-validator-valid.cto');
+        expect(results).toHaveLength(0);
+    });
+
+    test('should report violations when strings are missing length validators', async () => {
+        const results = await testRules({
+            rules: {
+                'string-length-validator': stringLengthValidator,
+            }
+        }, 'string-length-validator-invalid.cto');
+
+        // We expect multiple violations - one for each string without a length validator
+        expect(results.length).toBeGreaterThan(0);
+
+        // Check that the rule code is correct
+        results.forEach(result => {
+            expect(result.code).toBe('string-length-validator');
+        });
+
+        // Check that the message contains the expected text
+        const messageText = results.map(r => r.message).join(' ');
+        expect(messageText).toContain('must have a length validator');
+    });
+});


### PR DESCRIPTION
## Description

This PR implements several significant enhancements to the Concerto Linter and its Default Ruleset:

1. **Comprehensive Documentation**:
   - Enhanced the `concerto-linter` README with clearer structure and improved examples
   - Completely revamped the `default-ruleset` README with detailed documentation on rule customization
   - Added detailed information about namespace filtering and JSON output format

2. **Complete Test Coverage**:
   - Implemented unit tests for all rules in the default ruleset:
   - Enhanced existing test files for naming convention rules
   - Ensured all tests follow a consistent pattern and style

3. **Rule Configuration Documentation**:
   - Added a comprehensive table of all available rule IDs
   - Documented severity levels and their meanings
   - Provided examples for enabling, disabling, and adjusting rule severity


### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [x] Extend the documentation, if necessary
- [x] Merging to `main` from `Ahmed-Gaper/readme-and-tests`
