### PR TITLE
test: Add unit test for unrecognized model element in ModelFile

### DIFF
--- a/packages/concerto-core/test/composer/i18n.js
+++ b/packages/concerto-core/test/composer/i18n.js
@@ -25,22 +25,23 @@ const ModelManager = require('./../../lib/modelmanager');
 const ModelUtil = require('./../../lib/modelutil');
 const Util = require('../composer/composermodelutility');
 const ParserUtil = require('../introspect/parserutility');
+const ModelFile = require('../../lib/introspect/modelfile');
 const dayjs = require('dayjs');
 const utc = require('dayjs/plugin/utc');
 dayjs.extend(utc);
 
-describe('Globalization', function() {
+describe('Globalization', function () {
 
-    beforeEach(function() {
+    beforeEach(function () {
     });
 
-    describe('#check globalization library works', function() {
-        it('numbered variables using Array', function() {
+    describe('#check globalization library works', function () {
+        it('numbered variables using Array', function () {
             const formatter = Globalize('en').messageFormatter('test-hello-array');
-            formatter([ 'Wolfgang', 'Amadeus', 'Mozart' ]).should.equal('Hello, Wolfgang Amadeus Mozart');
+            formatter(['Wolfgang', 'Amadeus', 'Mozart']).should.equal('Hello, Wolfgang Amadeus Mozart');
         });
 
-        it('named variables using Object key-value pairs', function() {
+        it('named variables using Object key-value pairs', function () {
             const formatter = Globalize('en').messageFormatter('test-hello-object');
             formatter({
                 first: 'Wolfgang',
@@ -49,37 +50,37 @@ describe('Globalization', function() {
             }).should.equal('Hello, Wolfgang Amadeus Mozart');
         });
 
-        it('repeated numbered variables using Array', function() {
+        it('repeated numbered variables using Array', function () {
             const formatter = Globalize('en').messageFormatter('test-repeat-array');
-            formatter([ 'Bonkers' ]).should.equal('Bonkers Bonkers Bonkers');
+            formatter(['Bonkers']).should.equal('Bonkers Bonkers Bonkers');
         });
 
-        it('repeated named variables using Object key-value pairs', function() {
+        it('repeated named variables using Object key-value pairs', function () {
             const formatter = Globalize('en').messageFormatter('test-repeat-object');
             formatter({
                 value: 'Bonkers'
             }).should.equal('Bonkers Bonkers Bonkers');
         });
 
-        it.skip('check formatters', function() {
+        it.skip('check formatters', function () {
             // Use Globalize to format a message with plural inflection.
             let like = Globalize.messageFormatter('like');
             like(0).should.equal('Be the first to like this');
-            Globalize.dateFormatter()( dayjs.utc().format() ).should.not.be.null;
+            Globalize.dateFormatter()(dayjs.utc().format()).should.not.be.null;
             Globalize('pt').formatMessage('hello').should.equal('Olá');
 
             let formatter = Globalize.messageFormatter('hello');
 
             // Numbered variables using Array.
-            formatter([ 'Wolfgang', 'Amadeus', 'Mozart' ]).should.equal('Hello, Wolfgang Amadeus Mozart');
+            formatter(['Wolfgang', 'Amadeus', 'Mozart']).should.equal('Hello, Wolfgang Amadeus Mozart');
             // > "Hello, Wolfgang Amadeus Mozart"
 
             // Numbered variables using function arguments.
-            formatter( 'Wolfgang', 'Amadeus', 'Mozart' ).should.equal('Hello, Wolfgang Amadeus Mozart');
+            formatter('Wolfgang', 'Amadeus', 'Mozart').should.equal('Hello, Wolfgang Amadeus Mozart');
             // > "Hello, Wolfgang Amadeus Mozart"
 
             // Named variables using Object key-value pairs.
-            formatter = Globalize( 'en' ).messageFormatter( 'hey' );
+            formatter = Globalize('en').messageFormatter('hey');
             formatter({
                 first: 'Wolfgang',
                 middle: 'Amadeus',
@@ -88,16 +89,16 @@ describe('Globalization', function() {
         });
     });
 
-    describe('#check ClassDeclaration messages are correct', function() {
+    describe('#check ClassDeclaration messages are correct', function () {
 
-        it('check message in process()', function() {
+        it('check message in process()', function () {
             let formatter = Globalize('en').messageFormatter('classdeclaration-process-unrecmodelelem');
             formatter({
                 'type': 'Cow'
             }).should.equal('Unrecognised model element "Cow".');
         });
 
-        it('check message in getFields()', function() {
+        it('check message in getFields()', function () {
             let formatter = Globalize('en').messageFormatter('classdeclaration-getfield-notfindsupertype');
             formatter({
                 'type': 'Bar'
@@ -106,8 +107,8 @@ describe('Globalization', function() {
             // TODO (LG) functionally test this function
         });
 
-        describe('check messages in validate()', function() {
-            it('where identifier is not a property', function() {
+        describe('check messages in validate()', function () {
+            it('where identifier is not a property', function () {
                 let formatter = Globalize('en').messageFormatter('classdeclaration-validate-identifiernotproperty');
                 formatter({
                     'class': 'Cow',
@@ -123,12 +124,12 @@ describe('Globalization', function() {
                 invalidFile.should.not.be.null;
                 let invalidModelFile = ParserUtil.newModelFile(modelManager, invalidFile);
 
-                expect(function() {
+                expect(function () {
                     modelManager.addModelFile(invalidModelFile, fileName);
                 }).to.throw(IllegalModelException, 'Class "foo" is identified by field "fooID", but does not contain this property.');
             });
 
-            it('where identifier is not a string', function() {
+            it('where identifier is not a string', function () {
                 let formatter = Globalize.messageFormatter('classdeclaration-validate-identifiernotstring');
                 formatter({
                     'class': 'Cow',
@@ -144,23 +145,34 @@ describe('Globalization', function() {
                 invalidFile.should.not.be.null;
                 let invalidModelFile = ParserUtil.newModelFile(modelManager, invalidFile);
 
-                expect(function() {
+                expect(function () {
                     modelManager.addModelFile(invalidModelFile, fileName);
                 }).to.throw(IllegalModelException, 'Class "foo" is identified by field "fooID", but the type of the field is not "String".');
             });
         });
     });
 
-    describe('#check ModelFile messages are correct', function() {
-        it('check message in constructor()', function() {
+    describe('#check ModelFile messages are correct', function () {
+        it('check message in constructor()', function () {
             let formatter = Globalize.messageFormatter('modelfile-constructor-unrecmodelelem');
             formatter({
                 'type': 'Person',
             }).should.equal('Unrecognised model element "Person".');
 
-            // TODO (LG) functionally test this function
+            const modelManager = new ModelManager();
+            const ast = {
+                namespace: 'org.acme',
+                declarations: [{
+                    $class: 'concerto.metamodel.UnknownThing',
+                    name: 'Foo'
+                }]
+            };
+
+            expect(function () {
+                new ModelFile(modelManager, ast);
+            }).to.throw(IllegalModelException, /Unrecognised model element "concerto.metamodel.UnknownThing"./);
         });
-        it('check message in resolveType()', function() {
+        it('check message in resolveType()', function () {
             let formatter = Globalize.messageFormatter('modelfile-resolvetype-undecltype');
             formatter({
                 'type': 'Person',
@@ -176,12 +188,12 @@ describe('Globalization', function() {
             invalidFile.should.not.be.null;
             let invalidModelFile = ParserUtil.newModelFile(modelManager, invalidFile);
 
-            expect(function() {
+            expect(function () {
                 modelManager.addModelFile(invalidModelFile, fileName);
             }).to.throw(IllegalModelException, 'Undeclared type "Person" in "property Bar.foo.fooProperty"');
         });
 
-        it('check message in resolveImport()', function() {
+        it('check message in resolveImport()', function () {
             let formatter = Globalize.messageFormatter('modelfile-resolveimport-failfindimp');
             formatter({
                 'type': 'Type',
@@ -192,8 +204,8 @@ describe('Globalization', function() {
         });
     });
 
-    describe('#check TransactionDeclaration messages are correct', function() {
-        it('check message in getIdentifierFieldName()', function() {
+    describe('#check TransactionDeclaration messages are correct', function () {
+        it('check message in getIdentifierFieldName()', function () {
             let formatter = Globalize.messageFormatter('transactiondeclaration-getidentifierfieldname-noidentifyingfield');
             formatter().should.equal('Transactions do not have an identifying field.');
 
@@ -201,9 +213,9 @@ describe('Globalization', function() {
         });
     });
 
-    describe.skip('#check Factory messages are correct', function() {
-        describe('check messages in newResource()', function() {
-            it('where namespace hasn\'t been registered in the model manager', function() {
+    describe.skip('#check Factory messages are correct', function () {
+        describe('check messages in newResource()', function () {
+            it('where namespace hasn\'t been registered in the model manager', function () {
                 let formatter = Globalize.messageFormatter('factory-newinstance-notregisteredwithmm');
                 formatter({
                     'namespace': 'foo'
@@ -212,13 +224,13 @@ describe('Globalization', function() {
                 const modelManager = new ModelManager();
                 Util.addComposerModel(modelManager);
 
-                expect(function() {
+                expect(function () {
                     let factory = new Factory(modelManager);
                     factory.newResource('foo', 'bar', '123');
                 }).to.throw(Error, 'ModelFile for namespace foo has not been registered with the ModelManager');
             });
 
-            it('where a type is\'t declared in a namespace', function() {
+            it('where a type is\'t declared in a namespace', function () {
                 let formatter = Globalize.messageFormatter('factory-newinstance-typenotdeclaredinns');
                 formatter({
                     namespace: 'foo',
@@ -231,17 +243,17 @@ describe('Globalization', function() {
                 let fileName = './test/composer/models/factory/newinstance/foo-typenotdeclaredinns.cto';
                 let file = fs.readFileSync(fileName, 'utf8');
                 file.should.not.be.null;
-                modelManager.addCTOModel(file,fileName);
+                modelManager.addCTOModel(file, fileName);
 
-                expect(function() {
+                expect(function () {
                     let factory = new Factory(modelManager);
                     factory.newResource('foo', 'bar', '123');
                 }).to.throw(Error, 'Type bar is not declared in namespace foo');
             });
         });
 
-        describe('check messages in newResource()', function() {
-            it('where namespace hasn\'t been registered in the model manager', function() {
+        describe('check messages in newResource()', function () {
+            it('where namespace hasn\'t been registered in the model manager', function () {
                 let formatter = Globalize.messageFormatter('factory-newinstance-notregisteredwithmm');
                 formatter({
                     'namespace': 'foo'
@@ -249,13 +261,13 @@ describe('Globalization', function() {
 
                 const modelManager = new ModelManager();
 
-                expect(function() {
+                expect(function () {
                     let factory = new Factory(modelManager);
                     factory.newResource('foo', 'bar', '123');
                 }).to.throw(Error, 'ModelFile for namespace foo has not been registered with the ModelManager');
             });
 
-            it('where a type is\'t declared in a namespace', function() {
+            it('where a type is\'t declared in a namespace', function () {
                 let formatter = Globalize.messageFormatter('factory-newinstance-typenotdeclaredinns');
                 formatter({
                     namespace: 'foo',
@@ -268,17 +280,17 @@ describe('Globalization', function() {
                 let fileName = './test/composer/models/factory/newinstance/foo-typenotdeclaredinns.cto';
                 let file = fs.readFileSync(fileName, 'utf8');
                 file.should.not.be.null;
-                modelManager.addCTOModel(file,fileName);
+                modelManager.addCTOModel(file, fileName);
 
-                expect(function() {
+                expect(function () {
                     let factory = new Factory(modelManager);
                     factory.newResource('foo', 'bar', '123');
                 }).to.throw(Error, 'Type bar is not declared in namespace foo');
             });
         });
 
-        describe('check messages in newRelationship()', function() {
-            it('where namespace hasn\'t been registered in the model manager', function() {
+        describe('check messages in newRelationship()', function () {
+            it('where namespace hasn\'t been registered in the model manager', function () {
                 let formatter = Globalize.messageFormatter('factory-newrelationship-notregisteredwithmm');
                 formatter({
                     'namespace': 'foo'
@@ -287,13 +299,13 @@ describe('Globalization', function() {
                 const modelManager = new ModelManager();
                 Util.addComposerModel(modelManager);
 
-                expect(function() {
+                expect(function () {
                     let factory = new Factory(modelManager);
                     factory.newRelationship('foo', 'bar', '123');
                 }).to.throw(Error, 'ModelFile for namespace foo has not been registered with the ModelManager');
             });
 
-            it('where a type is\'t declared in a namespace', function() {
+            it('where a type is\'t declared in a namespace', function () {
                 let formatter = Globalize.messageFormatter('factory-newrelationship-typenotdeclaredinns');
                 formatter({
                     namespace: 'foo',
@@ -306,9 +318,9 @@ describe('Globalization', function() {
                 let fileName = './test/composer/models/factory/newrelationship/foo-typenotdeclaredinns.cto';
                 let file = fs.readFileSync(fileName, 'utf8');
                 file.should.not.be.null;
-                modelManager.addCTOModel(file,fileName);
+                modelManager.addCTOModel(file, fileName);
 
-                expect(function() {
+                expect(function () {
                     let factory = new Factory(modelManager);
                     factory.newRelationship('foo', 'bar', 123);
                 }).to.throw(Error, 'Type bar is not declared in namespace foo');
@@ -316,9 +328,9 @@ describe('Globalization', function() {
         });
     });
 
-    describe('ModelManager messages', function() {
-        describe('check messages in resolveType()', function() {
-            it('when no namespace is registered for type', function(){
+    describe('ModelManager messages', function () {
+        describe('check messages in resolveType()', function () {
+            it('when no namespace is registered for type', function () {
                 let formatter = Globalize.messageFormatter('modelmanager-resolvetype-nonsfortype');
                 formatter({
                     type: 'bar',
@@ -328,12 +340,12 @@ describe('Globalization', function() {
                 const modelManager = new ModelManager();
                 Util.addComposerModel(modelManager);
 
-                expect(function() {
+                expect(function () {
                     modelManager.resolveType('foo', 'bar');
                 }).to.throw(IllegalModelException, 'No registered namespace for type "bar" in "foo".');
             });
 
-            it('when a type doesn\'t exist in a namespace for a context', function() {
+            it('when a type doesn\'t exist in a namespace for a context', function () {
                 let formatter = Globalize.messageFormatter('modelmanager-resolvetype-notypeinnsforcontext');
                 formatter({
                     namespace: 'baz',
@@ -345,8 +357,8 @@ describe('Globalization', function() {
             });
         });
 
-        describe('#getType()', function() {
-            it('Namespace does not exist', function() {
+        describe('#getType()', function () {
+            it('Namespace does not exist', function () {
                 let formatter = Globalize.messageFormatter('modelmanager-gettype-noregisteredns');
                 formatter({
                     type: 'TYPE'
@@ -354,12 +366,12 @@ describe('Globalization', function() {
 
                 const modelManager = new ModelManager();
 
-                expect(function() {
+                expect(function () {
                     modelManager.getType('NAMESPACE.TYPE');
                 }).to.throw(Error, 'Namespace is not defined for type "NAMESPACE.TYPE".');
             });
 
-            it('check type exists in namespace', function() {
+            it('check type exists in namespace', function () {
                 let formatter = Globalize.messageFormatter('modelmanager-gettype-notypeinns');
                 formatter({
                     type: 'TYPE',
@@ -371,37 +383,37 @@ describe('Globalization', function() {
         });
     });
 
-    describe('#check Serializer messages are correct', function() {
-        it('check message in constructor()', function() {
+    describe('#check Serializer messages are correct', function () {
+        it('check message in constructor()', function () {
             let formatter = Globalize.messageFormatter('serializer-constructor-factorynull');
             formatter().should.equal('"Factory" cannot be "null".');
 
             const modelManager = new ModelManager();
             Util.addComposerModel(modelManager);
-            expect(function() {
+            expect(function () {
                 new Serializer(null, modelManager);
             }).to.throw(Error, '"Factory" cannot be "null".');
         });
 
-        it('check message in toJSON()', function() {
+        it('check message in toJSON()', function () {
             let formatter = Globalize.messageFormatter('serializer-tojson-notcobject');
             formatter().should.equal('"Serializer.toJSON" only accepts "Concept", "Event", "Asset", "Participant" or "Transaction".');
 
             const modelManager = new ModelManager();
             Util.addComposerModel(modelManager);
-            expect(function() {
+            expect(function () {
                 let serializer = new Serializer(true, modelManager);
                 serializer.toJSON({});
             }).to.throw(Error, '"Serializer.toJSON" only accepts "Concept", "Event", "Asset", "Participant" or "Transaction".');
         });
     });
 
-    describe('#check ModelUtil messages are correct', function() {
-        it('check message in getNamespace()', function() {
+    describe('#check ModelUtil messages are correct', function () {
+        it('check message in getNamespace()', function () {
             let formatter = Globalize.messageFormatter('modelutil-getnamespace-nofnq');
             formatter().should.equal('FQN is invalid.');
 
-            expect(function() {
+            expect(function () {
                 ModelUtil.getNamespace();
             }).to.throw(Error, 'FQN is invalid.');
         });


### PR DESCRIPTION
#### Fixes: N/A
### Problem:
The `ModelFile` constructor logic for handling unrecognized model elements was not covered by unit tests, leaving a potential gap in error handling verification. A `TODO` comment in `test/composer/i18n.js` requested functional testing for this case, but it remained unimplemented.

### Summary
This PR adds a unit test to `concerto-core/test/composer/i18n.js` to verify that the `ModelFile.js` constructor correctly throws an `IllegalModelException` when encountering an unrecognized model element.

This change fulfills a longstanding `TODO` in the test file and improves functional coverage for error handling in the introspection module.

### Changes
- Replaced `// TODO (LG) functionally test this function` with an actual test case.
- Verified that providing an invalid `declarations` array (with an unknown class type) triggers the expected error message: `Unrecognised model element "..."`.

### Verification
- **Test:** Added `check message in constructor()` case.
- **Status:** All tests passed locally (`npm test`).
