### PR TITLE
ci: add concurrency control to workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,10 @@ on:
       - main
       - v4.0.0 # Temporary, while we prepare for merge to main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Unit Tests

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -20,6 +20,10 @@ on:
   schedule:
     - cron: '34 1 * * 1'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/conformance-test.yml
+++ b/.github/workflows/conformance-test.yml
@@ -8,6 +8,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   conformance:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This reduces wasted CI minutes and prevents race conditions when multiple commits are pushed rapidly.
# Closes #1090 
### Changes
- Add `concurrency` groups to `build.yml`, `conformance-test.yml`, `codeql-analysis.yml`
- Cancel in-progress runs when new commits are pushed to the same branch
- CodeQL only cancels PR runs (preserves scheduled security scans on main)
### Flags
- **Pre-existing Test Failure**: verified that `concerto-linter` unit tests fail on the `main` branch as well; this PR does not introduce new failures.
### Screenshots or Video
N/A
### Related Issues
- Issue #1090 
### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [x] Extend the documentation, if necessary
- [x] Merging to `main` from `fork:branchname`
