### PR TITLE
fix: Replace console.log() with debug library in HTTPFileLoader

### DIFF
--- a/packages/concerto-util/lib/loaders/httpfileloader.js
+++ b/packages/concerto-util/lib/loaders/httpfileloader.js
@@ -14,6 +14,8 @@
 
 'use strict';
 
+const debug = require('debug')('concerto:HTTPFileLoader');
+
 /**
  * Loads Files from an HTTP(S) URL using fetch.
  * @class
@@ -55,7 +57,7 @@ class HTTPFileLoader {
             };
         }
 
-        console.log(requestUrl);
+        debug('loading', requestUrl);
         const response = await fetch(requestUrl, options);
         if (!response.ok) {
             throw new Error(`HTTP request failed with status: ${response.status}`);


### PR DESCRIPTION
### Problem
The HTTPFileLoader.load() method in `concerto-util` uses `console.log()` to output the request URL during file loading. This causes unwanted console spam , security concerns (URLs may contain sensitive paths) and takes up unnecessary terminal space. 

### Solution
Replace `console.log(requestUrl)` with `debug('loading', requestUrl)` , utilizing the debug library that is already imported  in the file `concerto-util`
### Changes:
File:  `packages/concerto-util/lib/loaders/httpfileloader.js`
Line 17: added debug import (`const debug = require('debug')('concerto:HTTPFileLoader');`)
Line 60: Changed `console.log(requestUrl);` → `debug('loading', requestUrl);`

### Why these changes were required:
- Prevents unwanted console spam for library users
- Gives users control over logging via debug
- Cleaner and silent production output - logs only appear when explicitly enabled
- Consistent - follows existing debug patterns in `concerto-util`

### Testing
- All existing tests pass
- Linting passes