### PR TITLE
perf(concerto-core): optimize   ModelManager and ModelFile filter   operations

### DIFF
--- a/packages/concerto-core/src/basemodelmanager.ts
+++ b/packages/concerto-core/src/basemodelmanager.ts
@@ -852,9 +852,11 @@ class BaseModelManager {
      * ModelFiles with no declarations after filtering will be removed.
      *
      * @param {FilterFunction} predicate - the filter function over a Declaration object
+     * @param {Object} [options] - options for the filter method
+     * @param {boolean} [options.disableValidation] — If true then the model files are not validated
      * @returns {BaseModelManager} - the filtered ModelManager
      */
-    filter(predicate){
+    filter(predicate, options?){
         const modelManager = new BaseModelManager({...this.options}, this.processFile);
         const filteredModels: ModelFileInstance[] = [];
 
@@ -868,7 +870,7 @@ class BaseModelManager {
             }
         }
 
-        modelManager.addModelFiles(filteredModels);
+        modelManager.addModelFiles(filteredModels, undefined, options?.disableValidation);
         return modelManager;
     }
 }

--- a/packages/concerto-core/src/basemodelmanager.ts
+++ b/packages/concerto-core/src/basemodelmanager.ts
@@ -209,9 +209,9 @@ class BaseModelManager {
              throw new Error(`Failed to load getDecoratorModel. Got: ${typeof getDecoratorModel}`);
         }
         const {decoratorModelAst, decoratorModelCto, decoratorModelFile} = getDecoratorModel();
-        
+
         const m = new ModelFile(this, decoratorModelAst, decoratorModelCto, decoratorModelFile);
- 
+
         this.addModelFile(m, decoratorModelCto, decoratorModelFile, true);
     }
 
@@ -856,59 +856,19 @@ class BaseModelManager {
      */
     filter(predicate){
         const modelManager = new BaseModelManager({...this.options}, this.processFile);
-        const removedFqns = []; // the list of FQN of types that have been removed
+        const filteredModels: ModelFileInstance[] = [];
 
-        // remove the types from model files, populating removedFqns
-        let filteredModels = Object.values(this.modelFiles)
-            .map((modelFile: ModelFileInstance) => modelFile.filter(predicate, modelManager, removedFqns))
-            .filter(Boolean);
-
-        // remove concerto model files - as these are automatically added
-        // when we recreate the model manager below
-        filteredModels = filteredModels.filter(mf => !mf.isSystemModelFile());
-
-        // now update filteredModels to remove any imports of removed types
-        const modelsWithValidImports = filteredModels.map( modelFile => {
-            const ast = modelFile.getAst();
-            let modified = false;
-            removedFqns.forEach( removedFqn => {
-                const ns = ModelUtil.getNamespace(removedFqn);
-                const isSystemImport = ns.startsWith('concerto@') || ns === 'concerto';
-                if(!isSystemImport && modelFile.getImports().includes(removedFqn)) {
-                    const removeName = ModelUtil.getShortName(removedFqn);
-                    const removeNamespace = ModelUtil.getNamespace(removedFqn);
-                    ast.imports = ast.imports.filter(imp => {
-                        const remove = ModelUtil.getShortName(imp.$class) === 'ImportType' &&
-                            imp.name === removeName &&
-                            imp.namespace === removeNamespace;
-                        if(remove) {
-                            modified = true;
-                        }
-                        return !remove;
-                    });
-                    ast.imports.forEach( imp => {
-                        if(imp.namespace === removeNamespace) {
-                            if(ModelUtil.getShortName(imp.$class) === 'ImportTypes') {
-                                imp.types = imp.types.filter((type) => {
-                                    const remove = (type === removeName);
-                                    if(remove) {
-                                        modified = true;
-                                    }
-                                    return !remove;
-                                });
-                            }
-                        }
-                    });
-                }
-            });
-            if(modified) {
-                return new ModelFile(this, ast, undefined, modelFile.fileName);
+        for (const modelFile of Object.values(this.modelFiles) as ModelFileInstance[]) {
+            if (modelFile.isSystemModelFile()) {
+                continue;
             }
-            else {
-                return modelFile;
+            const filtered = modelFile.filter(predicate, modelManager);
+            if (filtered) {
+                filteredModels.push(filtered);
             }
-        });
-        modelManager.addModelFiles(modelsWithValidImports);
+        }
+
+        modelManager.addModelFiles(filteredModels);
         return modelManager;
     }
 }

--- a/packages/concerto-core/src/introspect/modelfile.ts
+++ b/packages/concerto-core/src/introspect/modelfile.ts
@@ -865,9 +865,14 @@ class ModelFile extends Decorated {
      *
      * Will return null if the filtered ModelFile doesn't contain any declarations.
      *
+     * The predicate is also invoked on declarations from imported files to
+     * determine whether each import should be retained. It must be
+     * side-effect-free and total across all reachable namespaces.
+     *
      * @param {FilterFunction} predicate - the filter function over a Declaration object
      * @param {ModelManager} modelManager - the target ModelManager for the filtered ModelFile
      * @returns {ModelFile?} - the filtered ModelFile
+     * @private
      */
     filter(predicate, modelManager){
         const declarations: any[] = [];
@@ -891,20 +896,24 @@ class ModelFile extends Decorated {
             const sourceManager = this.getModelManager();
 
             ast.imports = ast.imports.filter(imp => {
-                if (ModelUtil.getShortName(imp.$class) === 'ImportType') {
-                    const sourceFile = sourceManager.getModelFile(imp.namespace);
+                const ns = imp.namespace;
+                if (ns.startsWith('concerto@') || ns === 'concerto') {
+                    return true;
+                }
+
+                const shortClass = ModelUtil.getShortName(imp.$class);
+
+                if (shortClass === 'ImportType') {
+                    const sourceFile = sourceManager.getModelFile(ns);
                     if (!sourceFile) {
                         return true;
                     }
                     const decl = sourceFile.getLocalType(imp.name);
                     return !decl || predicate(decl);
                 }
-                return true;
-            });
 
-            ast.imports = ast.imports.filter(imp => {
-                if (ModelUtil.getShortName(imp.$class) === 'ImportTypes') {
-                    const sourceFile = sourceManager.getModelFile(imp.namespace);
+                if (shortClass === 'ImportTypes') {
+                    const sourceFile = sourceManager.getModelFile(ns);
                     if (!sourceFile) {
                         return true;
                     }
@@ -914,6 +923,7 @@ class ModelFile extends Decorated {
                     });
                     return imp.types.length > 0;
                 }
+
                 return true;
             });
         }

--- a/packages/concerto-core/src/introspect/modelfile.ts
+++ b/packages/concerto-core/src/introspect/modelfile.ts
@@ -867,31 +867,56 @@ class ModelFile extends Decorated {
      *
      * @param {FilterFunction} predicate - the filter function over a Declaration object
      * @param {ModelManager} modelManager - the target ModelManager for the filtered ModelFile
-     * @param {string[]} removedDeclarations - an array that will be populated with the FQN of removed declarations
      * @returns {ModelFile?} - the filtered ModelFile
-     * @private
      */
-    filter(predicate, modelManager, removedDeclarations){
-        let declarations: any[] = []; // ast for all included declarations
-        this.declarations?.forEach( declaration => {
-            const included = predicate(declaration);
-            if(!included) {
-                removedDeclarations.push(declaration.getFullyQualifiedName());
-            }
-            else {
+    filter(predicate, modelManager){
+        const declarations: any[] = [];
+        for (const declaration of this.declarations) {
+            if (predicate(declaration)) {
                 declarations.push(declaration.ast);
             }
-        } );
+        }
+
+        if (declarations.length === 0) {
+            return null;
+        }
 
         const ast = {
             ...this.ast,
-            declarations: declarations,
+            declarations,
             imports: this.ast.imports?.map(imp => ({...imp})),
         };
-        if (ast.declarations?.length > 0){
-            return new ModelFile(modelManager, ast, undefined, this.fileName);
+
+        if (ast.imports) {
+            const sourceManager = this.getModelManager();
+
+            ast.imports = ast.imports.filter(imp => {
+                if (ModelUtil.getShortName(imp.$class) === 'ImportType') {
+                    const sourceFile = sourceManager.getModelFile(imp.namespace);
+                    if (!sourceFile) {
+                        return true;
+                    }
+                    const decl = sourceFile.getLocalType(imp.name);
+                    return !decl || predicate(decl);
+                }
+                return true;
+            });
+
+            for (const imp of ast.imports) {
+                if (ModelUtil.getShortName(imp.$class) === 'ImportTypes') {
+                    const sourceFile = sourceManager.getModelFile(imp.namespace);
+                    if (!sourceFile) {
+                        continue;
+                    }
+                    imp.types = imp.types.filter(type => {
+                        const decl = sourceFile.getLocalType(type);
+                        return !decl || predicate(decl);
+                    });
+                }
+            }
         }
-        return null;
+
+        return new ModelFile(modelManager, ast, undefined, this.fileName);
     }
 }
 

--- a/packages/concerto-core/src/introspect/modelfile.ts
+++ b/packages/concerto-core/src/introspect/modelfile.ts
@@ -902,18 +902,20 @@ class ModelFile extends Decorated {
                 return true;
             });
 
-            for (const imp of ast.imports) {
+            ast.imports = ast.imports.filter(imp => {
                 if (ModelUtil.getShortName(imp.$class) === 'ImportTypes') {
                     const sourceFile = sourceManager.getModelFile(imp.namespace);
                     if (!sourceFile) {
-                        continue;
+                        return true;
                     }
                     imp.types = imp.types.filter(type => {
                         const decl = sourceFile.getLocalType(type);
                         return !decl || predicate(decl);
                     });
+                    return imp.types.length > 0;
                 }
-            }
+                return true;
+            });
         }
 
         return new ModelFile(modelManager, ast, undefined, this.fileName);

--- a/packages/concerto-core/test/introspect/modelfile.js
+++ b/packages/concerto-core/test/introspect/modelfile.js
@@ -856,4 +856,60 @@ describe('ModelFile', () => {
         });
     });
 
+    describe('#filter', () => {
+        it('should return a filtered ModelFile keeping only matching declarations', () => {
+            modelManager.addCTOModel(`namespace org.filter@1.0.0
+            concept Kept {}
+            concept Removed {}
+            `, 'filter.cto');
+
+            const modelFile = modelManager.getModelFile('org.filter@1.0.0');
+            const filtered = modelFile.filter(
+                decl => decl.getFullyQualifiedName() === 'org.filter@1.0.0.Kept',
+                modelManager
+            );
+
+            filtered.should.not.be.null;
+            filtered.getAllDeclarations().length.should.equal(1);
+            filtered.getAllDeclarations()[0].getName().should.equal('Kept');
+        });
+
+        it('should return null if no declarations match', () => {
+            modelManager.addCTOModel(`namespace org.filter2@1.0.0
+            concept OnlyOne {}
+            `, 'filter2.cto');
+
+            const modelFile = modelManager.getModelFile('org.filter2@1.0.0');
+            const filtered = modelFile.filter(
+                () => false,
+                modelManager
+            );
+
+            should.not.exist(filtered);
+        });
+
+        it('should clean imports referencing filtered-out types', () => {
+            modelManager.addCTOModel(`namespace org.dep@1.0.0
+            concept Used {}
+            concept Unused {}
+            `, 'dep.cto');
+
+            modelManager.addCTOModel(`namespace org.consumer@1.0.0
+            import org.dep@1.0.0.{Used, Unused}
+            concept Consumer {
+                o Used used
+            }
+            `, 'consumer.cto');
+
+            const modelFile = modelManager.getModelFile('org.consumer@1.0.0');
+            const predicate = decl => decl.getFullyQualifiedName() !== 'org.dep@1.0.0.Unused';
+            const filtered = modelFile.filter(predicate, modelManager);
+
+            filtered.should.not.be.null;
+            const imports = filtered.getImports();
+            imports.should.include('org.dep@1.0.0.Used');
+            imports.should.not.include('org.dep@1.0.0.Unused');
+        });
+    });
+
 });

--- a/packages/concerto-core/test/introspect/modelfile.js
+++ b/packages/concerto-core/test/introspect/modelfile.js
@@ -910,6 +910,44 @@ describe('ModelFile', () => {
             imports.should.include('org.dep@1.0.0.Used');
             imports.should.not.include('org.dep@1.0.0.Unused');
         });
+
+        it('should filter out ImportTypeFrom when its type is excluded', () => {
+            modelManager.addCTOModel(`namespace org.dep@1.0.0
+            concept Foo {}
+            `, 'dep.cto');
+
+            modelManager.addCTOModel(`namespace org.consumer@1.0.0
+            import org.dep@1.0.0.Foo from https://example.com/dep.cto
+            concept Consumer {}
+            `, 'consumer.cto');
+
+            const modelFile = modelManager.getModelFile('org.consumer@1.0.0');
+            const predicate = decl => decl.getFullyQualifiedName() !== 'org.dep@1.0.0.Foo';
+            const filtered = modelFile.filter(predicate, modelManager);
+
+            const ast = filtered.getAst();
+            const depImport = ast.imports.find(imp => imp.namespace === 'org.dep@1.0.0');
+            should.not.exist(depImport);
+        });
+
+        it('should remove the entire import when all its types are filtered out', () => {
+            modelManager.addCTOModel(`namespace org.dep@1.0.0
+            concept OnlyType {}
+            `, 'dep.cto');
+
+            modelManager.addCTOModel(`namespace org.consumer@1.0.0
+            import org.dep@1.0.0.{OnlyType}
+            concept Consumer {}
+            `, 'consumer.cto');
+
+            const modelFile = modelManager.getModelFile('org.consumer@1.0.0');
+            const predicate = decl => decl.getFullyQualifiedName() !== 'org.dep@1.0.0.OnlyType';
+            const filtered = modelFile.filter(predicate, modelManager);
+
+            const ast = filtered.getAst();
+            const depImport = ast.imports.find(imp => imp.namespace === 'org.dep@1.0.0');
+            should.not.exist(depImport);
+        });
     });
 
 });

--- a/packages/concerto-core/test/introspect/modelfile.js
+++ b/packages/concerto-core/test/introspect/modelfile.js
@@ -930,6 +930,53 @@ describe('ModelFile', () => {
             should.not.exist(depImport);
         });
 
+        it('should never remove system imports regardless of predicate', () => {
+            modelManager.addCTOModel(`namespace org.test@1.0.0
+            import concerto@1.0.0.Concept
+            concept Foo {}
+            `, 'test.cto');
+
+            const modelFile = modelManager.getModelFile('org.test@1.0.0');
+            const filtered = modelFile.filter(
+                decl => decl.getFullyQualifiedName() === 'org.test@1.0.0.Foo',
+                modelManager
+            );
+
+            const ast = filtered.getAst();
+            const systemImport = ast.imports.find(imp =>
+                imp.namespace.startsWith('concerto@') || imp.namespace === 'concerto'
+            );
+            should.exist(systemImport);
+        });
+
+        it('should retain ImportType when source file is not in model manager', () => {
+            modelManager.addCTOModel(`namespace org.test@1.0.0
+            import org.missing@1.0.0.Unknown
+            concept Keeper {}
+            `, 'test.cto', true);
+
+            const modelFile = modelManager.getModelFile('org.test@1.0.0');
+            const filtered = modelFile.filter(() => true, modelManager);
+
+            const filteredAst = filtered.getAst();
+            const missingImport = filteredAst.imports.find(imp => imp.namespace === 'org.missing@1.0.0');
+            should.exist(missingImport);
+        });
+
+        it('should retain ImportTypes when source file is not in model manager', () => {
+            modelManager.addCTOModel(`namespace org.test2@1.0.0
+            import org.missing@1.0.0.{Unknown}
+            concept Keeper {}
+            `, 'test2.cto', true);
+
+            const modelFile = modelManager.getModelFile('org.test2@1.0.0');
+            const filtered = modelFile.filter(() => true, modelManager);
+
+            const filteredAst = filtered.getAst();
+            const missingImport = filteredAst.imports.find(imp => imp.namespace === 'org.missing@1.0.0');
+            should.exist(missingImport);
+        });
+
         it('should remove the entire import when all its types are filtered out', () => {
             modelManager.addCTOModel(`namespace org.dep@1.0.0
             concept OnlyType {}

--- a/packages/concerto-core/test/modelmanager.js
+++ b/packages/concerto-core/test/modelmanager.js
@@ -1187,6 +1187,22 @@ concept Bar {
             filtered.validateModelFiles();
         });
 
+        it('should skip validation when disableValidation option is set', () => {
+            modelManager.addCTOModel(`namespace org.skip@1.0.0
+            concept Kept {}
+            concept Removed {}
+            `, 'skip.cto');
+
+            const filtered = modelManager.filter(
+                decl => decl.getFullyQualifiedName() === 'org.skip@1.0.0.Kept',
+                { disableValidation: true }
+            );
+
+            filtered.getModelFiles().length.should.equal(1);
+            filtered.getModelFiles()[0].getAllDeclarations().length.should.equal(1);
+            filtered.getModelFiles()[0].getAllDeclarations()[0].getName().should.equal('Kept');
+        });
+
         it('should remove imports for filtered types', () => {
             modelManager.addCTOModel(`namespace child@1.0.0
             concept Used {}


### PR DESCRIPTION
<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #<CORRESPONDING ISSUE NUMBER>
<!--- Provide an overall summary of the pull request -->

- `BaseModelManager.filter` previously constructed each ModelFile 2–3× per file (once to filter, once for import cleanup, plus re-validation). Now exactly 1× — each avoided construction skips a full AST parse + semantic validation pass, which dominates wall-clock cost.
- `ModelFile.filter` is now self-contained: returns a fully correct ModelFile with cleaned imports, requiring only a predicate and target model manager.
- Added `disableValidation` option to `BaseModelManager.filter`.
- - Replaced O(M × R × T) nested import cleanup with O(N + T) linear approach using predicate-based import validation
- When all types in an `ImportTypes` entry were filtered out, the empty entry remained in the AST, causing the CTO printer to emit invalid `import ns.{}` syntax. Now removes the entire import when no types remain.
- Handles ImportTypeFrom (single named import with URI) in addition to ImportType.

### Complexity improvement

- **Before**: for each model file, iterated all removed FQNs and called `getImports()` (which rebuilds the full FQN list each call)

- **After**: O(N + T) — linear in total declarations plus total import type references using `O(1) getModelFile + getLocalType` lookups

Where 
  - N = total declarations, 
  - T = total import type references, 
  - M = model files,
  - R = removed declarations, 

### Author Checklist
- [ ] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [ ] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ ] Merging to `main` from `fork:branchname`