### PR TITLE
ci: add timeout-minutes to workflows #1103

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,8 @@ concurrency:
 jobs:
   build:
     name: Unit Tests
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30  # <--- Added timeout here
 
     strategy:
       matrix:
@@ -26,8 +28,6 @@ jobs:
           - windows-latest
           - macos-latest
           - ubuntu-latest
-
-    runs-on: ${{ matrix.os }}
 
     steps:
       - name: git checkout
@@ -67,10 +67,10 @@ jobs:
   notify:
     needs:
       - build
-
     name: Code Coverage
     if: ${{ success() }}
     runs-on: ubuntu-latest
+    timeout-minutes: 30  # <--- Added timeout here
 
     steps:
       - name: Coveralls Finished
@@ -79,4 +79,3 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           parallel-finished: true
           fail-on-error: false
-

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -32,6 +32,7 @@ jobs:
       actions: read
       contents: read
       security-events: write
+    timeout-minutes: 30  # <--- Added timeout here
 
     strategy:
       fail-fast: false

--- a/.github/workflows/conformance-test.yml
+++ b/.github/workflows/conformance-test.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   conformance:
     runs-on: ubuntu-latest
+    timeout-minutes: 30  # <--- Added timeout here
 
     steps:
       - name: Checkout Target Project
@@ -48,4 +49,3 @@ jobs:
           MODELFILE_PATH: ../../../../../../packages/concerto-core/index.js
           MODELMANAGER_PATH: ../../../../../../packages/concerto-core/index.js
         run: npm test
-        

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,7 @@ jobs:
     if: ${{ github.repository_owner == 'accordproject' }}
     runs-on: ubuntu-latest
     environment: production
+    timeout-minutes: 30  # <--- Added timeout here
 
     steps:
       - name: git checkout


### PR DESCRIPTION
This PR addresses issue #1103 by adding a 30-minute timeout to all jobs in the core workflows: build, conformance-test, codeql-analysis, and publish. This ensures that hung jobs do not consume unnecessary CI resources. This contribution is part of my GSoC 2026 application for the "Testing for Code Generation Targets" project.