### PR TITLE
fix(concerto-analysis): inheritance bug solved in /packages/concerto-analysis related to i/1067 raised

### DIFF
--- a/packages/concerto-analysis/src/compare.ts
+++ b/packages/concerto-analysis/src/compare.ts
@@ -130,7 +130,15 @@ export class Compare {
         if(a instanceof ScalarDeclaration || b instanceof ScalarDeclaration) {
             return;
         }
-        this.compareProperties(comparers, a.getOwnProperties(), b.getOwnProperties());
+        let propsA = a.getOwnProperties();
+        let propsB = b.getOwnProperties();
+        if (a.getProperties()) {
+            propsA = a.getProperties();
+        }
+        if (b.getProperties()) {
+            propsB = b.getProperties();
+        }
+        this.compareProperties(comparers, propsA, propsB);
     }
 
     private compareClassDeclarations(comparers: Comparer[], a: ClassDeclaration[], b: ClassDeclaration[]) {


### PR DESCRIPTION
<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes Issue#1067 
<!--- Provide an overall summary of the pull request -->

### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
- I have changed the _/packages/concerto-analysis/src/**compare.ts_ file** for parent-child property inheritance. Earlier there was **"a"** child's property being inherited, now only **"c"** child's property is inherited
- Key in findings(result) now displays an output -> _key: 'optional-property-added'_
- I tried adding no additional code, just used different properties of Compare class defined in **classdeclaration.js** file in _concerto-core_ directory, used **getProperties()** instead of **getOwnProperties()**
- Now we have **minor** result(1) instead of **major** result(3)

### Flags
<!--- Provide context or concerns a reviewer should be aware of -->
- You need to create a separate inheritance file to review the issue and check the result

### Code
```
{
  findings: [
    {
      key: 'optional-property-added',
      message: 'The optional field "cProperty" was added to the concept "Parent"',
      element: [Field],
      result: 1
    }
  ],
  result: 1
}
```

### Images
<img width="851" height="948" alt="image" src="https://github.com/user-attachments/assets/b6b37066-3b2b-449d-a00c-c1a0c0a9337c" />

### Results and Tests
- All tests passed in `npm run test`, more than 96% patching found.

### Related Issues
- Issue #1067 

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [x] Merging to `main` from `fork:branchname`
