### PR TITLE
fix(concerto-core): add opt-out for reserved system type name clashes

### DIFF
--- a/packages/concerto-core/src/basemodelmanager.ts
+++ b/packages/concerto-core/src/basemodelmanager.ts
@@ -100,7 +100,7 @@ class BaseModelManager {
      * @param {Object} [options.regExp] - An alternative regular expression engine.
      * @param {boolean} [options.metamodelValidation] - When true, modelfiles will be validated
      * @param {boolean} [options.addMetamodel] - When true, the Concerto metamodel is added to the model manager
-     * @param {boolean} [options.allowReservedSystemTypeNames] - When true, declarations may use reserved system type names
+    * @param {boolean} [options.dangerouslyAllowReservedSystemTypeNames] - Transitional escape hatch; when true, declarations may use reserved system type names
      * @param {object} [options.decoratorValidation] - the decorator validation configuration
      * @param {string} [options.decoratorValidation.missingDecorator] - the validation log level for missingDecorator decorators: off, warning, error
      * @param {string} [options.decoratorValidation.invalidDecorator] - the validation log level for invalidDecorator decorators: off, warning, error

--- a/packages/concerto-core/src/basemodelmanager.ts
+++ b/packages/concerto-core/src/basemodelmanager.ts
@@ -93,17 +93,18 @@ class BaseModelManager {
      options: any;
      decoratorValidation: any;
      metamodelModelFile: any;
-     /**
+    /**
      * Create the ModelManager.
      * @constructor
      * @param {object} [options] - ModelManager options, also passed to Serializer
      * @param {Object} [options.regExp] - An alternative regular expression engine.
      * @param {boolean} [options.metamodelValidation] - When true, modelfiles will be validated
      * @param {boolean} [options.addMetamodel] - When true, the Concerto metamodel is added to the model manager
+     * @param {boolean} [options.allowReservedSystemTypeNames] - When true, declarations may use reserved system type names
      * @param {object} [options.decoratorValidation] - the decorator validation configuration
      * @param {string} [options.decoratorValidation.missingDecorator] - the validation log level for missingDecorator decorators: off, warning, error
      * @param {string} [options.decoratorValidation.invalidDecorator] - the validation log level for invalidDecorator decorators: off, warning, error
-    * @param {*} [processFile] - how to obtain a concerto AST from an input to the model manager
+     * @param {*} [processFile] - how to obtain a concerto AST from an input to the model manager
     */
     constructor(options?: ModelManagerOptions, processFile?: (fileName: string | null, modelInput: string | unknown) => ModelFileSource) {
         this.processFile = processFile ? processFile : defaultProcessFile;

--- a/packages/concerto-core/src/basemodelmanager.ts
+++ b/packages/concerto-core/src/basemodelmanager.ts
@@ -100,7 +100,7 @@ class BaseModelManager {
      * @param {Object} [options.regExp] - An alternative regular expression engine.
      * @param {boolean} [options.metamodelValidation] - When true, modelfiles will be validated
      * @param {boolean} [options.addMetamodel] - When true, the Concerto metamodel is added to the model manager
-    * @param {boolean} [options.dangerouslyAllowReservedSystemTypeNames] - Transitional escape hatch; when true, declarations may use reserved system type names
+    * @param {boolean} [options.dangerouslyAllowReservedSystemTypeNamesInUserModels] - Transitional escape hatch; when true, declarations may use reserved system type names
      * @param {object} [options.decoratorValidation] - the decorator validation configuration
      * @param {string} [options.decoratorValidation.missingDecorator] - the validation log level for missingDecorator decorators: off, warning, error
      * @param {string} [options.decoratorValidation.invalidDecorator] - the validation log level for invalidDecorator decorators: off, warning, error

--- a/packages/concerto-core/src/introspect/declaration.ts
+++ b/packages/concerto-core/src/introspect/declaration.ts
@@ -84,8 +84,8 @@ class Declaration extends Decorated {
 
         // #648 - check for clashes against imported types
         if (modelFile.isImportedType(this.getName())) {
-            const dangerouslyAllowReservedSystemTypeNames = Boolean(modelFile.getModelManager()?.options?.dangerouslyAllowReservedSystemTypeNames);
-            if (dangerouslyAllowReservedSystemTypeNames && this.isReservedSystemTypeImport(modelFile, this.getName())) {
+            const dangerouslyAllowReservedSystemTypeNamesInUserModels = Boolean(modelFile.getModelManager()?.options?.dangerouslyAllowReservedSystemTypeNamesInUserModels);
+            if (dangerouslyAllowReservedSystemTypeNamesInUserModels && this.isReservedSystemTypeImport(modelFile, this.getName())) {
                 return;
             }
 

--- a/packages/concerto-core/src/introspect/declaration.ts
+++ b/packages/concerto-core/src/introspect/declaration.ts
@@ -17,6 +17,7 @@
 const Decorated = require('./decorated');
 const ModelUtil = require('../modelutil');
 const IllegalModelException = require('./illegalmodelexception');
+const RESERVED_SYSTEM_TYPES = new Set(['Concept', 'Asset', 'Transaction', 'Participant', 'Event']);
 
 // Types needed for TypeScript generation.
 /* eslint-disable no-unused-vars */
@@ -80,11 +81,34 @@ class Declaration extends Decorated {
      */
     validate(...args) {
         super.validate(...args);
+        const modelFile = this.getModelFile();
 
         // #648 - check for clashes against imported types
-        if (this.getModelFile().isImportedType(this.getName())){
+        if (modelFile.isImportedType(this.getName())) {
+            const allowReservedSystemTypeNames = Boolean(modelFile.getModelManager()?.options?.allowReservedSystemTypeNames);
+            if (allowReservedSystemTypeNames && this.isReservedSystemTypeImport(modelFile, this.getName())) {
+                return;
+            }
+
             throw new IllegalModelException(`Type '${this.getName()}' clashes with an imported type with the same name.`, this.modelFile, this.ast.location);
         }
+    }
+
+    /**
+     * Determines whether a type name resolves to a reserved type in the Concerto
+     * system namespace.
+     * @param {ModelFile} modelFile - the current model file
+     * @param {string} typeName - local/imported type name
+     * @returns {boolean} true if the resolved import is a reserved system type
+     */
+    private isReservedSystemTypeImport(modelFile, typeName) {
+        if (!RESERVED_SYSTEM_TYPES.has(typeName)) {
+            return false;
+        }
+
+        const importedFqn = modelFile.resolveImport(typeName);
+        const importedNs = ModelUtil.getNamespace(importedFqn);
+        return importedNs === 'concerto' || importedNs.startsWith('concerto@');
     }
 
     /**

--- a/packages/concerto-core/src/introspect/declaration.ts
+++ b/packages/concerto-core/src/introspect/declaration.ts
@@ -17,7 +17,6 @@
 const Decorated = require('./decorated');
 const ModelUtil = require('../modelutil');
 const IllegalModelException = require('./illegalmodelexception');
-const RESERVED_SYSTEM_TYPES = new Set(['Concept', 'Asset', 'Transaction', 'Participant', 'Event']);
 
 // Types needed for TypeScript generation.
 /* eslint-disable no-unused-vars */
@@ -85,8 +84,8 @@ class Declaration extends Decorated {
 
         // #648 - check for clashes against imported types
         if (modelFile.isImportedType(this.getName())) {
-            const allowReservedSystemTypeNames = Boolean(modelFile.getModelManager()?.options?.allowReservedSystemTypeNames);
-            if (allowReservedSystemTypeNames && this.isReservedSystemTypeImport(modelFile, this.getName())) {
+            const dangerouslyAllowReservedSystemTypeNames = Boolean(modelFile.getModelManager()?.options?.dangerouslyAllowReservedSystemTypeNames);
+            if (dangerouslyAllowReservedSystemTypeNames && this.isReservedSystemTypeImport(modelFile, this.getName())) {
                 return;
             }
 
@@ -102,13 +101,21 @@ class Declaration extends Decorated {
      * @returns {boolean} true if the resolved import is a reserved system type
      */
     private isReservedSystemTypeImport(modelFile, typeName) {
-        if (!RESERVED_SYSTEM_TYPES.has(typeName)) {
+        const importedType = modelFile.getType(typeName);
+        if (!importedType || typeof importedType === 'string') {
             return false;
         }
 
-        const importedFqn = modelFile.resolveImport(typeName);
-        const importedNs = ModelUtil.getNamespace(importedFqn);
-        return importedNs === 'concerto' || importedNs.startsWith('concerto@');
+        const importedModelFile = importedType.getModelFile();
+        if (!importedModelFile || !importedModelFile.isSystemModelFile()) {
+            return false;
+        }
+
+        return importedType.isConcept()
+            || importedType.isAsset()
+            || importedType.isTransaction()
+            || importedType.isParticipant()
+            || importedType.isEvent();
     }
 
     /**

--- a/packages/concerto-core/src/modelmanager.ts
+++ b/packages/concerto-core/src/modelmanager.ts
@@ -61,7 +61,7 @@ class ModelManager extends BaseModelManager {
      * @constructor
      * @param {object} [options] - ModelManager options, also passed to Serializer
      * @param {Object} [options.regExp] - An alternative regular expression engine.
-     * @param {boolean} [options.dangerouslyAllowReservedSystemTypeNames] - Transitional escape hatch; when true, declarations may use reserved system type names
+     * @param {boolean} [options.dangerouslyAllowReservedSystemTypeNamesInUserModels] - Transitional escape hatch; when true, declarations may use reserved system type names
      */
     constructor(options: ModelManagerOptions = {}) {
         super(options, ctoProcessFile(options));

--- a/packages/concerto-core/src/modelmanager.ts
+++ b/packages/concerto-core/src/modelmanager.ts
@@ -61,7 +61,7 @@ class ModelManager extends BaseModelManager {
      * @constructor
      * @param {object} [options] - ModelManager options, also passed to Serializer
      * @param {Object} [options.regExp] - An alternative regular expression engine.
-     * @param {boolean} [options.allowReservedSystemTypeNames] - When true, declarations may use reserved system type names
+     * @param {boolean} [options.dangerouslyAllowReservedSystemTypeNames] - Transitional escape hatch; when true, declarations may use reserved system type names
      */
     constructor(options: ModelManagerOptions = {}) {
         super(options, ctoProcessFile(options));

--- a/packages/concerto-core/src/modelmanager.ts
+++ b/packages/concerto-core/src/modelmanager.ts
@@ -61,6 +61,7 @@ class ModelManager extends BaseModelManager {
      * @constructor
      * @param {object} [options] - ModelManager options, also passed to Serializer
      * @param {Object} [options.regExp] - An alternative regular expression engine.
+     * @param {boolean} [options.allowReservedSystemTypeNames] - When true, declarations may use reserved system type names
      */
     constructor(options: ModelManagerOptions = {}) {
         super(options, ctoProcessFile(options));

--- a/packages/concerto-core/src/types.ts
+++ b/packages/concerto-core/src/types.ts
@@ -18,7 +18,9 @@ export interface ModelManagerOptions {
     regExp?: RegExp;
     metamodelValidation?: boolean;
     addMetamodel?: boolean;
-    allowReservedSystemTypeNames?: boolean;
+    // Transitional migration escape hatch for legacy models.
+    // This option is temporary and will be removed in a future release.
+    dangerouslyAllowReservedSystemTypeNames?: boolean;
     decoratorValidation?: {
         missingDecorator?: string;
         invalidDecorator?: string;

--- a/packages/concerto-core/src/types.ts
+++ b/packages/concerto-core/src/types.ts
@@ -20,7 +20,7 @@ export interface ModelManagerOptions {
     addMetamodel?: boolean;
     // Transitional migration escape hatch for legacy models.
     // This option is temporary and will be removed in a future release.
-    dangerouslyAllowReservedSystemTypeNames?: boolean;
+    dangerouslyAllowReservedSystemTypeNamesInUserModels?: boolean;
     decoratorValidation?: {
         missingDecorator?: string;
         invalidDecorator?: string;

--- a/packages/concerto-core/src/types.ts
+++ b/packages/concerto-core/src/types.ts
@@ -18,6 +18,7 @@ export interface ModelManagerOptions {
     regExp?: RegExp;
     metamodelValidation?: boolean;
     addMetamodel?: boolean;
+    allowReservedSystemTypeNames?: boolean;
     decoratorValidation?: {
         missingDecorator?: string;
         invalidDecorator?: string;

--- a/packages/concerto-core/test/introspect/modelfile.js
+++ b/packages/concerto-core/test/introspect/modelfile.js
@@ -367,9 +367,9 @@ describe('ModelFile', () => {
             }).should.throw('Type \'Transaction\' clashes with an imported type with the same name.');
         });
 
-        it('should allow a system type name when dangerouslyAllowReservedSystemTypeNames is enabled', () => {
+        it('should allow a system type name when dangerouslyAllowReservedSystemTypeNamesInUserModels is enabled', () => {
             const myModelManager = new ModelManager({
-                dangerouslyAllowReservedSystemTypeNames: true,
+                dangerouslyAllowReservedSystemTypeNamesInUserModels: true,
             });
 
             const model = `
@@ -384,9 +384,9 @@ describe('ModelFile', () => {
             myModelManager.getType('A@1.0.0.Asset').getName().should.equal('Asset');
         });
 
-        it('should still fail non-system clashes when dangerouslyAllowReservedSystemTypeNames is enabled', () => {
+        it('should still fail non-system clashes when dangerouslyAllowReservedSystemTypeNamesInUserModels is enabled', () => {
             const myModelManager = new ModelManager({
-                dangerouslyAllowReservedSystemTypeNames: true,
+                dangerouslyAllowReservedSystemTypeNamesInUserModels: true,
             });
 
             const imported = `namespace A@1.0.0

--- a/packages/concerto-core/test/introspect/modelfile.js
+++ b/packages/concerto-core/test/introspect/modelfile.js
@@ -367,6 +367,47 @@ describe('ModelFile', () => {
             }).should.throw('Type \'Transaction\' clashes with an imported type with the same name.');
         });
 
+        it('should allow a system type name when allowReservedSystemTypeNames is enabled', () => {
+            const myModelManager = new ModelManager({
+                allowReservedSystemTypeNames: true,
+            });
+
+            const model = `
+            namespace A@1.0.0
+            asset Asset identified by assetId {
+                o String assetId
+            }
+            `;
+
+            const modelFile = ParserUtil.newModelFile(myModelManager, model);
+            myModelManager.addModelFile(modelFile);
+            myModelManager.getType('A@1.0.0.Asset').getName().should.equal('Asset');
+        });
+
+        it('should still fail non-system clashes when allowReservedSystemTypeNames is enabled', () => {
+            const myModelManager = new ModelManager({
+                allowReservedSystemTypeNames: true,
+            });
+
+            const imported = `namespace A@1.0.0
+            concept B {
+                o String name
+            }`;
+
+            const clashing = `namespace B@1.0.0
+            import A@1.0.0.{B}
+            concept B {
+            }`;
+
+            const importedModelFile = ParserUtil.newModelFile(myModelManager, imported);
+            myModelManager.addModelFile(importedModelFile);
+
+            const clashingModelFile = ParserUtil.newModelFile(myModelManager, clashing);
+            (() => {
+                myModelManager.addModelFile(clashingModelFile);
+            }).should.throw('Type \'B\' clashes with an imported type with the same name.');
+        });
+
     });
 
     describe('#getDefinitions', () => {

--- a/packages/concerto-core/test/introspect/modelfile.js
+++ b/packages/concerto-core/test/introspect/modelfile.js
@@ -367,9 +367,9 @@ describe('ModelFile', () => {
             }).should.throw('Type \'Transaction\' clashes with an imported type with the same name.');
         });
 
-        it('should allow a system type name when allowReservedSystemTypeNames is enabled', () => {
+        it('should allow a system type name when dangerouslyAllowReservedSystemTypeNames is enabled', () => {
             const myModelManager = new ModelManager({
-                allowReservedSystemTypeNames: true,
+                dangerouslyAllowReservedSystemTypeNames: true,
             });
 
             const model = `
@@ -384,9 +384,9 @@ describe('ModelFile', () => {
             myModelManager.getType('A@1.0.0.Asset').getName().should.equal('Asset');
         });
 
-        it('should still fail non-system clashes when allowReservedSystemTypeNames is enabled', () => {
+        it('should still fail non-system clashes when dangerouslyAllowReservedSystemTypeNames is enabled', () => {
             const myModelManager = new ModelManager({
-                allowReservedSystemTypeNames: true,
+                dangerouslyAllowReservedSystemTypeNames: true,
             });
 
             const imported = `namespace A@1.0.0


### PR DESCRIPTION
<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #<CORRESPONDING ISSUE NUMBER>
<!--- Provide an overall summary of the pull request -->
Adds a targeted compatibility opt-out for reserved Concerto system type name clashes so dependent systems can migrate without losing other validation protections.

By default, behavior is unchanged. When enabled, only clashes against reserved system types are allowed.

### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
- Added a new ModelManager option: `dangerouslyAllowReservedSystemTypeNamesInUserModels ` (default false)
- Wired option into declaration clash validation:
  -  keeps existing clash validation
  -  skips only when clash is with reserved system types in concerto namespace:
      -  Concept, Asset, Transaction, Participant, Event
- Added tests for:
  -  default behavior still rejecting system type-name clashes
  -  opt-out allowing reserved system type-name clashes
  -  opt-out still rejecting non-system ambiguous type clashes
-  Documented the new option in constructor JSDoc.

### Flags
<!--- Provide context or concerns a reviewer should be aware of -->
- <ONE> This is intentionally scoped as a compatibility escape hatch.
- <TWO> Validation remains strict for non-system type collisions.
- <THREE> No API behavior changes unless `dangerouslyAllowReservedSystemTypeNamesInUserModels ` is explicitly enabled.

### Screenshots or Video
<!--- Provide an easily accessible demonstration of the changes, if applicable -->

### Related Issues
- Issue #<NUMBER>
- Pull Request #<NUMBER>

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [x] Extend the documentation, if necessary
- [x] Merging to `main` from `fork:branchname`
