### PR TITLE
ci: add timeout-minutes to workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,7 @@ concurrency:
 jobs:
   build:
     name: Unit Tests
+    timeout-minutes: 30
 
     strategy:
       matrix:
@@ -67,6 +68,7 @@ jobs:
       - build
 
     name: Code Coverage
+    timeout-minutes: 30
     if: ${{ success() }}
     runs-on: ubuntu-latest
 
@@ -83,6 +85,7 @@ jobs:
       - notify
 
     name: Publish to npm
+    timeout-minutes: 30
     if: ${{ success() && github.event_name == 'push' && github.repository_owner == 'accordproject' }}
     runs-on: ubuntu-latest
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -28,6 +28,7 @@ jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/conformance-test.yml
+++ b/.github/workflows/conformance-test.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   conformance:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - name: Checkout Target Project

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   publish:
     name: Publish to npm
+    timeout-minutes: 30
     if: ${{ github.repository_owner == 'accordproject' }}
     runs-on: ubuntu-latest
     environment: production


### PR DESCRIPTION
# Closes #1103

### Summary
Added a `timeout-minutes` configuration to jobs in the GitHub Actions workflows. This prevents jobs from running indefinitely and wasting CI resources.

### Changes
- Added `timeout-minutes: 30` to `build` and `publish` jobs in [build.yml](cci:7://file:///home/shubhraj/OpenSource/concerto/.github/workflows/build.yml:0:0-0:0)
- Added `timeout-minutes: 30` to `conformance` job in [conformance-test.yml](cci:7://file:///home/shubhraj/OpenSource/concerto/.github/workflows/conformance-test.yml:0:0-0:0)
- Added `timeout-minutes: 30` to `analyze` job in [codeql-analysis.yml](cci:7://file:///home/shubhraj/OpenSource/concerto/.github/workflows/codeql-analysis.yml:0:0-0:0)
- Added `timeout-minutes: 30` to `publish` job in [publish.yml](cci:7://file:///home/shubhraj/OpenSource/concerto/.github/workflows/publish.yml:0:0-0:0)

### Flags
- None

### Screenshots or Video
N/A

### Related Issues
- Issue #1103

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [x] Extend the documentation, if necessary
- [x] Merging to `main` from `chore/workflow-timeouts`