### PR TITLE
ci: Add Node.js 22.x to the CI build matrix.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,7 @@ jobs:
         node-version:
           - 18.x
           - 20.x
+          - 22.x
         os:
           - windows-latest
           - macos-latest


### PR DESCRIPTION
## Summary
- Add Node.js 22.x to the CI build matrix alongside 18.x and 20.x
- Node 22 is the current active LTS but was dropped during previous workflow restructuring
- CI matrix expands from 6 jobs (2 Node × 3 OS) to 9 jobs (3 Node × 3 OS)

## Test plan
- [ ] All 9 matrix jobs pass (Node 18/20/22 × Ubuntu/macOS/Windows)
- [ ] Coveralls coverage reports are received from all matrix legs
