### PR TITLE
fix: Add debug logging to HTTPFileLoader (backport from main)

### DIFF
--- a/packages/concerto-util/src/loaders/httpfileloader.js
+++ b/packages/concerto-util/src/loaders/httpfileloader.js
@@ -14,6 +14,8 @@
 
 'use strict';
 
+const debug = require('debug')('concerto:HTTPFileLoader');
+
 /**
  * Loads Files from an HTTP(S) URL using fetch.
  * @class
@@ -55,6 +57,7 @@ class HTTPFileLoader {
             };
         }
 
+        debug('loading', requestUrl);
         const response = await fetch(requestUrl, options);
         if (!response.ok) {
             throw new Error(`HTTP request failed with status: ${response.status}`);


### PR DESCRIPTION
### Related PR: #1125 

### Description:

This PR backports the logging improvements from `main` to the `v4.0.0` branch as requested by @mttrbrts.

In `main`, I replaced `console.log` with `debug()` to reduce spam.

In `v4.0.0`, there was no logging at all in `HTTPFileLoader`. 

This change adds `debug('loading', requestUrl)` to enable request tracing when needed, matching the functionality in `main`.
- **Original PR:** #1125
- **Branch:** `v4.0.0`
- **Tests:** All tests passed locally.