### PR TITLE
ci: update action versions and add npm caching

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
+          cache: 'npm'
 
       - run: npm ci
       - run: npm run build --if-present
@@ -51,7 +52,7 @@ jobs:
         run: npm run coverage
 
       - name: Coveralls
-        uses: coverallsapp/github-action@master
+        uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           flag-name: ${{ matrix.os }}
@@ -67,7 +68,7 @@ jobs:
 
     steps:
       - name: Coveralls Finished
-        uses: coverallsapp/github-action@master
+        uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           parallel-finished: true
@@ -92,6 +93,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 18.x
+          cache: 'npm'
 
       - run: npm ci
       - run: npm run build --if-present

--- a/.github/workflows/conformance-test.yml
+++ b/.github/workflows/conformance-test.yml
@@ -14,12 +14,13 @@ jobs:
 
     steps:
       - name: Checkout Target Project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18
+          cache: 'npm'
 
       - name: Install and Build Target Project
         run: |
@@ -27,7 +28,7 @@ jobs:
           npm run build
 
       - name: Checkout Conformance Suite
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: accordproject/concerto-conformance
           path: concerto-conformance

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,6 +24,7 @@ jobs:
         with:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'
+          cache: 'npm'
 
       # Ensure npm 11.5.1 or later for trusted publishing
       - run: npm install -g npm@latest
@@ -44,7 +45,7 @@ jobs:
           npm publish --workspaces --access public ${{ steps.tag.outputs.tag }} 2>&1
 
       - name: Create PR to increment version
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@v7
         with:
           base: main
           commit-message: 'chore(actions): publish ${{ github.event.release.tag_name }} to npm'


### PR DESCRIPTION
# Closes #1088 

### Changes

- Update `actions/checkout` and `actions/setup-node` to `v4` in [conformance-test.yml](cci:7://file:///home/shubhraj/OpenSource/concerto/.github/workflows/conformance-test.yml:0:0-0:0) for consistency with other workflows.
- Add `cache: 'npm'` to `setup-node` in [build.yml](cci:7://file:///home/shubhraj/OpenSource/concerto/.github/workflows/build.yml:0:0-0:0), [conformance-test.yml](cci:7://file:///home/shubhraj/OpenSource/concerto/.github/workflows/conformance-test.yml:0:0-0:0), and [publish.yml](cci:7://file:///home/shubhraj/OpenSource/concerto/.github/workflows/publish.yml:0:0-0:0) to improve CI build times.
- Pin `coverallsapp/github-action` to `v2` (was `@master`) in [build.yml](cci:7://file:///home/shubhraj/OpenSource/concerto/.github/workflows/build.yml:0:0-0:0) to ensure stability.
- Update `peter-evans/create-pull-request` to `v7` in [publish.yml](cci:7://file:///home/shubhraj/OpenSource/concerto/.github/workflows/publish.yml:0:0-0:0).

### Flags

- Validated that local IDE warnings for `environment: production` and `NPM_TOKEN` in [publish.yml](cci:7://file:///home/shubhraj/OpenSource/concerto/.github/workflows/publish.yml:0:0-0:0) are pre-existing false positives.
- Verified that the `concerto-linter` unit test failure is pre-existing on the `main` branch.

### Screenshots or Video
N/A

### Related Issues
- Issue #1088 

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [x] Extend the documentation, if necessary
- [x] Merging to `main` from `fork:branchname`