### PR TITLE
fix(concerto-vocabulary): avoid generating namespace term decorators from missing terms

### DIFF
--- a/packages/concerto-vocabulary/src/vocabularymanager.ts
+++ b/packages/concerto-vocabulary/src/vocabularymanager.ts
@@ -198,9 +198,11 @@ class VocabularyManager {
      * @param {string} locale the BCP-47 locale identifier
      * @param {string} declarationName the name of a concept or enum
      * @param {string} [propertyName] the name of a property (optional)
+     * @param {*} [options] options to configure term resolution
+     * @param {boolean} [options.generateMissing=true] whether to synthesize missing terms
      * @returns {*} the terms or null if it does not exist
      */
-    resolveTerms(modelManager: ModelManager, namespace: string, locale: string, declarationName: string, propertyName?: string) {
+    resolveTerms(modelManager: ModelManager, namespace: string, locale: string, declarationName: string, propertyName?: string, options?: any) {
         const modelFile = modelManager.getModelFile(namespace);
         // @ts-ignore
         const classDecl = modelFile ? (modelFile as any).getType(declarationName) : null;
@@ -216,7 +218,7 @@ class VocabularyManager {
                 property = propertyName ? classDecl ? classDecl.getProperty(propertyName) : null : null;
             }
         }
-        return this.getTerms(property ? property.getNamespace() : namespace, locale, property ? (property.getParent() as any).getName() : declarationName, propertyName);
+        return this.getTerms(property ? property.getNamespace() : namespace, locale, property ? (property.getParent() as any).getName() : declarationName, propertyName, options);
     }
 
     /**
@@ -256,9 +258,11 @@ class VocabularyManager {
      * @param {string} locale the BCP-47 locale identifier
      * @param {string} declarationName the name of a concept or enum
      * @param {string} [propertyName] the name of a property (optional)
+     * @param {*} [options] options to configure term resolution
+     * @param {boolean} [options.generateMissing=true] whether to synthesize missing terms
      * @returns {*} the terms or null if it does not exist
      */
-    getTerms(namespace: string, locale: string, declarationName: string, propertyName?: string): any {
+    getTerms(namespace: string, locale: string, declarationName: string, propertyName?: string, options?: any): any {
         const voc = this.getVocabulary(namespace, locale);
         let term = null;
         if (voc) {
@@ -270,9 +274,12 @@ class VocabularyManager {
         else {
             const dashIndex = locale.lastIndexOf('-');
             if (dashIndex >= 0) {
-                return this.getTerms(namespace, locale.substring(0, dashIndex), declarationName, propertyName);
+                return this.getTerms(namespace, locale.substring(0, dashIndex), declarationName, propertyName, options);
             }
             else {
+                if (options?.generateMissing === false) {
+                    return;
+                }
                 let missingKey = propertyName ? propertyName : declarationName;
                 missingKey = missingKey? missingKey : 'term';
                 return this.missingTermGenerator ? { [missingKey]: this.missingTermGenerator(namespace, locale, declarationName, propertyName) } : null;
@@ -309,7 +316,7 @@ class VocabularyManager {
 
         // @ts-ignore
         (modelManager as any).getModelFiles().forEach((model: any) => {
-            const terms = this.resolveTerms(modelManager, model.getNamespace(), locale, ''); // Corrected args
+            const terms = this.resolveTerms(modelManager, model.getNamespace(), locale, '', undefined, { generateMissing: false }); // Corrected args
             if (terms) {
                 Object.keys(terms).forEach( term => {
                     if(term === 'term') {

--- a/packages/concerto-vocabulary/test/__snapshots__/vocabularymanager.js.snap
+++ b/packages/concerto-vocabulary/test/__snapshots__/vocabularymanager.js.snap
@@ -11,24 +11,6 @@ Object {
         "arguments": Array [
           Object {
             "$class": "concerto.metamodel@1.0.0.DecoratorString",
-            "value": "Org.acme",
-          },
-        ],
-        "name": "Term",
-      },
-      "target": Object {
-        "$class": "org.accordproject.decoratorcommands@0.4.0.CommandTarget",
-        "namespace": "org.acme@1.0.0",
-      },
-      "type": "UPSERT",
-    },
-    Object {
-      "$class": "org.accordproject.decoratorcommands@0.4.0.Command",
-      "decorator": Object {
-        "$class": "concerto.metamodel@1.0.0.Decorator",
-        "arguments": Array [
-          Object {
-            "$class": "concerto.metamodel@1.0.0.DecoratorString",
             "value": "A colour",
           },
         ],
@@ -510,24 +492,6 @@ Object {
         "declaration": "Truck",
         "namespace": "org.acme@1.0.0",
         "property": "$identifier",
-      },
-      "type": "UPSERT",
-    },
-    Object {
-      "$class": "org.accordproject.decoratorcommands@0.4.0.Command",
-      "decorator": Object {
-        "$class": "concerto.metamodel@1.0.0.Decorator",
-        "arguments": Array [
-          Object {
-            "$class": "concerto.metamodel@1.0.0.DecoratorString",
-            "value": "Org.accordproject",
-          },
-        ],
-        "name": "Term",
-      },
-      "target": Object {
-        "$class": "org.accordproject.decoratorcommands@0.4.0.CommandTarget",
-        "namespace": "org.accordproject@1.0.0",
       },
       "type": "UPSERT",
     },


### PR DESCRIPTION
<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #<CORRESPONDING ISSUE NUMBER>
<!--- Provide an overall summary of the pull request -->
Namespace-level synthesized terms were redundant and could create unexpected namespace decorator output. This update preserves existing fallback behavior for declarations and properties while making namespace behavior explicit-only, keeping missing term generation enabled by default, but prevents redundant namespace-level `Term` decorators from being synthesized when a namespace term is not explicitly defined.

### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
- <ONE> Refactored term resolution to use a single path with an options flag.
- <TWO> Added generateMissing handling to term resolution so missing-term synthesis can be selectively disabled.
- <THREE> Disabled missing-term synthesis only for namespace-level decorator command generation.
- <FOUR> Updated vocabulary test snapshot.

### Flags
<!--- Provide context or concerns a reviewer should be aware of -->
- <ONE>
- <TWO>

### Screenshots or Video
<!--- Provide an easily accessible demonstration of the changes, if applicable -->

### Related Issues
- Issue #<NUMBER>
- Pull Request #<NUMBER>

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [ ] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ ] Merging to `main` from `fork:branchname`
