### PR TITLE
fix: replace console.warn() with debug library in JSONPopulator

### DIFF
--- a/packages/concerto-core/src/serializer/jsonpopulator.ts
+++ b/packages/concerto-core/src/serializer/jsonpopulator.ts
@@ -14,6 +14,7 @@
 
 'use strict';
 
+const debug = require('debug')('concerto:JSONPopulator');
 const { TypedStack } = require('@accordproject/concerto-util');
 const Relationship = require('../model/relationship');
 const Util = require('@accordproject/concerto-util').NullUtil;
@@ -137,7 +138,7 @@ class JSONPopulator {
         this.strictQualifiedDateTimes = strictQualifiedDateTimes !== undefined ? strictQualifiedDateTimes : true;
 
         if (process.env.TZ){
-            console.warn(`Environment variable 'TZ' is set to '${process.env.TZ}', this can cause unexpected behaviour when using unqualified date time formats.`);
+            debug(`Environment variable 'TZ' is set to '${process.env.TZ}', this can cause unexpected behaviour when using unqualified date time formats.`);
         }
     }
 


### PR DESCRIPTION
**Fixes:** N/A
### Summary:
Replace `console.warn()` call with the debug library in `concerto-core`, following the same pattern established in #1125 (HTTPFileLoader).

This is a cleaner version of #1133, targeting the v4.0.0 branch from the start.

### Changes:
- `jsonpopulator.js`: Add `debug('concerto:JSONPopulator')` import and replace `console.warn` for TZ environment variable warnings

**Why these changes:**
`console.warn()` pollutes console output in production environments, CI pipelines, etc. The debug library allows users to opt-in to these warnings via `DEBUG=concerto:*` when needed.

**Difference from main branch PR (#1133):**
The v4.0.0 branch only requires changes to `jsonpopulator.js`, as the `basemodelmanager.js` console.warn issue from the main branch PR doesn't exist in v4.0.0.

**Testing:**
All tests pass locally.

---
_Supersedes #1133 with cleaner git history_