### PR TITLE
fix(concerto-cto): print Double range bounds as decimal literals

### DIFF
--- a/packages/concerto-cto/src/printer.ts
+++ b/packages/concerto-cto/src/printer.ts
@@ -197,12 +197,12 @@ function modifiersFromMetaModel(mm: any): string {
         case `${MetaModelNamespace}.DoubleProperty`:
         case `${MetaModelNamespace}.DoubleScalar`:
             if (mm.defaultValue !== undefined) {
-                const doubleString = mm.defaultValue.toFixed(Math.max(1, (mm.defaultValue.toString().split('.')[1] || []).length));
+                const doubleString = toDoubleString(mm.defaultValue);
                 defaultString += ` default=${doubleString}`;
             }
             if (mm.validator) {
-                const lowerString = mm.validator.lower !== undefined ? mm.validator.lower : '';
-                const upperString = mm.validator.upper !== undefined ? mm.validator.upper : '';
+                const lowerString = mm.validator.lower !== undefined ? toDoubleString(mm.validator.lower) : '';
+                const upperString = mm.validator.upper !== undefined ? toDoubleString(mm.validator.upper) : '';
                 validatorString += ` range=[${lowerString},${upperString}]`;
             }
             break;
@@ -250,6 +250,16 @@ function modifiersFromMetaModel(mm: any): string {
     }
 
     return result + defaultString + validatorString;
+}
+
+/**
+ * Format a numeric literal as a Double token for CTO output.
+ * @param {number} value - numeric value to format
+ * @returns {string} CTO-compatible Double literal
+ */
+function toDoubleString(value: number): string {
+    const fractionalLength = (value.toString().split('.')[1] || '').length;
+    return value.toFixed(Math.max(1, fractionalLength));
 }
 
 /**

--- a/packages/concerto-cto/src/printer.ts
+++ b/packages/concerto-cto/src/printer.ts
@@ -258,8 +258,17 @@ function modifiersFromMetaModel(mm: any): string {
  * @returns {string} CTO-compatible Double literal
  */
 function toDoubleString(value: number): string {
-    const fractionalLength = (value.toString().split('.')[1] || '').length;
-    return value.toFixed(Math.max(1, fractionalLength));
+    const normalizedValue = Number(value).toLocaleString('en-US', {
+        useGrouping: false,
+        // Intl.NumberFormat permits 1..21; use the maximum to avoid exponent output.
+        maximumSignificantDigits: 21,
+    });
+
+    if (!normalizedValue.includes('.')) {
+        return `${normalizedValue}.0`;
+    }
+
+    return normalizedValue;
 }
 
 /**

--- a/packages/concerto-cto/test/printer.js
+++ b/packages/concerto-cto/test/printer.js
@@ -152,4 +152,33 @@ describe('parser', () => {
 
         result.should.include('o Double value range=[0.0,1.0]');
     });
+
+    it('Should print scientific notation Double range bounds without rounding to zero', () => {
+        const result = Printer.toCTO({
+            $class: 'concerto.metamodel@1.0.0.Model',
+            namespace: 'org.acme@1.0.0',
+            declarations: [
+                {
+                    $class: 'concerto.metamodel@1.0.0.ConceptDeclaration',
+                    name: 'Sample',
+                    isAbstract: false,
+                    properties: [
+                        {
+                            $class: 'concerto.metamodel@1.0.0.DoubleProperty',
+                            name: 'value',
+                            isArray: false,
+                            isOptional: false,
+                            validator: {
+                                $class: 'concerto.metamodel@1.0.0.DoubleDomainValidator',
+                                lower: 1e-7,
+                                upper: 1
+                            }
+                        }
+                    ]
+                }
+            ]
+        });
+
+        result.should.include('o Double value range=[0.0000001,1.0]');
+    });
 });

--- a/packages/concerto-cto/test/printer.js
+++ b/packages/concerto-cto/test/printer.js
@@ -123,4 +123,33 @@ describe('parser', () => {
         result.should.include('import org.example@1.0.0.*');
         result.should.include('from https://example.org/models/example.cto');
     });
+
+    it('Should print Double range bounds using decimal notation', () => {
+        const result = Printer.toCTO({
+            $class: 'concerto.metamodel@1.0.0.Model',
+            namespace: 'org.acme@1.0.0',
+            declarations: [
+                {
+                    $class: 'concerto.metamodel@1.0.0.ConceptDeclaration',
+                    name: 'Sample',
+                    isAbstract: false,
+                    properties: [
+                        {
+                            $class: 'concerto.metamodel@1.0.0.DoubleProperty',
+                            name: 'value',
+                            isArray: false,
+                            isOptional: false,
+                            validator: {
+                                $class: 'concerto.metamodel@1.0.0.DoubleDomainValidator',
+                                lower: 0,
+                                upper: 1
+                            }
+                        }
+                    ]
+                }
+            ]
+        });
+
+        result.should.include('o Double value range=[0.0,1.0]');
+    });
 });


### PR DESCRIPTION
<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #<CORRESPONDING ISSUE NUMBER>
<!--- Provide an overall summary of the pull request -->
Fixes a CTO printer mismatch where Double range bounds like 0 and 1 were emitted as integers, while the parser and canonical CTO expectations require Double-style literals such as 0.0 and 1.0.

### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
- <ONE> Updated Double literal formatting in `printer.ts` to reuse a dedicated formatter for:
  -  Double default values
  -  Double range lower and upper bounds
- <TWO> Added a regression test in printer.js to verify Double ranges are printed as `range=[0.0,1.0]`

### Author Checklist
- [ ] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [ ] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ ] Merging to `main` from `fork:branchname`
