### PR TITLE
fix(ci): add required permissions for create-pull-request

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,7 +6,10 @@ on:
       - published
 
 permissions:
-  id-token: write  # Required for OIDC / npmjs publish
+  id-token: write
+  contents: write
+  pull-requests: write
+
 
 jobs:
   publish:


### PR DESCRIPTION
Closes #1112

This PR fixes the release publish workflow failure caused by missing GitHub token permissions required by `peter-evans/create-pull-request@v7`.

### Changes
- Added explicit `contents: write` permission to allow branch pushes
- Added explicit `pull-requests: write` permission to allow PR creation
- Aligns the workflow with GitHub Actions’ current security model

### Flags
- No functional changes to the publish logic
- Workflow behavior remains the same, only permissions were updated
- Safe change limited to CI configuration

### Screenshots or Video
N/A

### Related Issues
- Issue #1112

### Author Checklist
- [x] Commits are signed off (DCO)
- [x] Commit messages follow Accord Project format
- [x] Changes are limited to CI configuration
- [x] No documentation update required
