### PR TITLE
fix: pin transitive ajv to 8.17.1 to avoid spectral codegen crash

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,9 @@
     "packages/concerto-linter",
     "packages/concerto-linter/default-ruleset"
   ],
+  "overrides": {
+    "ajv": "8.17.1"
+  },
   "name": "concerto",
   "description": "Monorepo for concerto packages",
   "version": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "packages/concerto-linter/default-ruleset"
   ],
   "overrides": {
-    "ajv": "8.17.1"
+    "ajv@^8.0.0": "8.17.1"
   },
   "name": "concerto",
   "description": "Monorepo for concerto packages",


### PR DESCRIPTION
## Summary

- `ajv@8.20.0` introduced a codegen regression that emits invalid JS when `@stoplight/spectral-functions` compiles its `alphabetical` function schema, throwing `SyntaxError: Unexpected token ':'` at require-time.
- `@stoplight/spectral-core` declares `\"ajv\": \"^8.6.2\"`, so npm resolves to the latest 8.x — currently 8.20.0 — breaking any consumer of `concerto-linter` (and therefore `concerto-cli@4.0.0`).
- This adds an `overrides` entry pinning transitive `ajv` to `8.17.1`. `concerto-linter`'s own direct dep is already `^8.17.1`, so this just clamps the upper bound for transitive resolutions.

## Repro

```
npx -y -p @accordproject/concerto-cli@4.0.0 concerto --version
# SyntaxError: Unexpected token ':'
#   at new Function (<anonymous>)
#   at Ajv.compileSchema (...@stoplight/spectral-core/node_modules/ajv/dist/compile/index.js:89:30)
```

Discovered while migrating https://github.com/accordproject/cicero-template-library to Cicero 0.26 (which depends on `concerto-cli@4.0.0`).

## Test plan

- [ ] `npm install` at the repo root resolves a single `ajv@8.17.1`.
- [ ] `npx concerto --help` runs without the spectral codegen crash.
- [ ] Existing test suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)