### PR TITLE
feat(concerto-linter): add no-duplicate-properties rule

### DIFF
--- a/packages/concerto-linter/default-ruleset/src/functions/find-duplicate-properties.ts
+++ b/packages/concerto-linter/default-ruleset/src/functions/find-duplicate-properties.ts
@@ -1,0 +1,73 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { IFunction, IFunctionResult } from '@stoplight/spectral-core';
+
+interface Property {
+    name: string;
+}
+
+interface Declaration {
+    name: string;
+    properties?: Property[];
+}
+
+/**
+ * Finds and reports duplicate property names within a Concerto Declaration.
+ *
+ * Iterates through the declaration's properties and reports an error for each
+ * property name that appears more than once. This prevents silent overwrites
+ * and ensures each property within a declaration is uniquely named.
+ *
+ * @param {unknown} targetVal The AST node to check, expected to be a Concerto Declaration object.
+ * @returns {IFunctionResult[]} An array of results indicating declarations with duplicate properties.
+ * @throws {Error} If the input is not a valid object.
+ */
+export const findDuplicateProperties: IFunction = (
+    targetVal,
+): IFunctionResult[] => {
+    const results: IFunctionResult[] = [];
+
+    // Validate that targetVal is a non-null object
+    if (typeof targetVal !== 'object' || targetVal === null) {
+        throw new Error('Value must be a valid AST object for a Concerto Declaration.');
+    }
+
+    const declaration = targetVal as Declaration;
+
+    // Skip declarations without properties (e.g., enums, scalars)
+    if (!Array.isArray(declaration.properties)) {
+        return results;
+    }
+
+    const seen = new Set<string>();
+    const duplicates = new Set<string>();
+
+    for (const property of declaration.properties) {
+        if (property && typeof property.name === 'string') {
+            if (seen.has(property.name)) {
+                duplicates.add(property.name);
+            }
+            seen.add(property.name);
+        }
+    }
+
+    for (const name of duplicates) {
+        results.push({
+            message: `Declaration '${declaration.name}' has duplicate property '${name}'.`,
+        });
+    }
+
+    return results;
+};

--- a/packages/concerto-linter/default-ruleset/src/no-duplicate-properties.ts
+++ b/packages/concerto-linter/default-ruleset/src/no-duplicate-properties.ts
@@ -1,0 +1,30 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { findDuplicateProperties } from './functions/find-duplicate-properties';
+
+/**
+ * Rule: No Duplicate Properties
+ * -----------------------------
+ * Ensures that no declaration contains duplicate property names.
+ * Duplicate properties can lead to silent overwrites and inconsistent
+ * model behavior, as the parser does not reject them at parse time.
+ */
+export default {
+    given: '$.models[*].declarations[*]',
+    severity: 0, // 0 = error, 1 = warning, 2 = info, 3 = hint
+    then: {
+        function: findDuplicateProperties,
+    },
+};

--- a/packages/concerto-linter/default-ruleset/src/ruleset-main.ts
+++ b/packages/concerto-linter/default-ruleset/src/ruleset-main.ts
@@ -23,6 +23,7 @@ import stringLengthValidator from './string-length-validator';
 import noReservedKeywords from './no-reserved-keywords';
 import noEmptyDeclarations from './no-empty-declarations';
 import abstractMustSubclassed from './abstract-must-subclassed';
+import noDuplicateProperties from './no-duplicate-properties';
 
 const concertoRuleset: RulesetDefinition = {
     rules: {
@@ -35,6 +36,7 @@ const concertoRuleset: RulesetDefinition = {
         'string-length-validator': stringLengthValidator,
         'no-empty-declarations': noEmptyDeclarations,
         'abstract-must-subclassed': abstractMustSubclassed,
+        'no-duplicate-properties': noDuplicateProperties,
     }
 };
 

--- a/packages/concerto-linter/default-ruleset/test/fixtures/no-duplicate-properties-invalid.cto
+++ b/packages/concerto-linter/default-ruleset/test/fixtures/no-duplicate-properties-invalid.cto
@@ -1,0 +1,7 @@
+namespace org.example@1.0.0
+
+concept Order {
+  o String orderId
+  o Integer quantity
+  o String orderId
+}

--- a/packages/concerto-linter/default-ruleset/test/fixtures/no-duplicate-properties-valid.cto
+++ b/packages/concerto-linter/default-ruleset/test/fixtures/no-duplicate-properties-valid.cto
@@ -1,0 +1,17 @@
+namespace org.example@1.0.0
+
+concept Order {
+  o String orderId
+  o Integer quantity
+  o Double price
+}
+
+asset Product {
+  o String productId
+  o String name
+}
+
+enum Status {
+  o ACTIVE
+  o INACTIVE
+}

--- a/packages/concerto-linter/default-ruleset/test/rules/no-duplicate-properties.test.ts
+++ b/packages/concerto-linter/default-ruleset/test/rules/no-duplicate-properties.test.ts
@@ -1,0 +1,34 @@
+import { testRules } from '../test-rule';
+import noDuplicateProperties from '../../src/no-duplicate-properties';
+
+describe('No Duplicate Properties Rule', () => {
+    test('should not report any violations when all properties are unique', async () => {
+        const results = await testRules({
+            rules: {
+                'no-duplicate-properties': noDuplicateProperties,
+            }
+        }, 'no-duplicate-properties-valid.cto');
+        expect(results).toHaveLength(0);
+    });
+
+    test('should report violations when declarations have duplicate properties', async () => {
+        const results = await testRules({
+            rules: {
+                'no-duplicate-properties': noDuplicateProperties,
+            }
+        }, 'no-duplicate-properties-invalid.cto');
+
+        // We expect at least one violation for the duplicate property
+        expect(results.length).toBeGreaterThan(0);
+
+        // Check that the rule code is correct
+        results.forEach(result => {
+            expect(result.code).toBe('no-duplicate-properties');
+        });
+
+        // Check that the message contains the expected text
+        const messageText = results.map(r => r.message).join(' ');
+        expect(messageText).toContain('duplicate property');
+        expect(messageText).toContain('orderId');
+    });
+});


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><h1>Closes #1213</h1><h2>Summary</h2><p>This PR adds a new <strong><code inline="">no-duplicate-properties</code></strong> linter rule to the <code inline="">concerto-linter-default-ruleset</code> package.</p><p>The rule detects and reports duplicate property names within a single Concerto declaration, helping developers catch accidental duplicate fields early during development.</p><hr><h2>Why This Change Is Needed</h2><p>The Concerto parser currently accepts declarations with duplicate property names without raising any error.</p><p>Example:</p><pre><code class="language-cto">namespace org.example@1.0.0

concept Order {
  o String orderId
  o Integer quantity
  o String orderId
}
</code></pre><p>When parsed, this silently produces:</p><pre><code class="language-text">["orderId", "quantity", "orderId"]
</code></pre><p>This can lead to:</p><ul><li><p><strong>Silent property overwrites</strong> — duplicate properties may shadow earlier definitions and cause unexpected runtime behavior</p></li><li><p><strong>Inconsistent downstream behavior</strong> — generators, validators, and serializers may interpret duplicates differently</p></li><li><p><strong>Developer confusion</strong> — no feedback is provided when duplicate properties are accidentally introduced</p></li></ul><p>Currently, no existing linter rule validates this scenario.</p><hr><h2>Implementation Details</h2><h3>New Spectral Function</h3><p><strong>File:</strong> <code inline="">src/functions/find-duplicate-properties.ts</code></p><ul><li><p>Implements duplicate detection using a <code inline="">Set&lt;string&gt;</code></p></li><li><p>Tracks already-seen property names efficiently</p></li><li><p>Reports each duplicate only once even if repeated multiple times</p></li></ul><h3>New Rule Definition</h3><p><strong>File:</strong> <code inline="">src/no-duplicate-properties.ts</code></p><ul><li><p>Targets all declarations using:</p></li></ul><pre><code class="language-text">$.models[*].declarations[*]
</code></pre><ul><li><p>Reports errors in the format:</p></li></ul><pre><code class="language-text">Declaration 'Order' has duplicate property 'orderId'.
</code></pre><h3>Ruleset Registration</h3><p><strong>Modified File:</strong> <code inline="">src/ruleset-main.ts</code></p><ul><li><p>Registers the new rule alongside existing default rules</p></li></ul><h3>Test Coverage</h3><p>Added complete test coverage including:</p><ul><li><p>Valid CTO fixtures</p></li><li><p>Invalid CTO fixtures</p></li><li><p>Unit tests following existing project patterns</p></li></ul><hr><h2>Changes Included</h2><h3>Added</h3><ul><li><p><code inline="">src/functions/find-duplicate-properties.ts</code></p></li><li><p><code inline="">src/no-duplicate-properties.ts</code></p></li><li><p><code inline="">test/fixtures/no-duplicate-properties-valid.cto</code></p></li><li><p><code inline="">test/fixtures/no-duplicate-properties-invalid.cto</code></p></li><li><p><code inline="">test/rules/no-duplicate-properties.test.ts</code></p></li></ul><h3>Modified</h3><ul><li><p><code inline="">src/ruleset-main.ts</code></p></li></ul><hr><h2>Behavior</h2><p>The rule:</p><ul><li><p>Iterates through declaration properties</p></li><li><p>Detects duplicate property names</p></li><li><p>Skips declarations without properties (e.g. enums/scalars)</p></li><li><p>Reports violations with severity <code inline="">0</code> (<strong>error</strong>)</p></li></ul><hr><h2>Test Results</h2>
Check | Status
-- | --
Default ruleset tests | ✅ Passed
Parent concerto-linter tests | ✅ Passed
ESLint | ✅ Clean
License check | ✅ Passed
Build | ✅ Passed

<hr><h2>Notes</h2><ul><li><p>This is a <strong>purely additive, non-breaking change</strong></p></li><li><p>Existing behavior remains unchanged</p></li><li><p>The implementation follows the same architecture and conventions as existing rules such as:</p><ul><li><p><code inline="">no-empty-declarations</code></p></li><li><p><code inline="">abstract-must-subclassed</code></p></li><li><p><code inline="">string-length-validator</code></p></li></ul></li></ul><hr><h2>Screenshots / Video</h2><p>Not applicable — this PR introduces a linter rule and associated tests only.</p><hr><h2>Author Checklist</h2><ul class="contains-task-list"><li class="task-list-item"><p><input type="checkbox" checked="" disabled=""> DCO sign-off added</p></li><li class="task-list-item"><p><input type="checkbox" checked="" disabled=""> Unit tests included</p></li><li class="task-list-item"><p><input type="checkbox" checked="" disabled=""> Commit messages follow project conventions</p></li><li class="task-list-item"><p><input type="checkbox" checked="" disabled=""> No regressions introduced</p></li><li class="task-list-item"><p><input type="checkbox" checked="" disabled=""> Documentation updated where necessary</p></li></ul></body></html><!--EndFragment-->
</body>
</html>