### PR TITLE
fix(*): mark optional parameters

### DIFF
--- a/packages/concerto-core/src/astmodelmanager.ts
+++ b/packages/concerto-core/src/astmodelmanager.ts
@@ -44,7 +44,7 @@ class AstModelManager extends BaseModelManager {
      * @constructor
      * @param {object} [options] - Serializer options
      */
-    constructor(options) {
+    constructor(options?) {
         super(options, astProcessFile);
     }
 }

--- a/packages/concerto-core/src/basemodelmanager.ts
+++ b/packages/concerto-core/src/basemodelmanager.ts
@@ -179,7 +179,7 @@ class BaseModelManager {
      * @param {string} [fileName] - a file name to associate with the model file
      * @throws {IllegalModelException}
      */
-    validateModelFile(modelFile, fileName) {
+    validateModelFile(modelFile, fileName?) {
         if (typeof modelFile === 'string') {
             const { ast } = this.processFile(fileName, modelFile);
             let m = new ModelFile(this, ast, modelFile, fileName);
@@ -313,7 +313,7 @@ class BaseModelManager {
      * @throws {IllegalModelException}
      * @return {ModelFile} The newly added model file (internal).
      */
-    addModel(modelInput, cto, fileName, disableValidation) {
+    addModel(modelInput, cto?, fileName?, disableValidation?) {
         const NAME = 'addModel';
         debug(NAME, 'addModel', modelInput, fileName);
 
@@ -337,7 +337,7 @@ class BaseModelManager {
      * @throws {IllegalModelException}
      * @returns {Object} The newly added model file (internal).
      */
-    updateModelFile(modelFile, fileName, disableValidation) {
+    updateModelFile(modelFile, fileName?, disableValidation?) {
         const NAME = 'updateModelFile';
         debug(NAME, 'updateModelFile', modelFile, fileName);
         if (typeof modelFile === 'string') {
@@ -792,7 +792,7 @@ class BaseModelManager {
      * @param {object} [options] - options for the from ast method
      * @param {object} [options.disableValidation] - option to disable metamodel validation and just fetch the models, to be used only if the metamodel is already validated
      */
-    fromAst(ast, options) {
+    fromAst(ast, options?) {
         this.clearModelFiles();
         ast.models.forEach( model => {
             if(!EXCLUDE_NS.includes(model.namespace)) { // excludes the internal namespaces, already added
@@ -811,7 +811,7 @@ class BaseModelManager {
      * @param {boolean} [includeConcertoNamespaces] - whether to include the concerto namespaces
      * @returns {*} the metamodel
      */
-    getAst(resolve,includeConcertoNamespaces) {
+    getAst(resolve?,includeConcertoNamespaces?) {
         const result = {
             $class: `${MetaModelNamespace}.Models`,
             models: [] as any[],

--- a/packages/concerto-core/src/decoratorextractor.ts
+++ b/packages/concerto-core/src/decoratorextractor.ts
@@ -51,7 +51,7 @@ class DecoratorExtractor {
      * @param {int} [action=DecoratorExtractor.Action.EXTRACT_ALL]  - the action to be performed
      * @param {object} [options] - decorator extractor options
      */
-    constructor(removeDecoratorsFromModel, locale, dcs_version, sourceModelAst, action = DecoratorExtractor.Action.EXTRACT_ALL, options) {
+    constructor(removeDecoratorsFromModel, locale, dcs_version, sourceModelAst, action = DecoratorExtractor.Action.EXTRACT_ALL, options?) {
         this.extractionDictionary = {};
         this.removeDecoratorsFromModel = removeDecoratorsFromModel;
         this.locale = locale;

--- a/packages/concerto-core/src/decoratormanager.ts
+++ b/packages/concerto-core/src/decoratormanager.ts
@@ -380,7 +380,7 @@ class DecoratorManager {
      * @param {boolean} [options.disableMetamodelValidation] - flag to disable metamodel validation, only use if you are sure that the models and decorators are already validated
      * @returns {ModelManager} a new model manager with the decorations applied
      */
-    static decorateModels(modelManager, decoratorCommandSet, options) {
+    static decorateModels(modelManager, decoratorCommandSet, options?) {
         if (!decoratorCommandSet || decoratorCommandSet?.length === 0) {
             return modelManager;
         }

--- a/packages/concerto-core/src/introspect/modelfile.ts
+++ b/packages/concerto-core/src/introspect/modelfile.ts
@@ -64,7 +64,7 @@ class ModelFile extends Decorated {
      * @param {string} [fileName] - The optional filename for this modelfile
      * @throws {IllegalModelException}
      */
-    constructor(modelManager, ast, definitions, fileName) {
+    constructor(modelManager, ast, definitions?, fileName?) {
         super(ast);
         this.modelManager = modelManager;
         this.external = false;

--- a/packages/concerto-core/src/serializer.ts
+++ b/packages/concerto-core/src/serializer.ts
@@ -46,8 +46,8 @@ if (global === undefined) {
  * @memberof module:concerto-core
  */
 class Serializer {
-    factory: any;        
-    modelManager: any;   
+    factory: any;
+    modelManager: any;
     defaultOptions: any;
     /**
      * Create a Serializer.
@@ -55,7 +55,7 @@ class Serializer {
      * @param {ModelManager} modelManager - The ModelManager to use for validation etc.
      * @param {object} [options] - Serializer options
      */
-    constructor(factory, modelManager, options) {
+    constructor(factory, modelManager, options?) {
         if(!factory) {
             throw new Error(Globalize.formatMessage('serializer-constructor-factorynull'));
         } else if(!modelManager) {
@@ -99,7 +99,7 @@ class Serializer {
      * @throws {Error} - throws an exception if resource is not an instance of
      * Resource or fails validation.
      */
-    toJSON(resource, options) {
+    toJSON(resource, options?) {
         // correct instance type
         if(!(resource instanceof Typed)) {
             throw new Error(Globalize.formatMessage('serializer-tojson-notcobject'));
@@ -153,7 +153,7 @@ class Serializer {
      * @param {boolean} [options.strictQualifiedDateTimes] - Only allow fully-qualified date-times with offsets.
      * @return {Resource} The new populated resource
      */
-    fromJSON(jsonObject, options) {
+    fromJSON(jsonObject, options?) {
         // set default options
         options = options ? Object.assign({}, this.defaultOptions, options) : this.defaultOptions;
 


### PR DESCRIPTION
<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #1192 
Marks documented optional parameters with `?` modifiers. Without these markers, users are forced to pass values for parameters that are intended to be optional.


### Screenshots or Video
<!--- Provide an easily accessible demonstration of the changes, if applicable -->

### Related Issues
- Issue #<NUMBER>
- Pull Request #<NUMBER>

### Author Checklist
- [ ] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [ ] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ ] Merging to `main` from `fork:branchname`
