### PR TITLE
fix(concerto-cto): declare path-browserify as a runtime dependency

### DIFF
--- a/packages/concerto-cto/package.json
+++ b/packages/concerto-cto/package.json
@@ -58,7 +58,6 @@
     "mocha": "^10.8.2",
     "npm-run-all": "4.1.5",
     "nyc": "15.1.0",
-    "path-browserify": "^1.0.1",
     "peggy": "2.0.1",
     "rimraf": "3.0.2",
     "sinon": "12.0.0",
@@ -73,6 +72,7 @@
     "@accordproject/concerto-metamodel": "^4.0.0-alpha.0",
     "@accordproject/concerto-util": "4.0.0",
     "acorn": "^8.15.0",
+    "path-browserify": "^1.0.1",
     "schema-utils": "^4.3.3"
   },
   "browserslist": "> 0.25%, not dead",


### PR DESCRIPTION
## Summary

`@accordproject/concerto-cto` compiles `src/external.ts` into `dist/`, and `external.ts` has a top-level `import * as pathBrowserify from 'path-browserify'`. But `packages/concerto-cto/package.json` lists `path-browserify` under `devDependencies`, so downstream consumers who `npm install @accordproject/concerto-cto` in a fresh project get `MODULE_NOT_FOUND` when the compiled code is loaded.

This PR moves `"path-browserify": "^1.0.1"` one section up — from `devDependencies` to `dependencies`. That's the entire diff.

## Why the bug hides in the dev loop

Two reasons the existing test suite doesn't catch this:

1. **npm workspaces hoisting.** `path-browserify` is declared at the root `package.json` *and* in `packages/concerto-cto/package.json` (devDeps). Inside the monorepo, npm hoists it to the root `node_modules/`, so local `mocha` runs resolve it fine. Downstream consumers don't inherit that hoisting.
2. **Browser build has its own shim.** `packages/concerto-cto/webpack.config.js` has an explicit `resolve.fallback.path: require.resolve('path-browserify')` for the bundled browser target. The Node entry (`main: dist/index.js`) has no equivalent shim, so it relies on npm actually installing the package.

## Reproducer

```bash
mkdir repro && cd repro
npm init -y
npm install @accordproject/concerto-cto
node -e "require('@accordproject/concerto-cto')"
# Error: Cannot find module 'path-browserify'
```

## What changed

- **`packages/concerto-cto/package.json`**: moved `"path-browserify": "^1.0.1"` from `devDependencies` to `dependencies`. One line moved, alphabetical ordering preserved in both sections.
- **`@types/path-browserify` stays in `devDependencies`** — `@types/*` packages are correctly dev-only since TypeScript declarations are stripped before publish.
- No source changes, no test changes.

## Test plan

- [x] `git diff` is one file, +1/-1.
- [x] `npm install` at repo root still resolves workspaces cleanly (path-browserify now satisfied by the `dependencies` declaration, same version, same file).
- [x] Existing monorepo tests run green (no behavioral change — same import, same dependency, different package.json section).

## Likely origin

Regression from #1005 (`feat(concerto-cto): Migrate package to TypeScript`, merged 2025-04-01). The TS migration introduced the top-level `import * as pathBrowserify from 'path-browserify'` style without moving the dep into `dependencies`.

Closes #1188.

Signed-off-by: Yuzhou Wang <wusiwyzb5@gmail.com>