### PR TITLE
refactor(concerto-core): optimize mapClassToType and fix JSDoc formatting.

### DIFF
--- a/packages/concerto-core/lib/dcsconverter.js
+++ b/packages/concerto-core/lib/dcsconverter.js
@@ -18,6 +18,12 @@ const yaml = require('yaml');
 const ModelUtil  = require('./modelutil');
 const { MetaModelNamespace } = require('@accordproject/concerto-metamodel');
 
+const mapClassToType = {
+        [`${MetaModelNamespace}.DecoratorString`]: 'String',
+        [`${MetaModelNamespace}.DecoratorNumber`]: 'Number',
+        [`${MetaModelNamespace}.DecoratorBoolean`]: 'Boolean',
+    };
+
 /**
  * handles the target field of a command
  * @param {object} target the value of target
@@ -47,11 +53,6 @@ function handleTarget(target){
  * @private
  */
 function handleArguments(argument){
-    const mapClassToType = {
-        [`${MetaModelNamespace}.DecoratorString`]: 'String',
-        [`${MetaModelNamespace}.DecoratorNumber`]: 'Number',
-        [`${MetaModelNamespace}.DecoratorBoolean`]: 'Boolean',
-    };
     if (argument.$class.endsWith('TypeReference')) {
         return {
             typeReference: {
@@ -123,7 +124,7 @@ function jsonToYaml(dcsJson){
 /**
  * handles each argument of the decorator
  * converts simplified argument objects back to full JSON representation
- * @param {string} MetaModelNamespace - the metamodel namespace
+ * @param {string} MetaModelNamespace - the namespace for the metamodel
  * @param {object} argument - the simplified argument object
  * @param {string} [argument.type] - the argument type for primitive values
  * @param {*} [argument.value] - the argument value


### PR DESCRIPTION
refactor(concerto-core): optimize mapClassToType and fix JSDoc formatting.

<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->

# Closes #<CORRESPONDING ISSUE NUMBER>
<!--- Provide an overall summary of the pull request -->

### Changes
Moved the mapClassToType object from handleArguments to the top-level scope of dcsconverter.js to prevent unnecessary re-allocation.
Updated JSDoc for the restoreArguments function to include a consistent description and hyphen for the MetaModelNamespace parameter.

### Flags
Concern: This is a minor refactor and documentation update submitted as part of a GSoC-related academic task.

No logic changes were made to the JSON-to-YAML conversion process.

### Screenshots or Video
<!--- Provide an easily accessible demonstration of the changes, if applicable -->

### Related Issues
- Issue: None (This is a minor improvement).
- Pull Request: N/A

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [x] Extend the documentation, if necessary
- [x] Merging to `main` from `fork:branchname`
