### PR TITLE
fix: correct typographical errors on v4.0.0 branch

### DIFF
--- a/packages/concerto-core/src/introspect/modelfile.js
+++ b/packages/concerto-core/src/introspect/modelfile.js
@@ -725,7 +725,7 @@ class ModelFile extends Decorated {
             this.enforceImportVersioning(imp);
             switch(imp.$class) {
             case `${MetaModelNamespace}.ImportAll`:
-                throw new Error('Wilcard Imports are not permitted.');
+                throw new Error('Wildcard Imports are not permitted.');
             case `${MetaModelNamespace}.ImportTypes`: {
                 const aliasedTypes = new Map();
                 if (imp.aliasedTypes) {

--- a/packages/concerto-core/src/model/relationship.js
+++ b/packages/concerto-core/src/model/relationship.js
@@ -79,11 +79,11 @@ class Relationship extends Identifiable {
     }
 
     /**
-     * Contructs a Relationship instance from a URI representation (created using toURI).
+     * Constructs a Relationship instance from a URI representation (created using toURI).
      * @param {ModelManager} modelManager - the model manager to bind the relationship to
      * @param {String} uriAsString - the URI as a string, generated using Identifiable.toURI()
-     * @param {String} [defaultNamespace] - default namespace to use for backwards compatability
-     * @param {String} [defaultType] - default type to use for backwards compatability
+     * @param {String} [defaultNamespace] - default namespace to use for backwards compatibility
+     * @param {String} [defaultType] - default type to use for backwards compatibility
      * @return {Relationship} the relationship
      */
     static fromURI(modelManager, uriAsString, defaultNamespace, defaultType) {

--- a/packages/concerto-core/src/model/typed.js
+++ b/packages/concerto-core/src/model/typed.js
@@ -189,7 +189,7 @@ class Typed {
         if (classDeclaration.getFullyQualifiedName() === fqt) {
             return true;
         }
-        // Now walk the class hierachy looking to see if it's an instance of the specified type.
+        // Now walk the class hierarchy looking to see if it's an instance of the specified type.
         let superTypeDeclaration = classDeclaration.getSuperTypeDeclaration();
         while (superTypeDeclaration) {
             if (superTypeDeclaration.getFullyQualifiedName() === fqt) {
@@ -201,7 +201,7 @@ class Typed {
     }
 
     /**
-     * Overriden to prevent people accidentally converting a resource to JSON
+     * Overridden to prevent people accidentally converting a resource to JSON
      * without using the Serializer.
      * @protected
      */

--- a/packages/concerto-core/src/serializer.js
+++ b/packages/concerto-core/src/serializer.js
@@ -128,7 +128,7 @@ class Serializer {
         parameters.stack.clear();
         parameters.stack.push(resource);
 
-        // this performs the conversion of the resouce into a standard JSON object
+        // this performs the conversion of the resource into a standard JSON object
         let result = classDeclaration.accept(generator, parameters);
         return result;
     }

--- a/packages/concerto-core/src/serializer/instancegenerator.js
+++ b/packages/concerto-core/src/serializer/instancegenerator.js
@@ -96,7 +96,7 @@ class InstanceGenerator {
                 throw new Error('Model is recursive.');
             }
             parameters.seen.push(fqn);
-        } else { parameters.seen.push('Primitve');
+        } else { parameters.seen.push('Primitive');
         }
         let result;
         if (field.isArray()) {

--- a/packages/concerto-core/src/serializer/jsonpopulator.js
+++ b/packages/concerto-core/src/serializer/jsonpopulator.js
@@ -233,7 +233,7 @@ class JSONPopulator {
             parameters.resourceStack.push(subResource);
             return decl.accept(this, parameters);
         }
-        // otherwise its a scalar value, we only need to return the primitve value of the scalar.
+        // otherwise its a scalar value, we only need to return the primitive value of the scalar.
         return value;
     }
 

--- a/packages/concerto-core/src/serializer/resourcevalidator.js
+++ b/packages/concerto-core/src/serializer/resourcevalidator.js
@@ -205,7 +205,7 @@ class ResourceValidator {
 
         const obj = parameters.stack.pop();
 
-        // are we dealing with a Resouce?
+        // are we dealing with a Resource?
         if(!((obj instanceof Resource))) {
             ResourceValidator.reportNotResouceViolation(parameters.rootResourceIdentifier, classDeclaration, obj );
         }
@@ -233,7 +233,7 @@ class ResourceValidator {
                 const field = toBeAssignedClassDeclaration.getProperty(propName);
                 if (!field) {
                     if(classDeclaration.isIdentified() &&
-                        // Allow shadowing of the $identifer field to normalize lookup of the identifying field.
+                        // Allow shadowing of the $identifier field to normalize lookup of the identifying field.
                         propName !== '$identifier'
                     ){
                         ResourceValidator.reportUndeclaredField(obj.getIdentifier(), propName, toBeAssignedClassDecName);
@@ -273,7 +273,7 @@ class ResourceValidator {
             }
             else {
                 if(!property.isOptional()) {
-                    // Allow shadowing of the $identifer field to normalize lookup of the identifying field.
+                    // Allow shadowing of the $identifier field to normalize lookup of the identifying field.
                     if (property.getName() === '$identifier' && identifierFieldName !== '$identifier'
                     ) {
                         continue;
@@ -631,7 +631,7 @@ class ResourceValidator {
 
     /**
      * Throw a validation exception for an abstract class
-     * @param {string} resourceId - the id of the resouce being validated
+     * @param {string} resourceId - the id of the resource being validated
      * @param {string} propertyName - the name of the property that is not declared
      * @param {string} fullyQualifiedTypeName - the fully qualified type being validated
      * @throws {ValidationException} the validation exception
@@ -648,7 +648,7 @@ class ResourceValidator {
 
     /**
      * Throw a validation exception for an invalid field assignment
-     * @param {string} resourceId - the id of the resouce being validated
+     * @param {string} resourceId - the id of the resource being validated
      * @param {string} propName - the name of the property that is being assigned
      * @param {*} obj - the Field
      * @param {Field} field - the Field

--- a/packages/concerto-core/test/introspect/modelfile.js
+++ b/packages/concerto-core/test/introspect/modelfile.js
@@ -173,7 +173,7 @@ describe('ModelFile', () => {
 
             (() => {
                 ParserUtil.newModelFile(strictModelManager, 'fake definitions');
-            }).should.throw(/Wilcard Imports are not permitted./);
+            }).should.throw(/Wildcard Imports are not permitted./);
         });
 
         it('should throw for an unrecognized body element', () => {

--- a/packages/concerto-util/src/warning.js
+++ b/packages/concerto-util/src/warning.js
@@ -25,7 +25,7 @@ let isWarningEmitted = false;
  * @param {string} detail - detail of the deprecation warning
  */
 function printDeprecationWarning(message, type, code, detail) {
-    // This will get pollyfilled in the webpack.config.js as process.emitWarning is not available in the browser
+    // This will get polyfilled in the webpack.config.js as process.emitWarning is not available in the browser
     const customEmitWarning = process.emitWarning;
     if (!isWarningEmitted) {
         isWarningEmitted = true;


### PR DESCRIPTION
# Closes #1110

Fix typographical errors in comments, JSDoc, and error messages on the v4.0.0 branch.

### Changes

**concerto-core/src (14 fixes, 7 files):**
- [introspect/modelfile.js](cci:7://file:///home/shubhraj/OpenSource/concerto/packages/concerto-core/lib/introspect/modelfile.js:0:0-0:0): Wilcard → Wildcard (error message)
- [model/relationship.js](cci:7://file:///home/shubhraj/OpenSource/concerto/packages/concerto-core/src/model/relationship.js:0:0-0:0): Contructs → Constructs, compatability → compatibility (2x)
- [model/typed.js](cci:7://file:///home/shubhraj/OpenSource/concerto/packages/concerto-core/lib/model/typed.js:0:0-0:0): hierachy → hierarchy, Overriden → Overridden
- [serializer.js](cci:7://file:///home/shubhraj/OpenSource/concerto/packages/concerto-core/lib/serializer.js:0:0-0:0): resouce → resource
- [serializer/instancegenerator.js](cci:7://file:///home/shubhraj/OpenSource/concerto/packages/concerto-core/src/serializer/instancegenerator.js:0:0-0:0): Primitve → Primitive
- [serializer/jsonpopulator.js](cci:7://file:///home/shubhraj/OpenSource/concerto/packages/concerto-core/src/serializer/jsonpopulator.js:0:0-0:0): primitve → primitive
- [serializer/resourcevalidator.js](cci:7://file:///home/shubhraj/OpenSource/concerto/packages/concerto-core/lib/serializer/resourcevalidator.js:0:0-0:0): Resouce → Resource, $identifer → $identifier (2x), resouce → resource (2x)

**concerto-util/src (1 fix, 1 file):**
- [warning.js](cci:7://file:///home/shubhraj/OpenSource/concerto/packages/concerto-util/src/warning.js:0:0-0:0): pollyfilled → polyfilled

**Tests (1 fix):**
- Updated test assertion for corrected error message

### Flags
- No functional changes - comments/JSDoc only
- One user-facing error message corrected ("Wildcard Imports")

### Screenshots or Video
N/A - comment fixes only

### Related Issues
- Closes #1110
- Requested by @mttrbrts in PR #1107

### Author Checklist
- [x] DCO sign-off
- [x] Linked to issue #1110
- [x] Follows contribution guidelines
- [x] Tests pass (CI will verify)
- [x] Merging from `Shubh-Raj/concerto:fix/typos-v4.0.0-issue-1110` to `accordproject/concerto:v4.0.0`