### PR TITLE
fix(concerto-core): avoid path.basename in browser bundle

### DIFF
--- a/packages/concerto-core/src/basemodelmanager.ts
+++ b/packages/concerto-core/src/basemodelmanager.ts
@@ -14,8 +14,6 @@
 
 'use strict';
 
-const fsPath = require('path');
-
 const { DefaultFileLoader, FileDownloader, ModelWriter } = require('@accordproject/concerto-util');
 const { MetaModelUtil, MetaModelNamespace } = require('@accordproject/concerto-metamodel');
 
@@ -30,6 +28,10 @@ const MetamodelException = require('./metamodelexception');
 import type { ModelFileSource, ModelManagerOptions } from './types';
 type ModelFileInstance = InstanceType<typeof ModelFile>;
 type ModelFileInput = string | ModelFileInstance;
+
+function getFileNameFromIdentifier(fileIdentifier) {
+    return fileIdentifier.split(/[\\/]/).pop() || fileIdentifier;
+}
 
 // Types needed for TypeScript generation.
 /* eslint-disable no-unused-vars */
@@ -550,7 +552,7 @@ class BaseModelManager {
                 fileName = file.namespace + '.cto';
             } else {
                 let fileIdentifier = file.fileName;
-                fileName = fsPath.basename(fileIdentifier);
+                fileName = getFileNameFromIdentifier(fileIdentifier);
             }
             models.push({ 'name' : fileName, 'content' : file.definitions });
         });

--- a/packages/concerto-core/src/basemodelmanager.ts
+++ b/packages/concerto-core/src/basemodelmanager.ts
@@ -30,7 +30,8 @@ type ModelFileInstance = InstanceType<typeof ModelFile>;
 type ModelFileInput = string | ModelFileInstance;
 
 function getFileNameFromIdentifier(fileIdentifier) {
-    return fileIdentifier.split(/[\\/]/).pop() || fileIdentifier;
+    const normalizedIdentifier = fileIdentifier.replace(/[\\/]+$/, '');
+    return normalizedIdentifier.split(/[\\/]/).pop() || fileIdentifier;
 }
 
 // Types needed for TypeScript generation.

--- a/packages/concerto-core/test/modelmanager.js
+++ b/packages/concerto-core/test/modelmanager.js
@@ -815,6 +815,43 @@ concept Bar {
                 name: 'org.acme.base.cto', content: modelBase
             });
         });
+
+        it('should use the last segment for slash-delimited file identifiers', () => {
+            modelManager.addCTOModel(modelBase, 'https://example.org/models/org.acme.base.cto');
+            const models = modelManager.getModels();
+            models[1].should.deep.equal({
+                name: 'org.acme.base.cto', content: modelBase
+            });
+        });
+
+        it('should use the last segment for backslash-delimited file identifiers', () => {
+            modelManager.addCTOModel(modelBase, 'dir\\subdir\\org.acme.base.cto');
+            const models = modelManager.getModels();
+            models[1].should.deep.equal({
+                name: 'org.acme.base.cto', content: modelBase
+            });
+        });
+
+        it('should fall back to the namespace when the file name is UNKNOWN', () => {
+            const modelFile = sinon.createStubInstance(ModelFile);
+            modelFile.getNamespace.returns('org.example@1.0.0');
+            modelFile.getVersion.returns('1.0.0');
+            modelFile.isModelFile.returns(true);
+            modelFile.getAst.returns({ $class: `${MetaModelNamespace}.Model` });
+            modelFile.isExternal.returns(false);
+            modelFile.fileName = 'UNKNOWN';
+            modelFile.namespace = 'org.example@1.0.0';
+            modelFile.definitions = 'namespace org.example@1.0.0';
+
+            modelManager.addModelFile(modelFile);
+
+            const models = modelManager.getModels();
+            models.find((model) => model.content === 'namespace org.example@1.0.0').should.deep.equal({
+                name: 'org.example@1.0.0.cto',
+                content: 'namespace org.example@1.0.0'
+            });
+        });
+
         it('should return a list of name / content pairs, with External Models', async () => {
             const externalModelFile = ParserUtil.newModelAst(modelManager, `namespace org.external@1.0.0
             concept Foo{ o String baz }`, '@external.cto');

--- a/packages/concerto-core/test/modelmanager.js
+++ b/packages/concerto-core/test/modelmanager.js
@@ -832,6 +832,21 @@ concept Bar {
             });
         });
 
+        it('should use the last non-empty segment for slash-delimited file identifiers with trailing separators', () => {
+            modelManager.addCTOModel(modelBase, 'https://example.org/models/');
+            const models = modelManager.getModels();
+            models[1].should.deep.equal({
+                name: 'models', content: modelBase
+            });
+        });
+
+        it('should use the last non-empty segment for backslash-delimited file identifiers with trailing separators', () => {
+            modelManager.addCTOModel(modelBase, 'dir\\subdir\\');
+            const models = modelManager.getModels();
+            models[1].should.deep.equal({
+                name: 'subdir', content: modelBase
+            });
+        });
         it('should fall back to the namespace when the file name is UNKNOWN', () => {
             const modelFile = sinon.createStubInstance(ModelFile);
             modelFile.getNamespace.returns('org.example@1.0.0');


### PR DESCRIPTION
# Closes #1229
Removes the browser-hostile `path.basename` dependency from `BaseModelManager#getModels()` so the `@accordproject/concerto-core` browser bundle works correctly when selected by downstream bundlers.

### Changes
- Replace `path.basename(fileIdentifier)` in `packages/concerto-core/src/basemodelmanager.ts` with a browser-safe helper that extracts the last path segment from `/` or `\` delimited identifiers.
- Add regression tests in `packages/concerto-core/test/modelmanager.js` covering slash-delimited identifiers, backslash-delimited identifiers, and the existing `UNKNOWN` filename fallback.

### Flags
- This is intentionally a source-level fix only; it does not change the `browser` entry or webpack fallback configuration.
- Targeted `#getModels` tests pass locally; a broader `modelmanager.js` run still shows one unrelated pre-existing `#updateExternalModels` failure.

### Screenshots or Video
Not applicable.

### Related Issues
- Issue #1229
- Pull Request #<NUMBER>

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [x] Merging to `main` from `Rishabh060105:Rishabh060105/fix-concerto-browser-basename`