### PR TITLE
fix: correct typographical errors in comments

### DIFF
--- a/packages/concerto-core/lib/model/relationship.js
+++ b/packages/concerto-core/lib/model/relationship.js
@@ -79,7 +79,7 @@ class Relationship extends Identifiable {
     }
 
     /**
-     * Contructs a Relationship instance from a URI representation (created using toURI).
+     * Constructs a Relationship instance from a URI representation (created using toURI).
      * @param {ModelManager} modelManager - the model manager to bind the relationship to
      * @param {String} uriAsString - the URI as a string, generated using Identifiable.toURI()
      * @param {String} [defaultNamespace] - default namespace to use for backwards compatibility

--- a/packages/concerto-core/lib/model/typed.js
+++ b/packages/concerto-core/lib/model/typed.js
@@ -189,7 +189,7 @@ class Typed {
         if (classDeclaration.getFullyQualifiedName() === fqt) {
             return true;
         }
-        // Now walk the class hierachy looking to see if it's an instance of the specified type.
+        // Now walk the class hierarchy looking to see if it's an instance of the specified type.
         let superTypeDeclaration = classDeclaration.getSuperTypeDeclaration();
         while (superTypeDeclaration) {
             if (superTypeDeclaration.getFullyQualifiedName() === fqt) {

--- a/packages/concerto-core/test/introspect/assetdeclaration.js
+++ b/packages/concerto-core/test/introspect/assetdeclaration.js
@@ -106,7 +106,7 @@ describe('AssetDeclaration', () => {
             }).should.throw(/more than one field named/);
         });
 
-        it('should throw when field has been duplicated in the same class hierachy', () => {
+        it('should throw when field has been duplicated in the same class hierarchy', () => {
             let asset = loadLastAssetDeclaration('test/data/parser/assetdeclaration.dupecomp.cto');
             (() => {
                 asset.validate();

--- a/packages/concerto-util/lib/warning.js
+++ b/packages/concerto-util/lib/warning.js
@@ -25,7 +25,7 @@ let isWarningEmitted = false;
  * @param {string} detail - detail of the deprecation warning
  */
 function printDeprecationWarning(message, type, code, detail) {
-    // This will get pollyfilled in the webpack.config.js as process.emitWarning is not available in the browser
+    // This will get polyfilled in the webpack.config.js as process.emitWarning is not available in the browser
     const customEmitWarning = process.emitWarning;
     if (!isWarningEmitted) {
         isWarningEmitted = true;


### PR DESCRIPTION
Closes #1108

### Changes
- Corrected "Contructs" to "Constructs"
- Corrected "hierachy" to "hierarchy"
- Corrected "pollyfilled" to "polyfilled"

### Flags
- No functional or logic changes
- Comment and documentation updates only

### Screenshots or Video
N/A

### Related Issues
- Issue #1108

### Author Checklist
- [x] Ensure you provide a DCO sign-off
- [x] Vital features and changes captured in unit and/or integration tests (N/A - comment only change)
- [x] Commits messages follow AP format
- [x] Extend the documentation, if necessary (N/A)
- [x] Merging to `main` from `fork:fix-typos-1108`