### PR TITLE
docs: add build-before-test instructions to DEVELOPERS.md

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -23,6 +23,30 @@ git remote add upstream "https://github.com/accordproject/concerto.git"
 
 # Install node.js dependencies:
 npm i
+
+# Build all packages:
+npm run build
+```
+
+#### Running Tests
+
+Before running tests, you must first build the project to compile all workspace dependencies:
+
+```shell
+# Build all packages (required before testing):
+npm run build
+
+# Run all tests:
+npm run test
+```
+
+> **Note:** The build step is required because some packages (like `concerto-linter`) depend on other workspace packages that need to be compiled first. The CI workflows follow this same pattern: build first, then test.
+
+If you're working on a specific package, you can run tests for just that package:
+
+```shell
+# Run tests for a specific package:
+npm run test -w @accordproject/concerto-core
 ```
 
 [apdev]: https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md


### PR DESCRIPTION
Closes #1096

## Summary
Updates [DEVELOPERS.md](cci:7://file:///home/shubhraj/OpenSource/concerto/DEVELOPERS.md:0:0-0:0) to clarify that developers must run `npm run build` before `npm run test` to ensure all workspace dependencies are compiled.

## Context
Per maintainer feedback on #1098, the original issue (#1096) where `concerto-linter` tests fail on fresh clones is better addressed as a documentation issue rather than a script change. The CI workflows already follow the build → test pattern, but the docs didn't reflect this.

## Changes
- Added `npm run build` step to the initial setup instructions
- Added new "Running Tests" section with clear build-before-test guidance
- Added explanatory note about why this is required (workspace dependencies)
- Added example for running tests on a specific package

## Author Checklist
- [x] DCO sign-off provided
- [x] Follows Accord Project commit message format
- [x] Documentation change only (no code changes)