### PR TITLE
fix: Fix spelling mistakes in code comments

### DIFF
--- a/packages/concerto-core/types/lib/model/relationship.d.ts
+++ b/packages/concerto-core/types/lib/model/relationship.d.ts
@@ -14,11 +14,11 @@ export = Relationship;
  */
 declare class Relationship extends Identifiable {
     /**
-     * Contructs a Relationship instance from a URI representation (created using toURI).
+     * Constructs a Relationship instance from a URI representation (created using toURI).
      * @param {ModelManager} modelManager - the model manager to bind the relationship to
      * @param {String} uriAsString - the URI as a string, generated using Identifiable.toURI()
-     * @param {String} [defaultNamespace] - default namespace to use for backwards compatability
-     * @param {String} [defaultType] - default type to use for backwards compatability
+     * @param {String} [defaultNamespace] - default namespace to use for backwards compatibility
+     * @param {String} [defaultType] - default type to use for backwards compatibility
      * @return {Relationship} the relationship
      */
     static fromURI(modelManager: ModelManager, uriAsString: string, defaultNamespace?: string, defaultType?: string): Relationship;

--- a/packages/concerto-core/types/lib/model/typed.d.ts
+++ b/packages/concerto-core/types/lib/model/typed.d.ts
@@ -88,7 +88,7 @@ declare class Typed {
      */
     instanceOf(fqt: string): boolean;
     /**
-     * Overriden to prevent people accidentally converting a resource to JSON
+     * Overridden to prevent people accidentally converting a resource to JSON
      * without using the Serializer.
      * @protected
      */

--- a/packages/concerto-core/types/lib/serializer/objectvalidator.d.ts
+++ b/packages/concerto-core/types/lib/serializer/objectvalidator.d.ts
@@ -68,7 +68,7 @@ declare class ObjectValidator {
     private static reportAbstractClass;
     /**
      * Throw a validation exception for an abstract class
-     * @param {string} resourceId - the id of the resouce being validated
+     * @param {string} resourceId - the id of the resource being validated
      * @param {string} propertyName - the name of the property that is not declared
      * @param {string} fullyQualifiedTypeName - the fully qualified type being validated
      * @throws {ValidationException} the validation exception
@@ -77,7 +77,7 @@ declare class ObjectValidator {
     private static reportUndeclaredField;
     /**
      * Throw a validation exception for an invalid field assignment
-     * @param {string} resourceId - the id of the resouce being validated
+     * @param {string} resourceId - the id of the resource being validated
      * @param {string} propName - the name of the property that is being assigned
      * @param {*} obj - the Field
      * @param {Field} field - the Field

--- a/packages/concerto-core/types/lib/serializer/resourcevalidator.d.ts
+++ b/packages/concerto-core/types/lib/serializer/resourcevalidator.d.ts
@@ -75,7 +75,7 @@ declare class ResourceValidator {
     private static reportAbstractClass;
     /**
      * Throw a validation exception for an abstract class
-     * @param {string} resourceId - the id of the resouce being validated
+     * @param {string} resourceId - the id of the resource being validated
      * @param {string} propertyName - the name of the property that is not declared
      * @param {string} fullyQualifiedTypeName - the fully qualified type being validated
      * @throws {ValidationException} the validation exception
@@ -84,7 +84,7 @@ declare class ResourceValidator {
     private static reportUndeclaredField;
     /**
      * Throw a validation exception for an invalid field assignment
-     * @param {string} resourceId - the id of the resouce being validated
+     * @param {string} resourceId - the id of the resource being validated
      * @param {string} propName - the name of the property that is being assigned
      * @param {*} obj - the Field
      * @param {Field} field - the Field


### PR DESCRIPTION
# Closes #1148

Fixed spelling mistakes found in JSDoc comments across 4 `.d.ts` type 
declaration files in `packages/concerto-core/types/`. JSDoc comments in 
`.d.ts` files surface directly in IDE tooltips and autocomplete hints for 
library consumers, so these typos affect the developer experience of anyone 
using this package.

### Changes
- `lib/model/relationship.d.ts`: `Contructs` → `Constructs`
- `lib/model/relationship.d.ts`: `compatability` → `compatibility` (×2)
- `lib/model/typed.d.ts`: `Overriden` → `Overridden`
- `lib/serializer/objectvalidator.d.ts`: `resouce` → `resource` (×2)
- `lib/serializer/resourcevalidator.d.ts`: `resouce` → `resource` (×2)

### Flags
- Comment/documentation-only changes — zero functional impact
- No tests required as no logic was modified
- **Note:** These `.d.ts` files may be generated from source files that 
  contain the same typos. The same fixes may need to be applied to the 
  original source to prevent the typos from returning on next type generation.

### Screenshots or Video
N/A — comment-only changes

### Related Issues
- Issue #1148

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [x] Merging to `main` from `fork:branchname`