### PR TITLE
fix(concerto-linter): validate namespace version across all models

### DIFF
--- a/packages/concerto-linter/default-ruleset/src/namespace-version.ts
+++ b/packages/concerto-linter/default-ruleset/src/namespace-version.ts
@@ -22,7 +22,7 @@ import { pattern } from '@stoplight/spectral-functions';
  */
 export default {
     description: 'namespace should specify a version.',
-    given: '$.models[0].namespace',
+    given: '$.models[*].namespace',
     message: 'namespace \'{{value}}\' should specify a version.',
     severity: 0, // 0 = error, 1 = warning, 2 = info, 3 = hint
     then: {

--- a/packages/concerto-linter/default-ruleset/test/rules/namespace-version.test.ts
+++ b/packages/concerto-linter/default-ruleset/test/rules/namespace-version.test.ts
@@ -1,5 +1,7 @@
 import { testRules } from '../test-rule';
 import namespaceVersion from '../../src/namespace-version';
+import { Spectral, Document } from '@stoplight/spectral-core';
+import { Json as JsonParsers } from '@stoplight/spectral-parsers';
 
 describe('Namespace Version Rule', () => {
     test('should not report any violations for namespaces with valid version', async () => {
@@ -19,6 +21,41 @@ describe('Namespace Version Rule', () => {
         }, 'namespace-invalid-version.cto');
         expect(results).toHaveLength(1);
         expect(results[0].code).toBe('namespace-version');
+        expect(results[0].message).toContain('should specify a version');
+    });
+
+    test('should validate all models, not just the first one', async () => {
+        // Construct a multi-model AST where the first model has a valid version
+        // but the second model does not — this verifies the rule checks all models.
+        const multiModelAST = {
+            $class: 'concerto.metamodel@1.0.0.Models',
+            models: [
+                {
+                    $class: 'concerto.metamodel@1.0.0.Model',
+                    namespace: 'org.valid@1.0.0',
+                    declarations: []
+                },
+                {
+                    $class: 'concerto.metamodel@1.0.0.Model',
+                    namespace: 'org.invalid',
+                    declarations: []
+                }
+            ]
+        };
+
+        const spectral = new Spectral();
+        spectral.setRuleset({
+            rules: {
+                'namespace-version': namespaceVersion,
+            }
+        });
+
+        const document = new Document(JSON.stringify(multiModelAST), JsonParsers);
+        const results = await spectral.run(document);
+
+        expect(results).toHaveLength(1);
+        expect(results[0].code).toBe('namespace-version');
+        expect(results[0].message).toContain('org.invalid');
         expect(results[0].message).toContain('should specify a version');
     });
 });


### PR DESCRIPTION
# Closes #1203

The `namespace-version` rule in the default ruleset used `$.models[0].namespace` which only checked the first model in the AST. This means when linting multiple Concerto models together, only the first model's namespace was validated for versioning — any subsequent models without a version silently passed.

### Changes
- Changed JSONPath `given` from `$.models[0].namespace` to `$.models[*].namespace` in the namespace-version rule, consistent with all other rules in the default ruleset
- Added a multi-model test case that constructs an AST with two models (one valid, one missing version) to verify the fix

### Flags
- This is a 1-line behavioral fix + test — no breaking changes
- All existing tests continue to pass
- Consistent with the pattern used by all 8 other rules in the default ruleset

### Screenshots or Video
N/A

### Related Issues
- Closes #1203

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [x] Extend the documentation, if necessary
- [x] Merging to `main` from `fork:fix/namespace-version-all-models`
