### PR TITLE
fix(concertino): avoid browser import failure

### DIFF
--- a/packages/concertino/src/index.ts
+++ b/packages/concertino/src/index.ts
@@ -20,11 +20,10 @@
 /* eslint-disable valid-jsdoc */
 import { IModels } from '@accordproject/concerto-metamodel';
 import { IConcertino } from './spec/concertino.metamodel@4.0.0-alpha.2';
+import schema from './spec/concertino.schema.json';
 import { convertToConcertino } from './concertinoSerializer';
 import { convertToMetamodel } from './metamodelSerializer';
 import Ajv, { ValidateFunction } from 'ajv';
-import { readFileSync } from 'fs';
-import { join } from 'path';
 
 /**
  * Conversion options for Concertino format.
@@ -36,14 +35,12 @@ export interface ConcertinoOptions {
   version?: string;
 }
 
-const schema = JSON.parse(readFileSync(join(__dirname, 'spec/concertino.schema.json'), 'utf-8'));
-
 /**
  * Concertino utility class for converting between Concerto metamodel and Concertino format.
  */
 export class ConcertinoConverter {
     private options: ConcertinoOptions;
-    private validate: ValidateFunction;
+    private validate?: ValidateFunction;
     private ajv: Ajv;
 
     /**
@@ -56,7 +53,6 @@ export class ConcertinoConverter {
             ...options
         };
         this.ajv = new Ajv();
-        this.validate = this.ajv.compile(schema);
     }
 
     /**
@@ -82,11 +78,19 @@ export class ConcertinoConverter {
     }
 
     public isValid(concertino: IConcertino): boolean {
-        return this.validate(concertino);
+        return this.getValidator()(concertino);
     }
 
     public getValidationErrors() {
-        return this.validate.errors;
+        return this.validate?.errors ?? null;
+    }
+
+    private getValidator(): ValidateFunction {
+        if (!this.validate) {
+            this.validate = this.ajv.compile(schema);
+        }
+
+        return this.validate;
     }
 
 }

--- a/packages/concertino/test/concertino.test.ts
+++ b/packages/concertino/test/concertino.test.ts
@@ -7,7 +7,8 @@ import { ConcertinoConverter } from '../src/';
 import { determineScalarType, dispatchDeclaration, getInheritanceChain, determinePropertyType } from '../src/concertinoSerializer';
 import { readdirSync, statSync } from 'fs';
 import { IModel, IModels } from '@accordproject/concerto-metamodel';
-import { it, expect, describe } from 'vitest';
+import Ajv from 'ajv';
+import { afterEach, it, expect, describe, vi } from 'vitest';
 
 const loadAllCtoFiles = (dir: string, models: object[]): void => {
     const files = readdirSync(dir);
@@ -31,6 +32,10 @@ const loadAllCtoFiles = (dir: string, models: object[]): void => {
         }
     });
 };
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
 
 describe('concertino roundtripping (sample models)', () => {
     const models: IModel[] = [];
@@ -64,6 +69,34 @@ describe('concertino roundtripping (sample models)', () => {
 });
 
 describe('concertino edge cases and error handling', () => {
+    it('should lazily compile the validator', () => {
+        const compileSpy = vi.spyOn(Ajv.prototype, 'compile');
+        const converter = new ConcertinoConverter();
+        const ast = {
+            $class: 'concerto.metamodel@1.0.0.Models',
+            models: [{
+                $class: 'concerto.metamodel@1.0.0.Model',
+                namespace: 'sourceUriTest@1.0.0',
+                sourceUri: 'uri'
+            }],
+        };
+
+        expect(compileSpy).not.toHaveBeenCalled();
+        expect(converter.getValidationErrors()).toBeNull();
+
+        const concertino = converter.fromConcertoMetamodel(ast);
+        expect(compileSpy).not.toHaveBeenCalled();
+        expect(converter.toConcertoMetamodel(concertino)).toStrictEqual(ast);
+        expect(compileSpy).not.toHaveBeenCalled();
+
+        expect(converter.isValid(concertino)).toBe(true);
+        expect(compileSpy).toHaveBeenCalledTimes(1);
+        expect(converter.getValidationErrors()).toBeNull();
+
+        expect(converter.isValid(concertino)).toBe(true);
+        expect(compileSpy).toHaveBeenCalledTimes(1);
+    });
+
     it('should roundtrip sourceUri', () => {
         const converter = new ConcertinoConverter();
         const ast = {

--- a/packages/concertino/tsconfig.json
+++ b/packages/concertino/tsconfig.json
@@ -33,7 +33,7 @@
     // "typeRoots": [],                                  /* Specify multiple folders that act like `./node_modules/@types`. */
     // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
     // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
-    // "resolveJsonModule": true,                        /* Enable importing .json files */
+    "resolveJsonModule": true,                          /* Enable importing .json files */
     // "noResolve": true,                                /* Disallow `import`s, `require`s or `<reference>`s from expanding the number of files TypeScript should add to a project. */
 
     /* JavaScript Support */


### PR DESCRIPTION

# Closes #1245
Ensure `@accordproject/concertino` can be imported safely in browser and bundler environments by removing top-level filesystem access from the package entrypoint and compiling the AJV validator only when validation is requested.

### Changes
- Replace eager schema loading via `fs.readFileSync(...)` with a JSON module import and lazy validator initialization inside `ConcertinoConverter`.
- Add regression coverage for lazy validator compilation and cached reuse, and enable `resolveJsonModule` for the `concertino` TypeScript build.

### Flags
- The package root no longer imports `fs` or `path`, which avoids browser bundler failures when consumers only need `fromConcertoMetamodel` or `toConcertoMetamodel`.
- Validation-related work and any schema-compilation failures now move from `ConcertinoConverter` construction time to the first `isValid()` call.

### Screenshots or Video
- N/A

### Related Issues
- Issue #1245
- Pull Request #1235

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [x] Merging to `main` from `Rishabh060105:issue-1245-concertino-browser-import`