### PR TITLE
fix(*): add v3 model compatibility support and disable adding, creating and updating unversioned models

### DIFF
--- a/packages/concerto-core/src/basemodelmanager.ts
+++ b/packages/concerto-core/src/basemodelmanager.ts
@@ -349,6 +349,9 @@ class BaseModelManager {
             if (!existing) {
                 throw new Error(`Model file for namespace ${modelFile.getNamespace()} not found`);
             }
+            if (!modelFile.getVersion()) {
+                throw new Error(`Cannot update with an unversioned namespace: ${modelFile.getNamespace()}`);
+            }
             if (!disableValidation) {
                 modelFile.validate();
             }
@@ -399,6 +402,9 @@ class BaseModelManager {
                     m = new ModelFile(this, ast, modelFile, fileName);
                 } else {
                     m = modelFile;
+                }
+                if (!m.getVersion()) {
+                    throw new Error(`Cannot add an unversioned namespace: ${m.getNamespace()}`);
                 }
                 if (!this.modelFiles[m.getNamespace()]) {
                     this.modelFiles[m.getNamespace()] = m;

--- a/packages/concerto-core/src/introspect/modelfile.ts
+++ b/packages/concerto-core/src/introspect/modelfile.ts
@@ -718,6 +718,11 @@ class ModelFile extends Decorated {
         this.namespace = ast.namespace;
         this.version = nsInfo.version;
 
+        // In v4, all non-system models must declare a namespace version (e.g., @1.0.0)
+        if (!this.version && !this.isSystemModelFile()) {
+            throw new Error(`Cannot create a ModelFile with an unversioned namespace: ${ast.namespace}. All models must specify a version (e.g., @1.0.0).`);
+        }
+
         // Make sure to clone imports since we will add built-in imports
         const imports = ast.imports ? ast.imports.concat([]) : [];
 

--- a/packages/concerto-core/src/introspect/modelfile.ts
+++ b/packages/concerto-core/src/introspect/modelfile.ts
@@ -673,14 +673,13 @@ class ModelFile extends Decorated {
      * Models targeting an older major version are considered backward-compatible
      * with newer runtimes (e.g. a model declaring "^3.0.0" loads under v4).
      */
-isCompatibleVersion() {
+    isCompatibleVersion() {
         if (this.ast.concertoVersion) {
             if (semver.satisfies(packageJson.version, this.ast.concertoVersion, { includePrerelease: true })) {
                 this.concertoVersion = this.ast.concertoVersion;
             } else {
-                // Allow models that target an older major version to load under a newer runtime.
-                const minVersion = semver.minVersion(this.ast.concertoVersion);
-                if (minVersion && semver.major(minVersion) < semver.major(packageJson.version)) {
+                // Allow v3 models to load under newer runtimes
+                if (semver.minSatisfying(['3.0.0'], this.ast.concertoVersion)) {
                     this.concertoVersion = this.ast.concertoVersion;
                 } else {
                     throw new Error(`ModelFile expects Concerto version ${this.ast.concertoVersion} but this is ${packageJson.version}`);

--- a/packages/concerto-core/src/introspect/modelfile.ts
+++ b/packages/concerto-core/src/introspect/modelfile.ts
@@ -682,7 +682,7 @@ class ModelFile extends Decorated {
                 if (semver.minSatisfying(['3.0.0'], this.ast.concertoVersion)) {
                     this.concertoVersion = this.ast.concertoVersion;
                 } else {
-                    throw new Error(`ModelFile expects Concerto version ${this.ast.concertoVersion} but this is ${packageJson.version}`);
+                    throw new Error(`This version of Concerto supports a language version of v3.0.0 or greater, but this model is for ${this.ast.concertoVersion}`);
                 }
             }
         }

--- a/packages/concerto-core/src/introspect/modelfile.ts
+++ b/packages/concerto-core/src/introspect/modelfile.ts
@@ -669,14 +669,22 @@ class ModelFile extends Decorated {
     }
 
     /**
-     * Check whether this modelfile is compatible with the concerto version
+     * Check whether this modelfile is compatible with the concerto version.
+     * Models targeting an older major version are considered backward-compatible
+     * with newer runtimes (e.g. a model declaring "^3.0.0" loads under v4).
      */
 isCompatibleVersion() {
         if (this.ast.concertoVersion) {
             if (semver.satisfies(packageJson.version, this.ast.concertoVersion, { includePrerelease: true })) {
                 this.concertoVersion = this.ast.concertoVersion;
             } else {
-                throw new Error(`ModelFile expects Concerto version ${this.ast.concertoVersion} but this is ${packageJson.version}`);
+                // Allow models that target an older major version to load under a newer runtime.
+                const minVersion = semver.minVersion(this.ast.concertoVersion);
+                if (minVersion && semver.major(minVersion) < semver.major(packageJson.version)) {
+                    this.concertoVersion = this.ast.concertoVersion;
+                } else {
+                    throw new Error(`ModelFile expects Concerto version ${this.ast.concertoVersion} but this is ${packageJson.version}`);
+                }
             }
         }
     }

--- a/packages/concerto-core/test/composer/i18n.js
+++ b/packages/concerto-core/test/composer/i18n.js
@@ -161,7 +161,7 @@ describe('Globalization', function () {
 
             const modelManager = new ModelManager();
             const ast = {
-                namespace: 'org.acme',
+                namespace: 'org.acme@1.0.0',
                 declarations: [{
                     $class: 'concerto.metamodel.UnknownThing',
                     name: 'Foo'

--- a/packages/concerto-core/test/data/decorators/invalid-typeref.cto
+++ b/packages/concerto-core/test/data/decorators/invalid-typeref.cto
@@ -12,7 +12,7 @@
  * limitations under the License.
  */
 
-namespace org.acme
+namespace org.acme@1.0.0
 
 @category(Missing)
 asset Car identified by id {

--- a/packages/concerto-core/test/data/parser/classdeclaration.scalararray.cto
+++ b/packages/concerto-core/test/data/parser/classdeclaration.scalararray.cto
@@ -12,7 +12,7 @@
  * limitations under the License.
  */
 
-namespace com.testing
+namespace com.testing@1.0.0
 
 scalar SSN extends String default="000-00-0000" regex= /\d{3}-\d{2}-\d{4}/
 

--- a/packages/concerto-core/test/data/semver/personv3.cto
+++ b/packages/concerto-core/test/data/semver/personv3.cto
@@ -1,0 +1,11 @@
+concerto version "^3.0.0"
+
+namespace person@1.0.0
+
+concept Phone {
+    o String number
+}
+
+concept Person identified by email {
+    o String email
+}

--- a/packages/concerto-core/test/data/zip/test-archive-dotfolders/models/.base/concerto.cto
+++ b/packages/concerto-core/test/data/zip/test-archive-dotfolders/models/.base/concerto.cto
@@ -18,7 +18,7 @@
  * The composer namespace defines built-in types for building Blockchain
  * based business networks. This file should not be modified.
  */
-namespace composer
+namespace composer@1.0.0
 
 /**
  * MyParticipant defines an actor in a blockchain based business network

--- a/packages/concerto-core/test/data/zip/test-archive-dotfolders/models/.base/mozart.cto
+++ b/packages/concerto-core/test/data/zip/test-archive-dotfolders/models/.base/mozart.cto
@@ -20,7 +20,7 @@
  *
  */
 
-namespace com.composer
+namespace com.composer@1.0.0
 
 /**
  * The types of animals that could be moved

--- a/packages/concerto-core/test/data/zip/test-archive/models/concerto.cto
+++ b/packages/concerto-core/test/data/zip/test-archive/models/concerto.cto
@@ -18,7 +18,7 @@
  * The composer namespace defines built-in types for building Blockchain
  * based business networks. This file should not be modified.
  */
-namespace composer
+namespace composer@1.0.0
 
 /**
  * MyParticipant defines an actor in a blockchain based business network

--- a/packages/concerto-core/test/data/zip/test-archive/models/mozart.cto
+++ b/packages/concerto-core/test/data/zip/test-archive/models/mozart.cto
@@ -20,7 +20,7 @@
  *
  */
 
-namespace com.composer
+namespace com.composer@1.0.0
 
 /**
  * The types of animals that could be moved

--- a/packages/concerto-core/test/introspect/concertoVersion.js
+++ b/packages/concerto-core/test/introspect/concertoVersion.js
@@ -46,7 +46,7 @@ describe('ModelFile', () => {
         it('should throw when concerto version is not compatible with model', () => {
             (() => {
                 ParserUtil.newModelFile(modelManager, versionInvalid);
-            }).should.throw(/ModelFile expects Concerto version/);
+            }).should.throw(/This version of Concerto supports a language version of v3.0.0 or greater/);
         });
 
         it('should return when concerto version is compatible with model', () => {

--- a/packages/concerto-core/test/introspect/mapdeclaration.js
+++ b/packages/concerto-core/test/introspect/mapdeclaration.js
@@ -43,7 +43,7 @@ describe('MapDeclaration', () => {
         modelManager = new ModelManager();
         Util.addComposerModel(modelManager);
         introspectUtils = new IntrospectUtils(modelManager);
-        modelFile = ParserUtil.newModelFile(modelManager, 'namespace com.test', 'mapdeclaration.cto');
+        modelFile = ParserUtil.newModelFile(modelManager, 'namespace com.test@1.0.0', 'mapdeclaration.cto');
     });
 
     describe('#constructor', () => {

--- a/packages/concerto-core/test/introspect/scalardeclaration.js
+++ b/packages/concerto-core/test/introspect/scalardeclaration.js
@@ -36,7 +36,7 @@ describe('ScalarDeclaration', () => {
         modelManager = new ModelManager();
         Util.addComposerModel(modelManager);
         introspectUtils = new IntrospectUtils(modelManager);
-        modelFile = ParserUtil.newModelFile(modelManager, 'namespace com.hyperledger.testing', 'org.acme.cto');
+        modelFile = ParserUtil.newModelFile(modelManager, 'namespace com.hyperledger.testing@1.0.0', 'org.acme.cto');
     });
     describe('Primitive type name conflict', () => {
         it('should throw an error when scalar name is a primitive type', () => {
@@ -81,7 +81,7 @@ describe('ScalarDeclaration', () => {
                 name: 'suchName'
             });
             clz.getName().should.equal('suchName');
-            clz.toString().should.equal('ScalarDeclaration {id=com.hyperledger.testing.suchName}');
+            clz.toString().should.equal('ScalarDeclaration {id=com.hyperledger.testing@1.0.0.suchName}');
         });
 
     });
@@ -104,7 +104,7 @@ describe('ScalarDeclaration', () => {
             let clz = new ScalarDeclaration(modelFile, {
                 name: 'suchName',
             });
-            clz.getFullyQualifiedName().should.equal('com.hyperledger.testing.suchName');
+            clz.getFullyQualifiedName().should.equal('com.hyperledger.testing@1.0.0.suchName');
         });
 
     });

--- a/packages/concerto-core/test/modelmanager.js
+++ b/packages/concerto-core/test/modelmanager.js
@@ -556,6 +556,7 @@ describe('ModelManager', () => {
 
             let mf2 = sinon.createStubInstance(ModelFile);
             mf2.getNamespace.returns('org.doge@1.0.0');
+            mf2.getVersion.returns('1.0.0');
             mf2.isModelFile.returns(true);
             mf2.getAst.returns({$class: `${MetaModelNamespace}.Model`});
             mf2.$marker = 'mf2';
@@ -589,6 +590,7 @@ describe('ModelManager', () => {
 
             let mf2 = sinon.createStubInstance(ModelFile);
             mf2.getNamespace.returns('org.doge@1.0.0');
+            mf2.getVersion.returns('1.0.0');
             mf2.isModelFile.returns(true);
             mf2.$marker = 'mf2';
             mf2.validate.throws(new Error('fake error'));

--- a/packages/concerto-core/test/semver.js
+++ b/packages/concerto-core/test/semver.js
@@ -56,7 +56,7 @@ describe('Semantic Versioning', () => {
             (() => {
                 modelManager = new ModelManager();
                 modelManager.addCTOModel('namespace test', 'test.cto');
-            }).should.throw(/Cannot add an unversioned namespace/);
+            }).should.throw(/Cannot create a ModelFile with an unversioned namespace/);
         });
 
         it('should not support unversioned imports', () => {

--- a/packages/concerto-core/test/semver.js
+++ b/packages/concerto-core/test/semver.js
@@ -30,11 +30,13 @@ describe('Semantic Versioning', () => {
     let sandbox;
     let modelManager;
     let personCto;
+    let personV3Cto;
     let employeeCto;
 
     beforeEach(() => {
         sandbox = sinon.createSandbox();
         personCto = fs.readFileSync('./test/data/semver/person.cto', 'utf-8');
+        personV3Cto = fs.readFileSync('./test/data/semver/personv3.cto', 'utf-8');
         employeeCto = fs.readFileSync('./test/data/semver/employee.cto', 'utf-8');
     });
 
@@ -79,6 +81,19 @@ import concerto.Event`, 'test.cto');
                     email: 'john.doe@example.com',
                 });
             }).should.throw(/Namespace is not defined/);
+        });
+    });
+
+    describe('#v3 backward compatibility', () => {
+        it('should support v3 models on newer runtime', () => {
+            modelManager = new ModelManager();
+            modelManager.addCTOModel(personV3Cto, 'personv3.cto');
+            modelManager.addCTOModel(employeeCto, 'employee.cto');
+
+            modelManager.getModelFile('person@1.0.0').should.be.not.null;
+            modelManager.getModelFile('employee@2.0.0').should.be.not.null;
+            modelManager.getType('person@1.0.0.Person').should.be.not.null;
+            modelManager.getType('employee@2.0.0.Employee').should.be.not.null;
         });
     });
 


### PR DESCRIPTION
<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #<CORRESPONDING ISSUE NUMBER>
<!--- Provide an overall summary of the pull request -->
Concerto v4 currently rejects models that declare a concerto version range targeting v3, even when those models are otherwise valid and semantically compatible with the v4 runtime. As a result, existing v3 models fail at load time and cannot be reused in v4 environments.

This change restores practical backward compatibility for v3-authored models while keeping strict validation for unsupported versions.


### Screenshots or Video
<!--- Provide an easily accessible demonstration of the changes, if applicable -->

### Related Issues
- Issue #<NUMBER>
- Pull Request #<NUMBER>

### Author Checklist
- [ ] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [ ] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ ] Merging to `main` from `fork:branchname`
