### PR TITLE
fix(concerto-cto): skip ImportTypes with empty types array in printer

### DIFF
--- a/packages/concerto-core/src/introspect/modelfile.ts
+++ b/packages/concerto-core/src/introspect/modelfile.ts
@@ -921,7 +921,13 @@ class ModelFile extends Decorated {
                         const decl = sourceFile.getLocalType(type);
                         return !decl || predicate(decl);
                     });
-                    return imp.types.length > 0;
+                    if (imp.types.length === 0) {
+                        return false;
+                    }
+                    if (imp.aliasedTypes && imp.aliasedTypes.length > 0) {
+                        imp.aliasedTypes = imp.aliasedTypes.filter(a => imp.types.includes(a.name));
+                    }
+                    return true;
                 }
 
                 return true;

--- a/packages/concerto-core/test/introspect/modelfile.js
+++ b/packages/concerto-core/test/introspect/modelfile.js
@@ -977,6 +977,32 @@ describe('ModelFile', () => {
             should.exist(missingImport);
         });
 
+        it('should remove aliasedTypes entries for filtered-out types', () => {
+            modelManager.addCTOModel(`namespace org.dep@1.0.0
+            concept Kept {}
+            concept Removed {}
+            `, 'dep.cto');
+
+            modelManager.addCTOModel(`namespace org.consumer@1.0.0
+            import org.dep@1.0.0.{Kept as K, Removed as R}
+            concept Consumer {
+                o K k
+            }
+            `, 'consumer.cto');
+
+            const modelFile = modelManager.getModelFile('org.consumer@1.0.0');
+            const predicate = decl => decl.getFullyQualifiedName() !== 'org.dep@1.0.0.Removed';
+            const filtered = modelFile.filter(predicate, modelManager);
+
+            const ast = filtered.getAst();
+            const depImport = ast.imports.find(imp => imp.namespace === 'org.dep@1.0.0');
+            should.exist(depImport);
+            depImport.types.should.deep.equal(['Kept']);
+            depImport.aliasedTypes.length.should.equal(1);
+            depImport.aliasedTypes[0].name.should.equal('Kept');
+            depImport.aliasedTypes[0].aliasedName.should.equal('K');
+        });
+
         it('should remove the entire import when all its types are filtered out', () => {
             modelManager.addCTOModel(`namespace org.dep@1.0.0
             concept OnlyType {}

--- a/packages/concerto-cto/src/printer.ts
+++ b/packages/concerto-cto/src/printer.ts
@@ -439,6 +439,9 @@ function toCTO(metaModel: IModel): string {
                     break;
                 case `${MetaModelNamespace}.ImportTypes`: {
                     const typesImport = imp as IImportTypes;
+                    if (!typesImport.types || typesImport.types.length === 0) {
+                        break;
+                    }
                     const aliasedTypes = typesImport.aliasedTypes
                         ? new Map(
                             typesImport.aliasedTypes.map((aliasedType: any) => [

--- a/packages/concerto-cto/test/printer.js
+++ b/packages/concerto-cto/test/printer.js
@@ -124,6 +124,21 @@ describe('parser', () => {
         result.should.include('from https://example.org/models/example.cto');
     });
 
+    it('Should skip ImportTypes with empty types array', () => {
+        const result = Printer.toCTO({
+            $class: 'concerto.metamodel@1.0.0.Model',
+            namespace: 'org.acme@1.0.0',
+            imports: [{
+                $class: 'concerto.metamodel@1.0.0.ImportTypes',
+                namespace: 'org.example@1.0.0',
+                types: [],
+                aliasedTypes: []
+            }],
+            declarations: [],
+        });
+        result.should.not.include('import org.example');
+    });
+
     it('Should print Double range bounds using decimal notation', () => {
         const result = Printer.toCTO({
             $class: 'concerto.metamodel@1.0.0.Model',

--- a/packages/concerto-cto/test/printer.js
+++ b/packages/concerto-cto/test/printer.js
@@ -139,6 +139,44 @@ describe('parser', () => {
         result.should.not.include('import org.example');
     });
 
+    it('Should skip ImportTypes with empty types array and orphaned aliasedTypes', () => {
+        const result = Printer.toCTO({
+            $class: 'concerto.metamodel@1.0.0.Model',
+            namespace: 'org.acme@1.0.0',
+            imports: [{
+                $class: 'concerto.metamodel@1.0.0.ImportTypes',
+                namespace: 'org.example@1.0.0',
+                types: [],
+                aliasedTypes: [
+                    { name: 'Person', aliasedName: 'Individual' }
+                ]
+            }],
+            declarations: [],
+        });
+        result.should.not.include('import org.example');
+        result.should.not.include('Person');
+        result.should.not.include('Individual');
+    });
+
+    it('Should not print aliases for types that were filtered out', () => {
+        const result = Printer.toCTO({
+            $class: 'concerto.metamodel@1.0.0.Model',
+            namespace: 'org.acme@1.0.0',
+            imports: [{
+                $class: 'concerto.metamodel@1.0.0.ImportTypes',
+                namespace: 'org.example@1.0.0',
+                types: ['Address'],
+                aliasedTypes: [
+                    { name: 'Person', aliasedName: 'Individual' }
+                ]
+            }],
+            declarations: [],
+        });
+        result.should.include('import org.example@1.0.0.{Address}');
+        result.should.not.include('Person');
+        result.should.not.include('Individual');
+    });
+
     it('Should print Double range bounds using decimal notation', () => {
         const result = Printer.toCTO({
             $class: 'concerto.metamodel@1.0.0.Model',


### PR DESCRIPTION
<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #<CORRESPONDING ISSUE NUMBER>
<!--- Provide an overall summary of the pull request -->

- The printer emitted `import namespace.{}` for `ImportTypes` with an empty `types` array, which produces invalid CTO that fails to parse
- This occurs when the `ModelFile.filter` operation removes all types from an `ImportTypes` import but the import entry remains in the AST
- Skip empty `ImportTypes` entirely during printing since they are semantically meaningless
- Clean up aliased types from the imports when orphaned
- Added tests covering empty types with empty aliasedTypes, empty types with orphaned aliasedTypes, types present with empty aliasedTypes, and stale aliasedTypes referencing filtered-out types

### Related Issues
- Issue #<NUMBER>
- Pull Request #<NUMBER>

### Author Checklist
- [ ] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [ ] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ ] Merging to `main` from `fork:branchname`
