### PR TITLE
fix(*): clone imports in ModelFile.filter to prevent mutation

### DIFF
--- a/packages/concerto-core/src/introspect/modelfile.ts
+++ b/packages/concerto-core/src/introspect/modelfile.ts
@@ -886,6 +886,7 @@ class ModelFile extends Decorated {
         const ast = {
             ...this.ast,
             declarations: declarations,
+            imports: this.ast.imports?.map(imp => ({...imp})),
         };
         if (ast.declarations?.length > 0){
             return new ModelFile(modelManager, ast, undefined, this.fileName);


### PR DESCRIPTION
<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #<CORRESPONDING ISSUE NUMBER>
<!--- Provide an overall summary of the pull request -->
`ModelFile.filter` used a shallow spread `({ ...this.ast })` to create the filtered AST, which shared import objects with the original model file. `BaseModelManager.filter` then mutated `imp.types` in-place on those shared objects, corrupting the source model files


### Author Checklist
- [ ] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [ ] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ ] Merging to `main` from `fork:branchname`
