### PR TITLE
Docs(analysis): Update installation instructions in README.md

### DIFF
--- a/packages/concerto-analysis/README.md
+++ b/packages/concerto-analysis/README.md
@@ -4,7 +4,7 @@ Analysis of [Concerto](https://github.com/accordproject/concerto/) model files.
 ## Install
 
 ```
-npm install @accordproject/concerto-types --save
+npm install @accordproject/concerto-analysis --save
 ```
 
 ## License <a name="license"></a>


### PR DESCRIPTION
Replaced the wrong package name (@accordproject/concerto-types) with the correct one (@accordproject/concerto-analysis) to ensure users install the intended package.

Closes #1123
Changes

Updated npm install command in packages/concerto-analysis/README.md

Replaced incorrect package name with correct package reference

Flags

Documentation-only change

No code logic modified

No breaking changes expected

Screenshots or Video
Not applicable (documentation change only)

Related Issues

Issue #1123


 Merging to main from fork:patch-1
