### PR TITLE
fix: correct additional typographical errors in comments

### DIFF
--- a/packages/concerto-core/lib/model/relationship.js
+++ b/packages/concerto-core/lib/model/relationship.js
@@ -79,7 +79,7 @@ class Relationship extends Identifiable {
     }
 
     /**
-     * Contructs a Relationship instance from a URI representation (created using toURI).
+     * Constructs a Relationship instance from a URI representation (created using toURI).
      * @param {ModelManager} modelManager - the model manager to bind the relationship to
      * @param {String} uriAsString - the URI as a string, generated using Identifiable.toURI()
      * @param {String} [defaultNamespace] - default namespace to use for backwards compatibility

--- a/packages/concerto-core/lib/model/typed.js
+++ b/packages/concerto-core/lib/model/typed.js
@@ -189,7 +189,7 @@ class Typed {
         if (classDeclaration.getFullyQualifiedName() === fqt) {
             return true;
         }
-        // Now walk the class hierachy looking to see if it's an instance of the specified type.
+        // Now walk the class hierarchy looking to see if it's an instance of the specified type.
         let superTypeDeclaration = classDeclaration.getSuperTypeDeclaration();
         while (superTypeDeclaration) {
             if (superTypeDeclaration.getFullyQualifiedName() === fqt) {

--- a/packages/concerto-util/lib/warning.js
+++ b/packages/concerto-util/lib/warning.js
@@ -25,7 +25,7 @@ let isWarningEmitted = false;
  * @param {string} detail - detail of the deprecation warning
  */
 function printDeprecationWarning(message, type, code, detail) {
-    // This will get pollyfilled in the webpack.config.js as process.emitWarning is not available in the browser
+    // This will get polyfilled in the webpack.config.js as process.emitWarning is not available in the browser
     const customEmitWarning = process.emitWarning;
     if (!isWarningEmitted) {
         isWarningEmitted = true;


### PR DESCRIPTION
# Closes #1108

Fix additional typographical errors in comments (follow-up to #1106).

### Changes
- Fixed `Contructs` → `Constructs` in relationship.js JSDoc
- Fixed `hierachy` → `hierarchy` in typed.js comment
- Fixed `pollyfilled` → `polyfilled` in warning.js comment

### Flags
- No functional changes - comments only
- Affects 2 packages: concerto-core, concerto-util

### Screenshots or Video
N/A - comment fixes only

### Related Issues
- Issue #1108
- Follow-up to PR #1107

### Author Checklist
- [x] DCO sign-off
- [x] Tests pass
- [x] Conventional commit format
- [x] Documentation (N/A)
- [x] Merging to `main` from `fork:fix/typos-issue-1108`