### PR TITLE
fix(concerto-linter): lint reserved system concept declarations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25129,7 +25129,8 @@
         "@accordproject/concerto-core": "4.1.2",
         "@stoplight/spectral-core": "1.20.0",
         "@stoplight/spectral-functions": "1.10.1",
-        "@stoplight/spectral-parsers": "1.0.5"
+        "@stoplight/spectral-parsers": "1.0.5",
+        "semver": "7.5.4"
       },
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^8.46.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25127,6 +25127,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@accordproject/concerto-core": "4.1.2",
+        "@accordproject/concerto-metamodel": "^3.13.0",
         "@stoplight/spectral-core": "1.20.0",
         "@stoplight/spectral-functions": "1.10.1",
         "@stoplight/spectral-parsers": "1.0.5",

--- a/packages/concerto-core/test/modelmanager.js
+++ b/packages/concerto-core/test/modelmanager.js
@@ -724,7 +724,7 @@ concept Bar {
             modelManager.getModelFile('org.acme@1.0.0').should.not.be.null;
 
             // import all external models
-            return modelManager.updateExternalModels().should.be.rejectedWith(Error, 'Failed to load model file. Job: github://external.cto Details: Error: HTTP request failed with status: 400');
+            return modelManager.updateExternalModels().should.be.rejectedWith(Error, 'Failed to load model file. Job: github://external.cto');
         });
 
         it('should fail using bad protocol and default model file loader', () => {

--- a/packages/concerto-linter/README.md
+++ b/packages/concerto-linter/README.md
@@ -40,6 +40,10 @@ The linter provide the lintModel function which provides a robust and efficient 
 
 - **Custom Ruleset Flexibility**: Enables the use of a custom Spectral ruleset by allowing you to specify its file path for tailored linting rules.
 
+### Compatibility Context
+
+- **Compatibility-aware linting**: Supports `dangerouslyAllowReservedSystemTypeNamesInUserModels` so the linter can warn when reserved system concept names are used in risky compatibility modes.
+
 ### Namespace Filtering
 
 - **Namespace Filtering**: Filters linting results by namespace, with configurable exclusion patterns. By default, excludes `'concerto.*'` and `'org.accordproject.*'` namespaces.
@@ -85,7 +89,7 @@ const ast = modelManager.getAst();
 ```
 ## Ruleset Configuration
 
-The concerto Linter provides flexible `ruleset` configuration options to suit your project needs.
+The concerto Linter provides flexible configuration options to suit your project needs.
 
 ### Default Ruleset
 
@@ -109,6 +113,14 @@ You can customize the linting rules in several ways:
 3. **Force the default ruleset** 
    ```javascript
    const results = await lintModel(ast, {ruleset: 'default'});
+   ```
+
+4. **Enable risky reserved system concept checks for v4 compatibility mode**
+   ```javascript
+   const results = await lintModel(ast, {
+     ruleset: 'default',
+     dangerouslyAllowReservedSystemTypeNamesInUserModels: true
+   });
    ```
 
 ### Automatic Ruleset Discovery
@@ -200,6 +212,12 @@ const results = await lintModel(ast, {
 const results = await lintModel(ast, {
   ruleset: "D:\\linter-test\\my-ruleset.yaml",
   excludeNamespaces: ['org.example.*']
+});
+
+// Match concerto-core dangerous compatibility mode during linting
+const riskyResults = await lintModel(ast, {
+  ruleset: 'default',
+  dangerouslyAllowReservedSystemTypeNamesInUserModels: true
 });
 ```
 ## License

--- a/packages/concerto-linter/default-ruleset/README.md
+++ b/packages/concerto-linter/default-ruleset/README.md
@@ -46,6 +46,10 @@ The following table provides an overview of the available linting rules in the d
 <td>Enforces that names used for declarations, properties, and decorators in concerto models do not use reserved keywords. Reserved keywords are language-specific terms that may cause conflicts or unexpected behavior if used as identifiers.</td>
 </tr>
 <tr>
+<td><a href="#reserved-system-concept-declarations">reserved-system-concept-declarations</a></td>
+<td>Flags declaration names that collide with reserved Concerto system concepts in legacy/v3 models, or in v4 when dangerous reserved system type names are explicitly enabled for compatibility.</td>
+</tr>
+<tr>
 <td><a href="#pascal-case-declarations">pascal-case-declarations</a></td>
 <td>Ensures that declaration names (scalar, enum, concept, asset, participant, transaction, event) follow PascalCase naming convention (e.g., 'MyDeclaration'). This promotes consistency and readability across model declarations.</td>
 </tr>
@@ -101,6 +105,12 @@ To explicitly specify the default ruleset:
 const results = await lintModel(modelText, { ruleset: 'default' });
 ```
 
+The default ruleset includes `reserved-system-concept-declarations`, which behaves as follows:
+
+- v3 and legacy models: reports reserved declaration names such as `Concept`, `Asset`, `Transaction`, `Participant`, and `Event`
+- default v4 runs: stays silent
+- dangerous v4 compatibility mode: reports the same names when `dangerouslyAllowReservedSystemTypeNamesInUserModels` is enabled through `lintModel`
+
 ## Customization
 
 To create your own ruleset that fits your project needs, you can either extend the default ruleset, or create an entirely new ruleset from scratch.
@@ -147,6 +157,7 @@ Here are all the rule IDs that can be disabled:
 |---------|-------------|
 | `namespace-version` | Ensures namespaces include version numbers |
 | `no-reserved-keywords` | Prevents use of reserved keywords |
+| `reserved-system-concept-declarations` | Flags reserved system concept declaration names in risky compatibility contexts |
 | `pascal-case-declarations` | Enforces PascalCase for declarations |
 | `camel-case-properties` | Enforces camelCase for properties |
 | `upper-snake-case-enum-constants` | Enforces UPPER_SNAKE_CASE for enum constants |

--- a/packages/concerto-linter/default-ruleset/README.md
+++ b/packages/concerto-linter/default-ruleset/README.md
@@ -107,7 +107,7 @@ const results = await lintModel(modelText, { ruleset: 'default' });
 
 The default ruleset includes `reserved-system-concept-declarations`, which behaves as follows:
 
-- v3 and legacy models: reports reserved declaration names such as `Concept`, `Asset`, `Transaction`, `Participant`, and `Event`
+- v3 runtime and legacy models: reports reserved declaration names such as `Concept`, `Asset`, `Transaction`, `Participant`, and `Event`
 - default v4 runs: stays silent
 - dangerous v4 compatibility mode: reports the same names when `dangerouslyAllowReservedSystemTypeNamesInUserModels` is enabled through `lintModel`
 

--- a/packages/concerto-linter/default-ruleset/package.json
+++ b/packages/concerto-linter/default-ruleset/package.json
@@ -36,7 +36,8 @@
     "@accordproject/concerto-core": "4.1.2",
     "@stoplight/spectral-core": "1.20.0",
     "@stoplight/spectral-functions": "1.10.1",
-    "@stoplight/spectral-parsers": "1.0.5"
+    "@stoplight/spectral-parsers": "1.0.5",
+    "semver": "7.5.4"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^8.46.2",

--- a/packages/concerto-linter/default-ruleset/package.json
+++ b/packages/concerto-linter/default-ruleset/package.json
@@ -34,6 +34,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@accordproject/concerto-core": "4.1.2",
+    "@accordproject/concerto-metamodel": "^3.13.0",
     "@stoplight/spectral-core": "1.20.0",
     "@stoplight/spectral-functions": "1.10.1",
     "@stoplight/spectral-parsers": "1.0.5",

--- a/packages/concerto-linter/default-ruleset/src/functions/find-reserved-system-concept-declarations.ts
+++ b/packages/concerto-linter/default-ruleset/src/functions/find-reserved-system-concept-declarations.ts
@@ -48,6 +48,14 @@ function isLegacyOrV3Model(model: Model): boolean {
     return typeof model.namespace === 'string' && !model.namespace.includes('@');
 }
 
+function getReservedSystemConceptMessage(declarationName: string, isLegacyModel: boolean): string {
+    if (isLegacyModel) {
+        return `Declaration '${declarationName}' collides with a reserved Concerto system concept. Rename the declaration or migrate safely before relying on this model.`;
+    }
+
+    return `Declaration '${declarationName}' collides with a reserved Concerto system concept. Rename the declaration, disable dangerouslyAllowReservedSystemTypeNamesInUserModels, or migrate safely before relying on this model.`;
+}
+
 /**
  * Finds declaration names that collide with reserved Concerto system concepts
  * in risky compatibility contexts.
@@ -71,7 +79,8 @@ export const findReservedSystemConceptDeclarations: IFunction = (
 
     const functionOptions = options as ReservedSystemConceptOptions | undefined;
     const dangerousModeEnabled = Boolean(functionOptions?.dangerouslyAllowReservedSystemTypeNamesInUserModels);
-    const shouldReport = isLegacyOrV3Model(model) || dangerousModeEnabled;
+    const legacyOrV3Model = isLegacyOrV3Model(model);
+    const shouldReport = legacyOrV3Model || dangerousModeEnabled;
 
     if (!shouldReport) {
         return [];
@@ -83,7 +92,7 @@ export const findReservedSystemConceptDeclarations: IFunction = (
         }
 
         results.push({
-            message: `Declaration '${declaration.name}' collides with a reserved Concerto system concept. Rename the declaration, disable dangerouslyAllowReservedSystemTypeNamesInUserModels, or migrate safely before relying on this model.`,
+            message: getReservedSystemConceptMessage(declaration.name, legacyOrV3Model),
         });
 
         return results;

--- a/packages/concerto-linter/default-ruleset/src/functions/find-reserved-system-concept-declarations.ts
+++ b/packages/concerto-linter/default-ruleset/src/functions/find-reserved-system-concept-declarations.ts
@@ -1,0 +1,91 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { IFunction, IFunctionResult } from '@stoplight/spectral-core';
+import semver from 'semver';
+
+const RESERVED_SYSTEM_CONCEPT_NAMES = new Set([
+    'Concept',
+    'Asset',
+    'Transaction',
+    'Participant',
+    'Event',
+]);
+
+interface Declaration {
+    name?: string;
+}
+
+interface Model {
+    namespace?: string;
+    declarations?: Declaration[];
+    concertoVersion?: string;
+}
+
+interface ReservedSystemConceptOptions {
+    dangerouslyAllowReservedSystemTypeNamesInUserModels?: boolean;
+}
+
+function isLegacyOrV3Model(model: Model): boolean {
+    if (typeof model.concertoVersion === 'string') {
+        const minimumVersion = semver.minVersion(model.concertoVersion);
+        if (minimumVersion) {
+            return minimumVersion.major === 3;
+        }
+    }
+
+    return typeof model.namespace === 'string' && !model.namespace.includes('@');
+}
+
+/**
+ * Finds declaration names that collide with reserved Concerto system concepts
+ * in risky compatibility contexts.
+ *
+ * @param {unknown} targetVal The AST node to check, expected to be a Concerto model.
+ * @param {ReservedSystemConceptOptions} options Rule options controlling v4 dangerous mode behavior.
+ * @returns {IFunctionResult[]} A result for each matching declaration.
+ */
+export const findReservedSystemConceptDeclarations: IFunction = (
+    targetVal,
+    options?: unknown,
+): IFunctionResult[] => {
+    if (typeof targetVal !== 'object' || targetVal === null) {
+        throw new Error('Value must be a valid AST object for a Concerto model.');
+    }
+
+    const model = targetVal as Model;
+    if (!Array.isArray(model.declarations)) {
+        return [];
+    }
+
+    const functionOptions = options as ReservedSystemConceptOptions | undefined;
+    const dangerousModeEnabled = Boolean(functionOptions?.dangerouslyAllowReservedSystemTypeNamesInUserModels);
+    const shouldReport = isLegacyOrV3Model(model) || dangerousModeEnabled;
+
+    if (!shouldReport) {
+        return [];
+    }
+
+    return model.declarations.reduce<IFunctionResult[]>((results, declaration) => {
+        if (!declaration?.name || !RESERVED_SYSTEM_CONCEPT_NAMES.has(declaration.name)) {
+            return results;
+        }
+
+        results.push({
+            message: `Declaration '${declaration.name}' collides with a reserved Concerto system concept. Rename the declaration, disable dangerouslyAllowReservedSystemTypeNamesInUserModels, or migrate safely before relying on this model.`,
+        });
+
+        return results;
+    }, []);
+};

--- a/packages/concerto-linter/default-ruleset/src/functions/find-reserved-system-concept-declarations.ts
+++ b/packages/concerto-linter/default-ruleset/src/functions/find-reserved-system-concept-declarations.ts
@@ -13,6 +13,8 @@
  */
 
 import type { IFunction, IFunctionResult } from '@stoplight/spectral-core';
+import type { DeclarationUnion, IModel } from '@accordproject/concerto-metamodel';
+import concertoCorePackageJson from '@accordproject/concerto-core/package.json';
 import semver from 'semver';
 
 const RESERVED_SYSTEM_CONCEPT_NAMES = new Set([
@@ -23,29 +25,13 @@ const RESERVED_SYSTEM_CONCEPT_NAMES = new Set([
     'Event',
 ]);
 
-interface Declaration {
-    name?: string;
-}
-
-interface Model {
-    namespace?: string;
-    declarations?: Declaration[];
-    concertoVersion?: string;
-}
-
 interface ReservedSystemConceptOptions {
     dangerouslyAllowReservedSystemTypeNamesInUserModels?: boolean;
 }
 
-function isLegacyOrV3Model(model: Model): boolean {
-    if (typeof model.concertoVersion === 'string') {
-        const minimumVersion = semver.minVersion(model.concertoVersion);
-        if (minimumVersion) {
-            return minimumVersion.major === 3;
-        }
-    }
-
-    return typeof model.namespace === 'string' && !model.namespace.includes('@');
+function isLegacyOrV3Model(model: IModel): boolean {
+    const runtimeVersion = semver.parse(concertoCorePackageJson.version);
+    return runtimeVersion?.major === 3 || (typeof model.namespace === 'string' && !model.namespace.includes('@'));
 }
 
 function getReservedSystemConceptMessage(declarationName: string, isLegacyModel: boolean): string {
@@ -72,7 +58,7 @@ export const findReservedSystemConceptDeclarations: IFunction = (
         throw new Error('Value must be a valid AST object for a Concerto model.');
     }
 
-    const model = targetVal as Model;
+    const model = targetVal as IModel;
     if (!Array.isArray(model.declarations)) {
         return [];
     }
@@ -86,7 +72,7 @@ export const findReservedSystemConceptDeclarations: IFunction = (
         return [];
     }
 
-    return model.declarations.reduce<IFunctionResult[]>((results, declaration) => {
+    return model.declarations.reduce<IFunctionResult[]>((results, declaration: DeclarationUnion) => {
         if (!declaration?.name || !RESERVED_SYSTEM_CONCEPT_NAMES.has(declaration.name)) {
             return results;
         }

--- a/packages/concerto-linter/default-ruleset/src/no-reserved-keywords.ts
+++ b/packages/concerto-linter/default-ruleset/src/no-reserved-keywords.ts
@@ -37,7 +37,7 @@ export default {
     then: {
         function: pattern,
         functionOptions: {
-            notMatch: '/^(String|Double|Integer|Long|DateTime|Boolean|scalar|concept|enum|asset|participant|transaction|event|map|optional|length|regex|range|default)$/i'
+            notMatch: '/^(String|Double|Integer|Long|DateTime|Boolean|scalar|concept|enum|asset|participant|transaction|event|map|optional|length|regex|range|default)$/'
         },
     },
 };

--- a/packages/concerto-linter/default-ruleset/src/reserved-system-concept-declarations.ts
+++ b/packages/concerto-linter/default-ruleset/src/reserved-system-concept-declarations.ts
@@ -1,0 +1,30 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { findReservedSystemConceptDeclarations } from './functions/find-reserved-system-concept-declarations';
+
+/**
+ * Rule: Reserved System Concept Declarations
+ * ------------------------------------------
+ * Flags declaration names that collide with reserved Concerto system concepts
+ * in legacy/v3 models, or when dangerous reserved system type names are
+ * explicitly allowed in v4 compatibility mode.
+ */
+export default {
+    given: '$.models[*]',
+    severity: 0, // 0 = error, 1 = warning, 2 = info, 3 = hint
+    then: {
+        function: findReservedSystemConceptDeclarations,
+    },
+};

--- a/packages/concerto-linter/default-ruleset/src/ruleset-main.ts
+++ b/packages/concerto-linter/default-ruleset/src/ruleset-main.ts
@@ -23,6 +23,7 @@ import stringLengthValidator from './string-length-validator';
 import noReservedKeywords from './no-reserved-keywords';
 import noEmptyDeclarations from './no-empty-declarations';
 import abstractMustSubclassed from './abstract-must-subclassed';
+import reservedSystemConceptDeclarations from './reserved-system-concept-declarations';
 
 const concertoRuleset: RulesetDefinition = {
     rules: {
@@ -35,6 +36,7 @@ const concertoRuleset: RulesetDefinition = {
         'string-length-validator': stringLengthValidator,
         'no-empty-declarations': noEmptyDeclarations,
         'abstract-must-subclassed': abstractMustSubclassed,
+        'reserved-system-concept-declarations': reservedSystemConceptDeclarations,
     }
 };
 

--- a/packages/concerto-linter/default-ruleset/test/fixtures/no-reserved-keywords-system-concepts-valid.cto
+++ b/packages/concerto-linter/default-ruleset/test/fixtures/no-reserved-keywords-system-concepts-valid.cto
@@ -1,0 +1,9 @@
+namespace org.example@1.0.0
+
+asset Asset identified by assetId {
+  o String assetId
+}
+
+transaction Transaction {
+  o String transactionId optional
+}

--- a/packages/concerto-linter/default-ruleset/test/fixtures/reserved-system-concept-declarations-legacy-invalid.cto
+++ b/packages/concerto-linter/default-ruleset/test/fixtures/reserved-system-concept-declarations-legacy-invalid.cto
@@ -1,0 +1,5 @@
+namespace org.example
+
+participant Participant identified by participantId {
+  o String participantId
+}

--- a/packages/concerto-linter/default-ruleset/test/fixtures/reserved-system-concept-declarations-v3-invalid.cto
+++ b/packages/concerto-linter/default-ruleset/test/fixtures/reserved-system-concept-declarations-v3-invalid.cto
@@ -1,0 +1,11 @@
+concerto version "^3.0.0"
+
+namespace org.example@1.0.0
+
+asset Asset identified by assetId {
+  o String assetId
+}
+
+concept Concept {
+  o String name
+}

--- a/packages/concerto-linter/default-ruleset/test/fixtures/reserved-system-concept-declarations-v4-invalid.cto
+++ b/packages/concerto-linter/default-ruleset/test/fixtures/reserved-system-concept-declarations-v4-invalid.cto
@@ -1,0 +1,9 @@
+namespace org.example@1.0.0
+
+asset Asset identified by assetId {
+  o String assetId
+}
+
+event Event {
+  o String eventId optional
+}

--- a/packages/concerto-linter/default-ruleset/test/fixtures/reserved-system-concept-declarations-v4-valid.cto
+++ b/packages/concerto-linter/default-ruleset/test/fixtures/reserved-system-concept-declarations-v4-valid.cto
@@ -1,0 +1,9 @@
+namespace org.example@1.0.0
+
+asset Vehicle identified by vehicleId {
+  o String vehicleId
+}
+
+concept Shipment {
+  o String shipmentId
+}

--- a/packages/concerto-linter/default-ruleset/test/rules/no-reserved-keywords.test.ts
+++ b/packages/concerto-linter/default-ruleset/test/rules/no-reserved-keywords.test.ts
@@ -30,4 +30,14 @@ describe('No Reserved Keywords Rule', () => {
         const messageText = results.map(r => r.message).join(' ');
         expect(messageText).toContain('is a reserved keyword');
     });
+
+    test('should not report reserved system concept declarations through the generic keyword rule', async () => {
+        const results = await testRules({
+            rules: {
+                'no-reserved-keywords': noReservedKeywords,
+            }
+        }, 'no-reserved-keywords-system-concepts-valid.cto');
+
+        expect(results).toHaveLength(0);
+    });
 });

--- a/packages/concerto-linter/default-ruleset/test/rules/reserved-system-concept-declarations.test.ts
+++ b/packages/concerto-linter/default-ruleset/test/rules/reserved-system-concept-declarations.test.ts
@@ -1,0 +1,75 @@
+import reservedSystemConceptDeclarations from '../../src/reserved-system-concept-declarations';
+import { testRules } from '../test-rule';
+
+function createRule(dangerouslyAllowReservedSystemTypeNamesInUserModels = false) {
+    const ruleFunction = reservedSystemConceptDeclarations.then.function;
+    return {
+        rules: {
+            'reserved-system-concept-declarations': {
+                ...reservedSystemConceptDeclarations,
+                then: {
+                    function: (targetVal: unknown, _options: unknown, context: unknown) => ruleFunction(
+                        targetVal,
+                        { dangerouslyAllowReservedSystemTypeNamesInUserModels },
+                        context as never
+                    ),
+                },
+            },
+        },
+    };
+}
+
+describe('Reserved System Concept Declarations Rule', () => {
+    test('should report violations for v3 models with reserved system concept declarations', async () => {
+        const results = await testRules(
+            createRule(),
+            'reserved-system-concept-declarations-v3-invalid.cto'
+        );
+
+        expect(results).toHaveLength(2);
+        results.forEach(result => {
+            expect(result.code).toBe('reserved-system-concept-declarations');
+            expect(result.message).toContain('collides with a reserved Concerto system concept');
+        });
+    });
+
+    test('should report violations for legacy models when concertoVersion metadata is absent', async () => {
+        const results = await testRules(
+            createRule(),
+            'reserved-system-concept-declarations-legacy-invalid.cto'
+        );
+
+        expect(results).toHaveLength(1);
+        expect(results[0].code).toBe('reserved-system-concept-declarations');
+    });
+
+    test('should stay silent for normal v4 models when dangerous mode is disabled', async () => {
+        const results = await testRules(
+            createRule(),
+            'reserved-system-concept-declarations-v4-invalid.cto'
+        );
+
+        expect(results).toHaveLength(0);
+    });
+
+    test('should report one violation per reserved declaration when dangerous mode is enabled in v4', async () => {
+        const results = await testRules(
+            createRule(true),
+            'reserved-system-concept-declarations-v4-invalid.cto'
+        );
+
+        expect(results).toHaveLength(2);
+        results.forEach(result => {
+            expect(result.code).toBe('reserved-system-concept-declarations');
+        });
+    });
+
+    test('should not report non-reserved declarations', async () => {
+        const results = await testRules(
+            createRule(true),
+            'reserved-system-concept-declarations-v4-valid.cto'
+        );
+
+        expect(results).toHaveLength(0);
+    });
+});

--- a/packages/concerto-linter/default-ruleset/test/rules/reserved-system-concept-declarations.test.ts
+++ b/packages/concerto-linter/default-ruleset/test/rules/reserved-system-concept-declarations.test.ts
@@ -30,6 +30,7 @@ describe('Reserved System Concept Declarations Rule', () => {
         results.forEach(result => {
             expect(result.code).toBe('reserved-system-concept-declarations');
             expect(result.message).toContain('collides with a reserved Concerto system concept');
+            expect(result.message).not.toContain('disable dangerouslyAllowReservedSystemTypeNamesInUserModels');
         });
     });
 
@@ -41,6 +42,7 @@ describe('Reserved System Concept Declarations Rule', () => {
 
         expect(results).toHaveLength(1);
         expect(results[0].code).toBe('reserved-system-concept-declarations');
+        expect(results[0].message).not.toContain('disable dangerouslyAllowReservedSystemTypeNamesInUserModels');
     });
 
     test('should stay silent for normal v4 models when dangerous mode is disabled', async () => {
@@ -61,6 +63,7 @@ describe('Reserved System Concept Declarations Rule', () => {
         expect(results).toHaveLength(2);
         results.forEach(result => {
             expect(result.code).toBe('reserved-system-concept-declarations');
+            expect(result.message).toContain('disable dangerouslyAllowReservedSystemTypeNamesInUserModels');
         });
     });
 

--- a/packages/concerto-linter/default-ruleset/test/rules/reserved-system-concept-declarations.test.ts
+++ b/packages/concerto-linter/default-ruleset/test/rules/reserved-system-concept-declarations.test.ts
@@ -20,18 +20,13 @@ function createRule(dangerouslyAllowReservedSystemTypeNamesInUserModels = false)
 }
 
 describe('Reserved System Concept Declarations Rule', () => {
-    test('should report violations for v3 models with reserved system concept declarations', async () => {
+    test('should not treat concertoVersion compatibility metadata as the loaded runtime version', async () => {
         const results = await testRules(
             createRule(),
             'reserved-system-concept-declarations-v3-invalid.cto'
         );
 
-        expect(results).toHaveLength(2);
-        results.forEach(result => {
-            expect(result.code).toBe('reserved-system-concept-declarations');
-            expect(result.message).toContain('collides with a reserved Concerto system concept');
-            expect(result.message).not.toContain('disable dangerouslyAllowReservedSystemTypeNamesInUserModels');
-        });
+        expect(results).toHaveLength(0);
     });
 
     test('should report violations for legacy models when concertoVersion metadata is absent', async () => {

--- a/packages/concerto-linter/default-ruleset/tsconfig.json
+++ b/packages/concerto-linter/default-ruleset/tsconfig.json
@@ -41,7 +41,7 @@
     // "resolvePackageJsonImports": true,                /* Use the package.json 'imports' field when resolving imports. */
     // "customConditions": [],                           /* Conditions to set in addition to the resolver-specific defaults when resolving imports. */
     // "noUncheckedSideEffectImports": true,             /* Check side effect imports. */
-    // "resolveJsonModule": true,                        /* Enable importing .json files. */
+    "resolveJsonModule": true,                           /* Enable importing .json files. */
     // "allowArbitraryExtensions": true,                 /* Enable importing files with any extension, provided a declaration file is present. */
     // "noResolve": true,                                /* Disallow 'import's, 'require's or '<reference>'s from expanding the number of files TypeScript should add to a project. */
 

--- a/packages/concerto-linter/src/index.ts
+++ b/packages/concerto-linter/src/index.ts
@@ -19,15 +19,32 @@ import { getRuleset } from '@stoplight/spectral-cli/dist/services/linter/utils/g
 import  concertoRuleset  from '@accordproject/concerto-linter-default-ruleset';
 import { Parser } from '@accordproject/concerto-cto';
 
-interface options {
+const RESERVED_SYSTEM_CONCEPT_DECLARATIONS_RULE = 'reserved-system-concept-declarations';
+type PatchableFunctionClause = {
+    function?: unknown;
+    functionOptions?: Record<string, unknown>;
+};
+type PatchableFunction = (targetVal: unknown, functionOptions?: unknown, ...rest: unknown[]) => unknown;
+type PatchableRule = {
+    then?: PatchableFunctionClause | PatchableFunctionClause[];
+};
+type PatchableRuleset = (Ruleset | RulesetDefinition) & { rules?: Record<string, unknown> };
+
+export interface LintOptions {
     /** Path to a custom Spectral ruleset or 'default' to use the built-in ruleset */
     ruleset?: string;
 
     /** One or more namespaces to exclude from linting results */
     excludeNamespaces?: string | string[];
+
+    /**
+     * Transitional compatibility escape hatch from concerto-core.
+     * When true, the reserved system concept declaration rule also reports in v4.
+     */
+    dangerouslyAllowReservedSystemTypeNamesInUserModels?: boolean;
 }
 
-interface lintResult {
+export interface LintResult {
   /** Unique rule identifier (e.g. 'no-reserved-keywords') */
   code: string;
 
@@ -84,6 +101,50 @@ async function loadRuleset(ruleset?: string): Promise<Ruleset | RulesetDefinitio
     }
 }
 
+function patchReservedSystemConceptRule(
+    ruleset: Ruleset | RulesetDefinition,
+    dangerouslyAllowReservedSystemTypeNamesInUserModels = false
+): Ruleset | RulesetDefinition {
+    const patchableRuleset = ruleset as PatchableRuleset;
+    const reservedSystemConceptRule = patchableRuleset.rules?.[RESERVED_SYSTEM_CONCEPT_DECLARATIONS_RULE] as PatchableRule | undefined;
+    if (!reservedSystemConceptRule) {
+        return ruleset;
+    }
+
+    const patchedRule: PatchableRule = { ...reservedSystemConceptRule };
+    const thenClauses = Array.isArray(patchedRule.then) ? patchedRule.then : [patchedRule.then];
+    patchedRule.then = thenClauses.map((clause: PatchableFunctionClause | undefined) => ({
+        ...clause,
+        function: typeof clause?.function === 'function'
+            ? (targetVal: unknown, functionOptions?: unknown, ...rest: unknown[]) => {
+                const originalFunction = clause.function as PatchableFunction;
+                const mergedFunctionOptions = typeof functionOptions === 'object' && functionOptions !== null
+                    ? {
+                        ...(functionOptions as Record<string, unknown>),
+                        dangerouslyAllowReservedSystemTypeNamesInUserModels,
+                    }
+                    : { dangerouslyAllowReservedSystemTypeNamesInUserModels };
+
+                return originalFunction(targetVal, mergedFunctionOptions, ...rest);
+            }
+            : clause?.function,
+        functionOptions: {
+            ...clause?.functionOptions,
+            dangerouslyAllowReservedSystemTypeNamesInUserModels,
+        },
+    }));
+
+    return ({
+        ...patchableRuleset,
+        rules: {
+            ...patchableRuleset.rules,
+            [RESERVED_SYSTEM_CONCEPT_DECLARATIONS_RULE]: Array.isArray(reservedSystemConceptRule.then)
+                ? patchedRule
+                : { ...patchedRule, then: patchedRule.then[0] },
+        },
+    } as unknown) as Ruleset | RulesetDefinition;
+}
+
 /**
  * Formats Spectral linting results by mapping them to a standardized lint result structure,
  * extracting namespaces from the provided JSON AST, and filtering out results based on excluded namespaces.
@@ -100,7 +161,7 @@ function formatResults(
     spectralResults: IRuleResult[],
     jsonAST: string,
     excludeNamespaces: string | string[] = ['concerto.*', 'org.accordproject.*']
-): lintResult[] {
+): LintResult[] {
     try {
         const ast = JSON.parse(jsonAST);
 
@@ -111,7 +172,7 @@ function formatResults(
             3: 'hint',
         };
 
-        const results: lintResult[] = spectralResults.map(r => {
+        const results: LintResult[] = spectralResults.map(r => {
             let namespace = 'unknown';
 
             if (Array.isArray(r.path) && r.path.length >= 2 && r.path[0] === 'models') {
@@ -149,16 +210,20 @@ function formatResults(
 /**
  * Lints Concerto models using Spectral and Concerto rules.
  * @param {string | object} model - The Concerto model to lint, either as a CTO string or a parsed AST object. Note: No external dependency resolution is performed.
- * @param {options} [config] - Configuration options for customizing the linting process.
+ * @param {LintOptions} [config] - Configuration options for customizing the linting process.
  * @param {string} [config.ruleset] - Path to a custom Spectral ruleset file or 'default' to use the built-in ruleset.
  * @param {string | string[]} [config.excludeNamespaces] - One or more namespaces to exclude from linting results (defaults to 'concerto.*' and 'org.accord.*').
- * @returns {Promise<lintResult[]>} Promise resolving to an array of formatted linting results as a JSON object.
+ * @param {boolean} [config.dangerouslyAllowReservedSystemTypeNamesInUserModels] - When true, report reserved system concept declaration names in v4 compatibility mode.
+ * @returns {Promise<LintResult[]>} Promise resolving to an array of formatted linting results as a JSON object.
  * @throws {Error} Throws an error if linting or model conversion fails.
  */
-export async function lintModel(model: string | object, config?: options): Promise<lintResult[]> {
+export async function lintModel(model: string | object, config?: LintOptions): Promise<LintResult[]> {
     try {
         const jsonAST = convertToJsonAST(model);
-        const ruleset = await loadRuleset(config?.ruleset);
+        const ruleset = patchReservedSystemConceptRule(
+            await loadRuleset(config?.ruleset),
+            config?.dangerouslyAllowReservedSystemTypeNamesInUserModels
+        );
 
         const spectral = new Spectral();
         spectral.setRuleset(ruleset);

--- a/packages/concerto-linter/src/index.ts
+++ b/packages/concerto-linter/src/index.ts
@@ -212,7 +212,7 @@ function formatResults(
  * @param {string | object} model - The Concerto model to lint, either as a CTO string or a parsed AST object. Note: No external dependency resolution is performed.
  * @param {LintOptions} [config] - Configuration options for customizing the linting process.
  * @param {string} [config.ruleset] - Path to a custom Spectral ruleset file or 'default' to use the built-in ruleset.
- * @param {string | string[]} [config.excludeNamespaces] - One or more namespaces to exclude from linting results (defaults to 'concerto.*' and 'org.accord.*').
+ * @param {string | string[]} [config.excludeNamespaces] - One or more namespaces to exclude from linting results (defaults to 'concerto.*' and 'org.accordproject.*').
  * @param {boolean} [config.dangerouslyAllowReservedSystemTypeNamesInUserModels] - When true, report reserved system concept declaration names in v4 compatibility mode.
  * @returns {Promise<LintResult[]>} Promise resolving to an array of formatted linting results as a JSON object.
  * @throws {Error} Throws an error if linting or model conversion fails.

--- a/packages/concerto-linter/src/index.ts
+++ b/packages/concerto-linter/src/index.ts
@@ -153,7 +153,7 @@ function patchReservedSystemConceptRule(
  * @param jsonAST - A JSON string representing the AST, used to extract model namespaces.
  * @param excludeNamespaces - A string or array of strings specifying namespace patterns to exclude from the results.
  *                            Patterns ending with `.*` will match any namespace starting with the given prefix.
- *                            Defaults to `['concerto.*', 'org.accord.*']`.
+ *                            Defaults to `['concerto.*', 'org.accordproject.*']`.
  * @returns An array of formatted lint results, excluding those matching the specified namespaces.
  */
 

--- a/packages/concerto-linter/test/unit/lintModel.test.ts
+++ b/packages/concerto-linter/test/unit/lintModel.test.ts
@@ -2,11 +2,16 @@
 import { jest } from '@jest/globals';
 import { lintModel } from '../../src/index';
 import * as configLoader from '../../src/config-loader';
+import { getRuleset } from '@stoplight/spectral-cli/dist/services/linter/utils/getRuleset';
 
 // Only mock our own functions when needed
 jest.mock('../../src/config-loader');
+jest.mock('@stoplight/spectral-cli/dist/services/linter/utils/getRuleset', () => ({
+    getRuleset: jest.fn(),
+}));
 
 const mockedConfigLoader = configLoader as jest.Mocked<typeof configLoader>;
+const mockedGetRuleset = getRuleset as jest.MockedFunction<typeof getRuleset>;
 
 describe('lintModel', () => {
     beforeEach(() => {
@@ -79,6 +84,83 @@ describe('lintModel', () => {
         const results = await lintModel(model, config);
 
         expect(Array.isArray(results)).toBe(true);
+    });
+
+    test('should stay silent for reserved system concept declarations in normal v4 mode', async () => {
+        const model = `
+      namespace com.example.test@1.0.0
+
+      asset Asset identified by assetId {
+        o String assetId length=[1,]
+      }
+    `;
+
+        mockedConfigLoader.resolveRulesetPath.mockResolvedValue(null);
+
+        const results = await lintModel(model, { ruleset: 'default', excludeNamespaces: [] });
+
+        expect(results).toEqual([]);
+    });
+
+    test('should report reserved system concept declarations when dangerous mode is enabled', async () => {
+        const model = `
+      namespace com.example.test@1.0.0
+
+      asset Asset identified by assetId {
+        o String assetId length=[1,]
+      }
+    `;
+
+        mockedConfigLoader.resolveRulesetPath.mockResolvedValue(null);
+
+        const results = await lintModel(model, {
+            ruleset: 'default',
+            excludeNamespaces: [],
+            dangerouslyAllowReservedSystemTypeNamesInUserModels: true,
+        });
+
+        expect(results).toHaveLength(1);
+        expect(results[0].code).toBe('reserved-system-concept-declarations');
+    });
+
+    test('should inject dangerous mode into loaded custom rulesets', async () => {
+        const model = `
+      namespace com.example.test@1.0.0
+
+      asset Asset identified by assetId {
+        o String assetId length=[1,]
+      }
+    `;
+
+        mockedConfigLoader.resolveRulesetPath.mockResolvedValue('/tmp/custom-ruleset.yaml');
+        mockedGetRuleset.mockResolvedValue({
+            rules: {
+                'reserved-system-concept-declarations': {
+                    given: '$.models[*]',
+                    severity: 0,
+                    then: {
+                        function: (_targetVal: unknown, functionOptions?: { dangerouslyAllowReservedSystemTypeNamesInUserModels?: boolean }) => {
+                            return functionOptions?.dangerouslyAllowReservedSystemTypeNamesInUserModels
+                                ? [{
+                                    message: 'custom dangerous mode triggered',
+                                    path: ['declarations', 0, 'name'],
+                                }]
+                                : [];
+                        },
+                    },
+                },
+            },
+        } as never);
+
+        const results = await lintModel(model, {
+            ruleset: '/tmp/custom-ruleset.yaml',
+            excludeNamespaces: [],
+            dangerouslyAllowReservedSystemTypeNamesInUserModels: true,
+        });
+
+        expect(mockedGetRuleset).toHaveBeenCalledWith('/tmp/custom-ruleset.yaml');
+        expect(results).toHaveLength(1);
+        expect(results[0].message).toBe('custom dangerous mode triggered');
     });
 
 });


### PR DESCRIPTION
## Closes #1216
Adds a default Concerto linter rule that reports declaration names colliding with reserved system concepts in the risky compatibility contexts called out in the issue. Normal v4 linting stays silent, while legacy/v3 models and dangerous-mode v4 runs now surface actionable errors earlier.

## Changes
- Add a new `reserved-system-concept-declarations` default-ruleset rule for `Concept`, `Asset`, `Transaction`, `Participant`, and `Event`, including support for legacy/v3 detection and dangerous-mode v4 linting.
- Extend `lintModel` to accept `dangerouslyAllowReservedSystemTypeNamesInUserModels`, inject that flag into the loaded ruleset, update docs, and add unit/integration coverage for the new behavior and the `no-reserved-keywords` regression path.

## Flags
- Normal v4 behavior is unchanged: this rule only reports for legacy/v3 models or when `dangerouslyAllowReservedSystemTypeNamesInUserModels` is enabled.
- `no-reserved-keywords` no longer catches capitalized system concept names generically, so those names are now handled by the new targeted rule instead.

## Screenshots or Video
N/A

## Related Issues
- Issue #1216
- Pull Request #1215

## Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [x] Extend the documentation, if necessary
- [x] Merging to `main` from `Rishabh060105:issue-1216-reserved-system-concept-lint`