### PR TITLE
fix(concerto-core): handle RelationshipMapValueType in map value type processing

### DIFF
--- a/packages/concerto-core/src/introspect/mapvaluetype.ts
+++ b/packages/concerto-core/src/introspect/mapvaluetype.ts
@@ -91,6 +91,7 @@ class MapValueType extends Decorated {
         let decl;
         switch(this.ast.$class) {
         case `${MetaModelNamespace}.ObjectMapValueType`:
+        case `${MetaModelNamespace}.RelationshipMapValueType`:
 
             // ObjectMapValueType must have TypeIdentifier.
             if (!('type' in ast)) {

--- a/packages/concerto-core/test/introspect/mapdeclaration.js
+++ b/packages/concerto-core/test/introspect/mapdeclaration.js
@@ -143,6 +143,13 @@ describe('MapDeclaration', () => {
 
         it('should validate when map value is an identified concept declaration', () => {
             let decl = introspectUtils.loadLastDeclaration('test/data/parser/mapdeclaration/mapdeclaration.goodvalue.declaration.identified.concept.cto', MapDeclaration);
+            expect(decl.getValue().getType()).to.equal('Person');
+            decl.validate();
+        });
+
+        it('should validate when map value is a relationship declaration', () => {
+            let decl = introspectUtils.loadLastDeclaration('test/data/parser/mapdeclaration/mapdeclaration.badvalue.declaration.relationship.cto', MapDeclaration);
+            expect(decl.getValue().getType()).to.equal('Person');
             decl.validate();
         });
 


### PR DESCRIPTION
<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #<CORRESPONDING ISSUE NUMBER>
<!--- Provide an overall summary of the pull request -->
This change fixes a gap in map value type introspection where `RelationshipMapValueType` was not handled in `MapValueType.processType()`. As a result, `this.type` could remain unset and `getType()` could return `undefined` for relationship map values. The fix adds the missing switch branch and routes it through the same `TypeIdentifier` handling.

### Screenshots or Video
<!--- Provide an easily accessible demonstration of the changes, if applicable -->

### Related Issues
- Issue #<NUMBER>
- Pull Request #<NUMBER>

### Author Checklist
- [ ] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [ ] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ ] Merging to `main` from `fork:branchname`
