### PR TITLE
chore(ci): move lockfile-lint and syncpack from preinstall script

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,7 @@ jobs:
           cache: 'npm'
 
       - run: npm ci
+      - run: npm run lint:package
       - run: npm run build --if-present
       - env:
           NODE_OPTIONS: "--max_old_space_size=4096"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,6 +30,7 @@ jobs:
       - run: npm install -g npm@latest
 
       - run: npm ci
+      - run: npm run lint:package
       - run: npm run build --if-present
 
       - name: tag

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "lint:deps": "syncpack lint",
     "lint:deps:fix": "syncpack fix",
     "lint:lockfile": "lockfile-lint --path package-lock.json --type npm --allowed-hosts npm --validate-https",
-    "preinstall": "npm run lint:lockfile && npm run lint:deps",
+    "lint:package": "npm run lint:lockfile && npm run lint:deps",
     "pretest": "npm run licchk",
     "test": "npm test -ws"
   },


### PR DESCRIPTION
Following https://github.com/accordproject/concerto-codegen/commit/450ac33ea83ca26ab5fd979c6532c7a813edfea7 this moves `lockfile-lint` and `syncpack` commands away from preinstall and into a separate command that gets invoked after installs. That way it won't block downstream installs of the packages.


### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [ ] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ ] Merging to `main` from `fork:branchname`
