### PR TITLE
chore(semver-ranges): validate that concerto linter does not flag semver range usage

### DIFF
--- a/packages/concerto-cto/lib/parser.js
+++ b/packages/concerto-cto/lib/parser.js
@@ -6262,6 +6262,124 @@ function peg$parse(input, options) {
     return s0;
   }
 
+  function peg$parsesemverMajorX() {
+    var s0, s1, s2, s3;
+
+    s0 = peg$currPos;
+    s1 = peg$parsenumericIdentifier();
+    if (s1 !== peg$FAILED) {
+      if (input.charCodeAt(peg$currPos) === 46) {
+        s2 = peg$c6;
+        peg$currPos++;
+      } else {
+        s2 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$e19); }
+      }
+      if (s2 !== peg$FAILED) {
+        if (input.charCodeAt(peg$currPos) === 120) {
+          s3 = peg$c18;
+          peg$currPos++;
+        } else {
+          s3 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$e40); }
+        }
+        if (s3 !== peg$FAILED) {
+          s1 = [s1, s2, s3];
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parsesemverMajorMinorX() {
+    var s0, s1, s2, s3, s4, s5;
+
+    s0 = peg$currPos;
+    s1 = peg$parsenumericIdentifier();
+    if (s1 !== peg$FAILED) {
+      if (input.charCodeAt(peg$currPos) === 46) {
+        s2 = peg$c6;
+        peg$currPos++;
+      } else {
+        s2 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$e19); }
+      }
+      if (s2 !== peg$FAILED) {
+        s3 = peg$parsenumericIdentifier();
+        if (s3 !== peg$FAILED) {
+          if (input.charCodeAt(peg$currPos) === 46) {
+            s4 = peg$c6;
+            peg$currPos++;
+          } else {
+            s4 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$e19); }
+          }
+          if (s4 !== peg$FAILED) {
+            if (input.charCodeAt(peg$currPos) === 120) {
+              s5 = peg$c18;
+              peg$currPos++;
+            } else {
+              s5 = peg$FAILED;
+              if (peg$silentFails === 0) { peg$fail(peg$e40); }
+            }
+            if (s5 !== peg$FAILED) {
+              s1 = [s1, s2, s3, s4, s5];
+              s0 = s1;
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parseversionSelector() {
+    var s0, s1;
+
+    s0 = peg$currPos;
+    s1 = peg$parsesemver();
+    if (s1 === peg$FAILED) {
+      s1 = peg$parsesemverMajorMinorX();
+      if (s1 === peg$FAILED) {
+        s1 = peg$parsesemverMajorX();
+      }
+    }
+    if (s1 !== peg$FAILED) {
+      s0 = input.substring(s0, peg$currPos);
+    } else {
+      s0 = s1;
+    }
+
+    return s0;
+  }
+
   function peg$parseversionCore() {
     var s0, s1, s2, s3, s4, s5, s6;
 
@@ -10099,13 +10217,7 @@ function peg$parse(input, options) {
         if (peg$silentFails === 0) { peg$fail(peg$e90); }
       }
       if (s2 !== peg$FAILED) {
-        s3 = peg$currPos;
-        s4 = peg$parsesemver();
-        if (s4 !== peg$FAILED) {
-          s3 = input.substring(s3, peg$currPos);
-        } else {
-          s3 = s4;
-        }
+        s3 = peg$parseversionSelector();
         if (s3 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 46) {
             s4 = peg$c6;
@@ -10150,7 +10262,7 @@ function peg$parse(input, options) {
   }
 
   function peg$parseVersionedQualifiedNamespace() {
-    var s0, s1, s2, s3, s4;
+    var s0, s1, s2, s3;
 
     s0 = peg$currPos;
     s1 = peg$parseQualifiedName();
@@ -10163,13 +10275,7 @@ function peg$parse(input, options) {
         if (peg$silentFails === 0) { peg$fail(peg$e90); }
       }
       if (s2 !== peg$FAILED) {
-        s3 = peg$currPos;
-        s4 = peg$parsesemver();
-        if (s4 !== peg$FAILED) {
-          s3 = input.substring(s3, peg$currPos);
-        } else {
-          s3 = s4;
-        }
+        s3 = peg$parseversionSelector();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
           s0 = peg$f103(s1, s3);

--- a/packages/concerto-cto/lib/parser.pegjs
+++ b/packages/concerto-cto/lib/parser.pegjs
@@ -746,6 +746,17 @@ semver
     return { versionCore, pre, build };
   }
 
+// Support limited semver range selectors for imports: 1.x or 1.1.x
+semverMajorX
+  = numericIdentifier '.' 'x'
+
+semverMajorMinorX
+  = numericIdentifier '.' numericIdentifier '.' 'x'
+
+// Capture either a full semver or the limited wildcard forms as a raw string
+versionSelector
+  = $(semver / semverMajorMinorX / semverMajorX)
+
 versionCore
   = major:$numericIdentifier '.' minor:$numericIdentifier '.' patch:$numericIdentifier
   {
@@ -1669,12 +1680,12 @@ QualifiedName
   }
 
 VersionedQualifiedName
-  = ns:QualifiedName '@' version:$semver '.' name:$Identifier {
+  = ns:QualifiedName '@' version:versionSelector '.' name:$Identifier {
   	return `${ns}@${version}.${name}`;
   }
 
 VersionedQualifiedNamespace
-  = ns:QualifiedName '@' version:$semver {
+  = ns:QualifiedName '@' version:versionSelector {
   	return `${ns}@${version}`;
   }
 

--- a/packages/concerto-cto/test/cto/semver-imports-wildcard-minor.cto
+++ b/packages/concerto-cto/test/cto/semver-imports-wildcard-minor.cto
@@ -1,0 +1,11 @@
+namespace test.person
+
+import test@1.1.x.{Foo,Bar}
+import test@1.1.x.Foo
+import test@1.1.x.* from github://foo
+
+participant Person identified by name {
+  o String name
+}
+
+

--- a/packages/concerto-cto/test/cto/semver-imports-wildcard-minor.json
+++ b/packages/concerto-cto/test/cto/semver-imports-wildcard-minor.json
@@ -1,0 +1,41 @@
+{
+    "$class": "concerto.metamodel@1.0.0.Model",
+    "decorators": [],
+    "namespace": "test.person",
+    "imports": [
+        {
+            "$class": "concerto.metamodel@1.0.0.ImportTypes",
+            "namespace": "test@1.1.x",
+            "types": ["Foo", "Bar"]
+        },
+        {
+            "$class": "concerto.metamodel@1.0.0.ImportType",
+            "name": "Foo",
+            "namespace": "test@1.1.x"
+        },
+        {
+            "$class": "concerto.metamodel@1.0.0.ImportAll",
+            "namespace": "test@1.1.x",
+            "uri": "github://foo"
+        }
+    ],
+    "declarations": [
+        {
+            "$class": "concerto.metamodel@1.0.0.ParticipantDeclaration",
+            "name": "Person",
+            "isAbstract": false,
+            "properties": [
+                {
+                    "$class": "concerto.metamodel@1.0.0.StringProperty",
+                    "name": "name",
+                    "isArray": false,
+                    "isOptional": false
+                }
+            ],
+            "identified": {
+                "$class": "concerto.metamodel@1.0.0.IdentifiedBy",
+                "name": "name"
+            }
+        }
+    ]
+}

--- a/packages/concerto-cto/test/cto/semver-imports-wildcard.cto
+++ b/packages/concerto-cto/test/cto/semver-imports-wildcard.cto
@@ -1,0 +1,11 @@
+namespace test.person
+
+import test@1.x.{Foo,Bar}
+import test@1.x.Foo
+import test@1.x.* from github://foo
+
+participant Person identified by name {
+  o String name
+}
+
+

--- a/packages/concerto-cto/test/cto/semver-imports-wildcard.json
+++ b/packages/concerto-cto/test/cto/semver-imports-wildcard.json
@@ -1,0 +1,41 @@
+{
+    "$class": "concerto.metamodel@1.0.0.Model",
+    "decorators": [],
+    "namespace": "test.person",
+    "imports": [
+        {
+            "$class": "concerto.metamodel@1.0.0.ImportTypes",
+            "namespace": "test@1.x",
+            "types": ["Foo", "Bar"]
+        },
+        {
+            "$class": "concerto.metamodel@1.0.0.ImportType",
+            "name": "Foo",
+            "namespace": "test@1.x"
+        },
+        {
+            "$class": "concerto.metamodel@1.0.0.ImportAll",
+            "namespace": "test@1.x",
+            "uri": "github://foo"
+        }
+    ],
+    "declarations": [
+        {
+            "$class": "concerto.metamodel@1.0.0.ParticipantDeclaration",
+            "name": "Person",
+            "isAbstract": false,
+            "properties": [
+                {
+                    "$class": "concerto.metamodel@1.0.0.StringProperty",
+                    "name": "name",
+                    "isArray": false,
+                    "isOptional": false
+                }
+            ],
+            "identified": {
+                "$class": "concerto.metamodel@1.0.0.IdentifiedBy",
+                "name": "name"
+            }
+        }
+    ]
+}

--- a/packages/concerto-linter/default-ruleset/test/fixtures/namespace-wildcard-imports.cto
+++ b/packages/concerto-linter/default-ruleset/test/fixtures/namespace-wildcard-imports.cto
@@ -1,0 +1,9 @@
+namespace ns.parent@1.2.3
+
+import dep@1.x.{Foo}
+import dep@1.1.x.*
+import dep@1.x.Foo
+
+concept Dummy {}
+
+

--- a/packages/concerto-linter/default-ruleset/test/rules/namespace-version.test.ts
+++ b/packages/concerto-linter/default-ruleset/test/rules/namespace-version.test.ts
@@ -21,4 +21,13 @@ describe('Namespace Version Rule', () => {
         expect(results[0].code).toBe('namespace-version');
         expect(results[0].message).toContain('should specify a version');
     });
+
+    test('should not report violations when imports use wildcard semver selectors', async () => {
+        const results = await testRules({
+            rules: {
+                'namespace-version': namespaceVersion,
+            },
+        }, 'namespace-wildcard-imports.cto');
+        expect(results).toHaveLength(0);
+    });
 });


### PR DESCRIPTION
- **fix(*): fix package lock (#963)**
- **feat: add GH action for closing stale prs and issues  (#961)**
- **bug(util): fix browser pointer in concerto-util pkg json (#966)**
- **fix(scripts): remove leading v from version tag**
- **fix(utils): fix browser build for concerto-util (#970)**
- **chore(aliasing): tests import aliasing (#977)**
- **chore(actions): publish v3.20.3 to npm (#978)**
- **chore(dcs): expose canMigrate and migrateTo methods from DecoratorManager (#979)**
- **chore(actions): publish v3.20.4 to npm (#980)**
- **fix(jsonpopulator) Updated processMapType to handle nested abstract c… (#827)**
- **chore(gh): remove deprecated issue_template.md from root directory (#997)**
- **fix(scalar): add validation for scalar declarations (#995)**
- **feat: vocabulary support for namespace scoped decorators (reopened) (#1004)**
- **Fixing Default Values Ignoring Meta properties. (#1013)**
- **fix(analysis): detect changes for various model modifications (#1000)**
- **refactor(concerto-core): improve deep copy performance in decorator manager (#1014)**
- **chore(actions): publish v3.21.0 to npm (#1015)**
- **chore(core): decorateModels perf config (#1022)**
- **chore(actions): publish v3.22.0 to npm (#1026)**
- **feat: Add concert-linter package structure and naming convention rules (#1027)**
- **feat(linter): Add configurable linter support (#1036)**
- **feat(linter): Introduce default-ruleset package for extensibility (#1038)**
- **Fix: Resolve default-ruleset Publish Failure (#1039)**
- **feat(dcsconverter): implement DCS JSON to YAML conversion (#1037)**
- **feat(ci/cd): Add GitHub workflow to run concerto-conformance tests on PRs (#1041)**
- **refactor: add missing $class fields in dcs json (#1043)**
- **feat: add new default ruleset (#1045)**
- **feat(concertino): add new lightweight object-centric serialization of models (#1031)**
- **feat(concertino): optimize format and built target (#1048)**
- **feat(concerto-core): implement YAML to JSON conversion for DCS (#1044)**
- **feat(linter): Add string length, PascalCase decorators, reserved keywords rules (#1054)**
- **fix(linter): add reserved-keywords rule and enhance decorator-name rule (#1056)**
- **feat(linter): refactor lintModel output shape & add namespace filtering (#1057)**
- **docs(linter): update READMEs and add unit tests for all rules (#1060)**
- **chore(actions): publish 3.23.0 to npm (#1049)**
- **chore(actions): publish v3.24.0 to npm (#1061)**
- **chore(deps): bump brace-expansion (#1062)**
- **fix(dcs-converter): improve type system handling in JSON <-> YAML conversion by removing regex post-processing (#1059)**
- **refactor(linter): Update workflow for obtaining parsed AST of .cto model (#1063)**
- **chore(deps): bump vite from 7.0.0 to 7.1.5 in /packages/concertino (#1064)**
- **chore(deps): bump vite from 7.1.5 to 7.1.11 in /packages/concertino (#1068)**
- **feat(parser): update parser to support semver x rages**
- **chore(semver-ranges): validate that concerto linter does not flag semver range usage**

<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #<CORRESPONDING ISSUE NUMBER>
<!--- Provide an overall summary of the pull request -->

### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
- <ONE>
- <TWO>

### Flags
<!--- Provide context or concerns a reviewer should be aware of -->
- <ONE>
- <TWO>

### Screenshots or Video
<!--- Provide an easily accessible demonstration of the changes, if applicable -->

### Related Issues
- Issue #<NUMBER>
- Pull Request #<NUMBER>

### Author Checklist
- [ ] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [ ] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ ] Merging to `main` from `fork:branchname`
