### PR TITLE
refactor(linter): Update workflow for obtaining parsed AST of .cto model

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15516,9 +15516,8 @@
       "version": "3.24.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@accordproject/concerto-core": "3.24.0",
+        "@accordproject/concerto-cto": "3.24.0",
         "@accordproject/concerto-linter-default-ruleset": "3.24.0",
-        "@accordproject/concerto-metamodel": "3.12.4",
         "@stoplight/spectral-cli": "6.15.0",
         "@stoplight/spectral-core": "1.20.0",
         "@stoplight/spectral-parsers": "1.0.5",
@@ -15544,7 +15543,7 @@
       "version": "3.24.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@accordproject/concerto-core": "3.24.0",
+        "@accordproject/concerto-cto": "3.24.0",
         "@stoplight/spectral-core": "1.20.0",
         "@stoplight/spectral-functions": "1.10.1",
         "@stoplight/spectral-parsers": "1.0.5"

--- a/packages/concerto-linter/default-ruleset/package.json
+++ b/packages/concerto-linter/default-ruleset/package.json
@@ -33,7 +33,7 @@
   "author": "accordproject.org",
   "license": "Apache-2.0",
   "dependencies": {
-    "@accordproject/concerto-core": "3.24.0",
+    "@accordproject/concerto-cto": "3.24.0",
     "@stoplight/spectral-core": "1.20.0",
     "@stoplight/spectral-functions": "1.10.1",
     "@stoplight/spectral-parsers": "1.0.5"

--- a/packages/concerto-linter/default-ruleset/test/test-rule.ts
+++ b/packages/concerto-linter/default-ruleset/test/test-rule.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs/promises';
 import * as path from 'path';
-import { ModelManager } from '@accordproject/concerto-core';
+import { Parser } from '@accordproject/concerto-cto';
 import { Json as JsonParsers } from '@stoplight/spectral-parsers';
 import { Spectral, Document, IRuleResult, RulesetDefinition } from '@stoplight/spectral-core';
 
@@ -8,6 +8,7 @@ import { Spectral, Document, IRuleResult, RulesetDefinition } from '@stoplight/s
  * Tests the Concerto linter's default ruleset.
  * @param {RulesetDefinition} [ruleset] - Optional ruleset to apply for testing.
  * @param {string} modelFile - The model (CTO string) to be linted.
+ Note: No external dependency resolution is performed.
  * @returns {Promise<IRuleResult[]>} A promise that resolves to an array of linting results.
  * @throws {Error} If a critical processing failure occurs during linting.
  */
@@ -16,9 +17,7 @@ export async function testRules(ruleset: RulesetDefinition, modelFile: string): 
         const filePath = path.resolve(__dirname, './fixtures/', modelFile);
         const model = await fs.readFile(filePath, 'utf-8');
 
-        const manager = new ModelManager();
-        manager.addCTOModel(model);
-        const jsonAST = JSON.stringify(manager.getAst());
+        const jsonAST = JSON.stringify(Parser.parseModels([model]));
 
         const spectral = new Spectral();
         spectral.setRuleset(ruleset);

--- a/packages/concerto-linter/package.json
+++ b/packages/concerto-linter/package.json
@@ -32,9 +32,8 @@
   "author": "accordproject.org",
   "license": "Apache-2.0",
   "dependencies": {
-    "@accordproject/concerto-core": "3.24.0",
     "@accordproject/concerto-linter-default-ruleset": "3.24.0",
-    "@accordproject/concerto-metamodel": "3.12.4",
+    "@accordproject/concerto-cto": "3.24.0",
     "find-up": "5.0.0",
     "@stoplight/spectral-cli": "6.15.0",
     "@stoplight/spectral-core": "1.20.0",

--- a/packages/concerto-linter/src/index.ts
+++ b/packages/concerto-linter/src/index.ts
@@ -17,7 +17,7 @@ import { Json as JsonParsers } from '@stoplight/spectral-parsers';
 import { resolveRulesetPath } from './config-loader';
 import { getRuleset } from '@stoplight/spectral-cli/dist/services/linter/utils/getRuleset';
 import  concertoRuleset  from '@accordproject/concerto-linter-default-ruleset';
-import { ModelManager } from '@accordproject/concerto-core';
+import { Parser } from '@accordproject/concerto-cto';
 
 interface options {
     /** Path to a custom Spectral ruleset or 'default' to use the built-in ruleset */
@@ -57,9 +57,8 @@ interface lintResult {
 function convertToJsonAST(model: string | object): string {
     try {
         if (typeof model === 'string') {
-            const manager = new ModelManager();
-            manager.addCTOModel(model);
-            return JSON.stringify(manager.getAst());
+            const modelFile = Parser.parseModels([model]);
+            return JSON.stringify(modelFile);
         }
         return JSON.stringify(model);
     } catch (error) {
@@ -149,13 +148,12 @@ function formatResults(
 
 /**
  * Lints Concerto models using Spectral and Concerto rules.
- *
- * @param {string | object} model - The Concerto model to lint, either as a CTO string or a parsed AST object.
- * @param {options} [config] - Linting configuration options.
- * @param {string} [config.ruleset] - Path to a custom Spectral ruleset or 'default' to use the built-in ruleset.
- * @param {string | string[]} [config.excludeNamespaces] - One or more namespaces to exclude from linting results. Defaults to excluding 'concerto.*' and 'org.accord.*'.
- * @returns {Promise<lintResult[]>} Promise resolving to an array of formatted linting results as an JSON object.
- * @throws {Error} Throws if linting or model conversion fails.
+ * @param {string | object} model - The Concerto model to lint, either as a CTO string or a parsed AST object. Note: No external dependency resolution is performed.
+ * @param {options} [config] - Configuration options for customizing the linting process.
+ * @param {string} [config.ruleset] - Path to a custom Spectral ruleset file or 'default' to use the built-in ruleset.
+ * @param {string | string[]} [config.excludeNamespaces] - One or more namespaces to exclude from linting results (defaults to 'concerto.*' and 'org.accord.*').
+ * @returns {Promise<lintResult[]>} Promise resolving to an array of formatted linting results as a JSON object.
+ * @throws {Error} Throws an error if linting or model conversion fails.
  */
 export async function lintModel(model: string | object, config?: options): Promise<lintResult[]> {
     try {


### PR DESCRIPTION
## Description
This PR updates how the linter generates the JSON AST for a `.cto` model.  

## Changes
- Introduced `Parser.parseModels` as the primary method for parsing `.cto` file contents.  
- Removed dependency on `ModelLoader` when parsing models.  

## Rationale
Previously, the workflow attempted to add models to a `ModelManager` and get the JSON AST.  
This caused errors when external dependencies were missing.  
The updated workflow avoids hidden resolution steps and instead requires users to provide **all models** they want linted.

---


### Author Checklist
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [x] Merging to `main` from `Ahmed-Gaper/update-linter-parsing`
