### PR TITLE
fix(concerto-core): correct typographical errors in comments and error messages

### DIFF
--- a/packages/concerto-core/lib/introspect/modelfile.js
+++ b/packages/concerto-core/lib/introspect/modelfile.js
@@ -244,7 +244,7 @@ class ModelFile extends Decorated {
             const unseenNamespace = existingNamespaceVersion === undefined;
 
             // This check is needed because we automatically add both versioned and unversioned versions of
-            // the root namespace for backwards compatibillity unless we're running in strict mode
+            // the root namespace for backwards compatibility unless we're running in strict mode
             const isGlobalModel = name === 'concerto';
 
             const differentVersionsOfSameNamespace = !unseenNamespace && existingNamespaceVersion !== importVersion;
@@ -754,10 +754,10 @@ class ModelFile extends Decorated {
             switch(imp.$class) {
             case `${MetaModelNamespace}.ImportAll`:
                 if (this.getModelManager().isStrict()){
-                    throw new Error('Wilcard Imports are not permitted in strict mode.');
+                    throw new Error('Wildcard Imports are not permitted in strict mode.');
                 }
                 Warning.printDeprecationWarning(
-                    'Wilcard Imports are deprecated in this version of Concerto and will be removed in a future version.',
+                    'Wildcard Imports are deprecated in this version of Concerto and will be removed in a future version.',
                     ErrorCodes.DEPRECATION_WARNING,
                     ErrorCodes.CONCERTO_DEPRECATION_002,
                     'Please refer to https://concerto.accordproject.org/deprecation/002'

--- a/packages/concerto-core/lib/model/relationship.js
+++ b/packages/concerto-core/lib/model/relationship.js
@@ -82,8 +82,8 @@ class Relationship extends Identifiable {
      * Contructs a Relationship instance from a URI representation (created using toURI).
      * @param {ModelManager} modelManager - the model manager to bind the relationship to
      * @param {String} uriAsString - the URI as a string, generated using Identifiable.toURI()
-     * @param {String} [defaultNamespace] - default namespace to use for backwards compatability
-     * @param {String} [defaultType] - default type to use for backwards compatability
+     * @param {String} [defaultNamespace] - default namespace to use for backwards compatibility
+     * @param {String} [defaultType] - default type to use for backwards compatibility
      * @return {Relationship} the relationship
      */
     static fromURI(modelManager, uriAsString, defaultNamespace, defaultType) {

--- a/packages/concerto-core/lib/model/typed.js
+++ b/packages/concerto-core/lib/model/typed.js
@@ -201,7 +201,7 @@ class Typed {
     }
 
     /**
-     * Overriden to prevent people accidentally converting a resource to JSON
+     * Overridden to prevent people accidentally converting a resource to JSON
      * without using the Serializer.
      * @protected
      */

--- a/packages/concerto-core/lib/serializer.js
+++ b/packages/concerto-core/lib/serializer.js
@@ -128,7 +128,7 @@ class Serializer {
         parameters.stack.clear();
         parameters.stack.push(resource);
 
-        // this performs the conversion of the resouce into a standard JSON object
+        // this performs the conversion of the resource into a standard JSON object
         let result = classDeclaration.accept(generator, parameters);
         return result;
     }

--- a/packages/concerto-core/lib/serializer/instancegenerator.js
+++ b/packages/concerto-core/lib/serializer/instancegenerator.js
@@ -96,7 +96,7 @@ class InstanceGenerator {
                 throw new Error('Model is recursive.');
             }
             parameters.seen.push(fqn);
-        } else { parameters.seen.push('Primitve');
+        } else { parameters.seen.push('Primitive');
         }
         let result;
         if (field.isArray()) {

--- a/packages/concerto-core/lib/serializer/jsonpopulator.js
+++ b/packages/concerto-core/lib/serializer/jsonpopulator.js
@@ -233,7 +233,7 @@ class JSONPopulator {
             parameters.resourceStack.push(subResource);
             return decl.accept(this, parameters);
         }
-        // otherwise its a scalar value, we only need to return the primitve value of the scalar.
+        // otherwise its a scalar value, we only need to return the primitive value of the scalar.
         return value;
     }
 

--- a/packages/concerto-core/lib/serializer/objectvalidator.js
+++ b/packages/concerto-core/lib/serializer/objectvalidator.js
@@ -510,7 +510,7 @@ class ObjectValidator {
 
     /**
      * Throw a validation exception for an abstract class
-     * @param {string} resourceId - the id of the resouce being validated
+     * @param {string} resourceId - the id of the resource being validated
      * @param {string} propertyName - the name of the property that is not declared
      * @param {string} fullyQualifiedTypeName - the fully qualified type being validated
      * @throws {ValidationException} the validation exception
@@ -527,7 +527,7 @@ class ObjectValidator {
 
     /**
      * Throw a validation exception for an invalid field assignment
-     * @param {string} resourceId - the id of the resouce being validated
+     * @param {string} resourceId - the id of the resource being validated
      * @param {string} propName - the name of the property that is being assigned
      * @param {*} obj - the Field
      * @param {Field} field - the Field

--- a/packages/concerto-core/lib/serializer/resourcevalidator.js
+++ b/packages/concerto-core/lib/serializer/resourcevalidator.js
@@ -205,7 +205,7 @@ class ResourceValidator {
 
         const obj = parameters.stack.pop();
 
-        // are we dealing with a Resouce?
+        // are we dealing with a Resource?
         if(!((obj instanceof Resource))) {
             ResourceValidator.reportNotResouceViolation(parameters.rootResourceIdentifier, classDeclaration, obj );
         }
@@ -233,7 +233,7 @@ class ResourceValidator {
                 const field = toBeAssignedClassDeclaration.getProperty(propName);
                 if (!field) {
                     if(classDeclaration.isIdentified() &&
-                        // Allow shadowing of the $identifer field to normalize lookup of the identifying field.
+                        // Allow shadowing of the $identifier field to normalize lookup of the identifying field.
                         propName !== '$identifier'
                     ){
                         ResourceValidator.reportUndeclaredField(obj.getIdentifier(), propName, toBeAssignedClassDecName);
@@ -273,7 +273,7 @@ class ResourceValidator {
             }
             else {
                 if(!property.isOptional()) {
-                    // Allow shadowing of the $identifer field to normalize lookup of the identifying field.
+                    // Allow shadowing of the $identifier field to normalize lookup of the identifying field.
                     if (property.getName() === '$identifier' && identifierFieldName !== '$identifier'
                     ) {
                         continue;
@@ -631,7 +631,7 @@ class ResourceValidator {
 
     /**
      * Throw a validation exception for an abstract class
-     * @param {string} resourceId - the id of the resouce being validated
+     * @param {string} resourceId - the id of the resource being validated
      * @param {string} propertyName - the name of the property that is not declared
      * @param {string} fullyQualifiedTypeName - the fully qualified type being validated
      * @throws {ValidationException} the validation exception
@@ -648,7 +648,7 @@ class ResourceValidator {
 
     /**
      * Throw a validation exception for an invalid field assignment
-     * @param {string} resourceId - the id of the resouce being validated
+     * @param {string} resourceId - the id of the resource being validated
      * @param {string} propName - the name of the property that is being assigned
      * @param {*} obj - the Field
      * @param {Field} field - the Field

--- a/packages/concerto-core/test/introspect/modelfile.js
+++ b/packages/concerto-core/test/introspect/modelfile.js
@@ -172,7 +172,7 @@ describe('ModelFile', () => {
 
             (() => {
                 ParserUtil.newModelFile(strictModelManager, 'fake definitions');
-            }).should.throw(/Wilcard Imports are not permitted in strict mode./);
+            }).should.throw(/Wildcard Imports are not permitted in strict mode./);
         });
 
         it('should throw for an unrecognized body element', () => {


### PR DESCRIPTION
# Closes #1106

Fix typographical errors in user-facing error messages, comments, and JSDoc across `concerto-core`.

### Changes
- Fixed `Wilcard` → `Wildcard` in error messages (modelfile.js)
- Fixed `compatibillity` → `compatibility` in comments (modelfile.js)
- Fixed `Primitve`/`primitve` → `Primitive`/`primitive` (instancegenerator.js, jsonpopulator.js)
- Fixed `resouce` → `resource` in JSDoc (serializer.js, objectvalidator.js, resourcevalidator.js)
- Fixed `$identifer` → `$identifier` in comments (resourcevalidator.js)
- Fixed `Overriden` → `Overridden` in JSDoc (typed.js)
- Fixed `compatability` → `compatibility` in JSDoc (relationship.js)
- Updated test to match corrected error message (test/introspect/modelfile.js)

### Flags
- No functional changes - comments and string literals only
- The method name [reportNotResouceViolation](cci:1://file:///home/shubhraj/OpenSource/concerto/packages/concerto-core/lib/serializer/resourcevalidator.js:543:4-557:5) was intentionally left unchanged as renaming it would be a breaking API change

### Screenshots or Video
N/A - documentation and error message fixes only

### Related Issues
- Issue #1106

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [x] Extend the documentation, if necessary
- [x] Merging to [main](cci:1://file:///home/shubhraj/OpenSource/concerto/packages/concerto-types/scripts/codegen.js:7:0-19:1) from `fork:branchname`