### PR TITLE
fix: ensure default-ruleset builds before linter tests

### DIFF
--- a/packages/concerto-linter/package.json
+++ b/packages/concerto-linter/package.json
@@ -13,7 +13,7 @@
     "clean": "rimraf dist",
     "prebuild": "npm-run-all clean && cd ./default-ruleset && npm run build",
     "build": "tsc -p tsconfig.build.json",
-    "pretest": "npm run build -w @accordproject/concerto-linter-default-ruleset && npm-run-all lint",
+    "pretest": "npm run prebuild && npm-run-all lint",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "test": "jest",


### PR DESCRIPTION
# Closes #1096 
Fix build order issue causing linter tests to fail on fresh clones by ensuring default-ruleset builds before tests run.

### Changes
- Update pretest script in packages/concerto-linter/package.json
- Build @accordproject/concerto-linter-default-ruleset workspace before running lint
- Prevents module resolution error: Cannot find module '@accordproject/concerto-linter-default-ruleset'

### Flags
- Breaking: No
- Tested: Verified by removing dist/ folder and running npm test - all 18 tests passed
- Impact: Improves developer experience for new contributors and fixes CI on clean environments

### Screenshots or Video
Before Fix: npm test results in src/index.ts:19:31 - error TS2307: Cannot find module '@accordproject/concerto-linter-default-ruleset'. After Fix: All 18 tests pass successfully including configLoader.test.ts, lintModel.test.ts, loadRuleset.test.ts, and formatResults.test.ts

### Related Issues
- Issue #1096 

### Author Checklist
- [x] Ensure you provide a DCO sign-off for your commits using the --signoff option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow AP format
- [x] Extend the documentation, if necessary
- [x] Merging to main from fork:branchname