### PR TITLE
docs(concerto-analysis): fix incorrect npm install command

### DIFF
--- a/packages/concerto-analysis/README.md
+++ b/packages/concerto-analysis/README.md
@@ -4,7 +4,7 @@ Analysis of [Concerto](https://github.com/accordproject/concerto/) model files.
 ## Install
 
 ```
-npm install @accordproject/concerto-types --save
+npm install @accordproject/concerto-analysis --save
 ```
 
 ## License <a name="license"></a>


### PR DESCRIPTION
<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #1123
Fix incorrect npm install command in concerto-analysis README. The package name was showing @accordproject/concerto-types instead of @accordproject/concerto-analysis, which would cause users to install the wrong package.

### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
- Fixed line 7 in packages/concerto-analysis/README.md
- Changed npm install command from @accordproject/concerto-types to @accordproject/concerto-analysis
- This was a copy-paste error from another package's README

### Flags
<!--- Provide context or concerns a reviewer should be aware of -->
- Documentation-only change, no code modifications

### Screenshots or Video
<!--- Provide an easily accessible demonstration of the changes, if applicable -->
N/A 

### Related Issues
- Issue #1123

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests (N/A - documentation change)
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [x] Extend the documentation, if necessary (N/A - this IS a documentation fix)
- [x] Merging to `main` from `fork:branchname` (Shubh-Raj:fix/issue-1123-concerto-analysis-readme)