### PR TITLE
ci: upgrade outdated GitHub Actions in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Use Node.js 20.x
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: 20.x
 
@@ -35,7 +35,7 @@ jobs:
           npm publish --workspaces --access public ${{ steps.tag.outputs.tag }} 2>&1
 
       - name: Create PR to increment version
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@v7
         with:
           base: main
           commit-message: 'chore(actions): publish ${{ github.event.release.tag_name }} to npm'


### PR DESCRIPTION
# Closes #1112

Upgrade outdated GitHub Actions in the `Publish to npm` workflow on the `v4.0.0` branch.

### Changes
- `actions/setup-node`: v1 → v4
- `peter-evans/create-pull-request`: v3 → v7

The v3 version of `create-pull-request` no longer works with current GitHub Actions token permissions, causing the "Create PR to increment version" step to fail.

### Flags
- CI workflow change only - cannot be fully tested locally
- No functional code changes

### Screenshots or Video
N/A - workflow configuration change

### Related Issues
- Issue #1112

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [x] Extend the documentation, if necessary
- [x] Merging to `v4.0.0` from `Shubh-Raj:fix/upgrade-publish-workflow-issue-1112`