### PR TITLE
ci: add path-based PR labeling workflow

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,52 @@
+# Labeler configuration for automatic PR labeling based on file paths
+
+# Package labels
+pkg:core:
+  - changed-files:
+    - any-glob-to-any-file: 'packages/concerto-core/**'
+
+pkg:analysis:
+  - changed-files:
+    - any-glob-to-any-file: 'packages/concerto-analysis/**'
+
+pkg:cto:
+  - changed-files:
+    - any-glob-to-any-file: 'packages/concerto-cto/**'
+
+pkg:linter:
+  - changed-files:
+    - any-glob-to-any-file: 'packages/concerto-linter/**'
+
+pkg:util:
+  - changed-files:
+    - any-glob-to-any-file: 'packages/concerto-util/**'
+
+pkg:vocabulary:
+  - changed-files:
+    - any-glob-to-any-file: 'packages/concerto-vocabulary/**'
+
+pkg:types:
+  - changed-files:
+    - any-glob-to-any-file: 'packages/concerto-types/**'
+
+# File type labels
+documentation:
+  - changed-files:
+    - any-glob-to-any-file: '**/*.md'
+
+ci:
+  - changed-files:
+    - any-glob-to-any-file: '.github/workflows/**'
+
+tests:
+  - changed-files:
+    - any-glob-to-any-file: 
+      - '**/*.test.js'
+      - '**/test/**'
+
+dependencies:
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'package.json'
+      - 'package-lock.json'
+      - '**/package.json'

--- a/.github/workflows/pull-request-labeler.yml
+++ b/.github/workflows/pull-request-labeler.yml
@@ -1,0 +1,23 @@
+name: "Pull Request Labeler"
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, closed]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  labeler:
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v6
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          sync-labels: true
+          dot: true


### PR DESCRIPTION
This helps maintainers quickly identify which components a PR affects and route reviews to the appropriate experts.
# Closes #1094
### Changes
- Add `.github/labeler.yml` config with 11 label categories
- Add `.github/workflows/pull-request-labeler.yml` using `actions/labeler@v6`
- Package labels: `pkg:core`, `pkg:analysis`, `pkg:cto`, `pkg:linter`, `pkg:util`, `pkg:vocabulary`, `pkg:types`
- Type labels: `documentation`, `ci`, `tests`, `dependencies`
- Includes concurrency control and `sync-labels: true` for auto-updates
### Flags
- **Pre-existing Test Failure**: verified that `concerto-linter` tests fail on `main` branch as well; this PR does not introduce new failures.
- **Trigger**: Uses `pull_request_target` for label permissions on forks
### Screenshots or Video
N/A (will be visible on future PRs)
### Related Issues
- Issue #1094 
### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [x] Extend the documentation, if necessary
- [x] Merging to `main` from `fork:branchname`