### PR TITLE
perf(concerto-core): optimise ModelFile.fromAst declaration and import processing

### DIFF
--- a/packages/concerto-core/src/introspect/decorated.ts
+++ b/packages/concerto-core/src/introspect/decorated.ts
@@ -81,16 +81,18 @@ class Decorated {
         this.decorators = [];
 
         if(this.ast.decorators) {
+            const modelFile: any = this.getModelFile();
+            const factories = modelFile.getModelManager()?.getDecoratorFactories();
+            const hasFactories = factories && factories.length > 0;
             for(let n=0; n < this.ast.decorators.length; n++ ) {
                 let thing = this.ast.decorators[n];
-                let modelFile: any = this.getModelFile();
-                let modelManager = modelFile.getModelManager();
-                let factories = modelManager.getDecoratorFactories();
                 let decorator;
-                for (let factory of factories) {
-                    decorator = factory.newDecorator(this, thing);
-                    if (decorator) {
-                        break;
+                if (hasFactories) {
+                    for (let factory of factories) {
+                        decorator = factory.newDecorator(this, thing);
+                        if (decorator) {
+                            break;
+                        }
                     }
                 }
                 if (!decorator) {

--- a/packages/concerto-core/src/introspect/modelfile.ts
+++ b/packages/concerto-core/src/introspect/modelfile.ts
@@ -745,7 +745,7 @@ class ModelFile extends Decorated {
                 throw new Error('Wildcard Imports are not permitted.');
             case `${MetaModelNamespace}.ImportTypes`: {
                 const ns = imp.namespace;
-                if (imp.aliasedTypes) {
+                if (imp.aliasedTypes && imp.aliasedTypes.length > 0) {
                     const aliasedTypes = new Map();
                     imp.aliasedTypes.forEach(({ name, aliasedName }) => {
                         if(ModelUtil.isPrimitiveType(aliasedName)){
@@ -756,7 +756,7 @@ class ModelFile extends Decorated {
                     // Local-name(aliased or non-aliased) is mapped to the Fully qualified type name
                     imp.types.forEach((type) => {
                         const alias = aliasedTypes.get(type);
-                        this.importShortNames.set(alias || type, `${ns}.${type}`);
+                        this.importShortNames.set(alias ?? type, `${ns}.${type}`);
                     });
                 } else {
                     imp.types.forEach((type) =>

--- a/packages/concerto-core/src/introspect/modelfile.ts
+++ b/packages/concerto-core/src/introspect/modelfile.ts
@@ -107,9 +107,10 @@ class ModelFile extends Decorated {
 
         // Now build local types from Declarations
         this.localTypes = new Map();
+        const namespace = this.getNamespace();
         for(let index in this.declarations) {
             let classDeclaration = this.declarations[index];
-            let localType = this.getNamespace() + '.' + classDeclaration.getName();
+            let localType = namespace + '.' + classDeclaration.getName();
             this.localTypes.set(localType, this.declarations[index]);
         }
     }
@@ -743,27 +744,25 @@ class ModelFile extends Decorated {
             case `${MetaModelNamespace}.ImportAll`:
                 throw new Error('Wildcard Imports are not permitted.');
             case `${MetaModelNamespace}.ImportTypes`: {
-                const aliasedTypes = new Map();
+                const ns = imp.namespace;
                 if (imp.aliasedTypes) {
+                    const aliasedTypes = new Map();
                     imp.aliasedTypes.forEach(({ name, aliasedName }) => {
                         if(ModelUtil.isPrimitiveType(aliasedName)){
                             throw new Error('Types cannot be aliased to primitive type');
                         }
                         aliasedTypes.set(name, aliasedName);
                     });
+                    // Local-name(aliased or non-aliased) is mapped to the Fully qualified type name
+                    imp.types.forEach((type) => {
+                        const alias = aliasedTypes.get(type);
+                        this.importShortNames.set(alias || type, `${ns}.${type}`);
+                    });
+                } else {
+                    imp.types.forEach((type) =>
+                        this.importShortNames.set(type, `${ns}.${type}`)
+                    );
                 }
-                // Local-name(aliased or non-aliased) is mapped to the Fully qualified type name
-                imp.types.forEach((type) =>
-                    aliasedTypes.has(type)
-                        ? this.importShortNames.set(
-                            aliasedTypes.get(type),
-                            `${imp.namespace}.${type}`
-                        )
-                        : this.importShortNames.set(
-                            type,
-                            `${imp.namespace}.${type}`
-                        )
-                );
                 break;
             }
             default:
@@ -780,74 +779,77 @@ class ModelFile extends Decorated {
         }
 
         for(let n=0; n < ast.declarations.length; n++) {
-            // Make sure to clone since we may add super type
-            let thing = Object.assign({}, ast.declarations[n]);
+            let thing = ast.declarations[n];
 
-            if(thing.$class === `${MetaModelNamespace}.AssetDeclaration`) {
+            switch(thing.$class) {
+            case `${MetaModelNamespace}.AssetDeclaration`:
                 // Default super type for asset
                 if (!thing.superType) {
+                    thing = Object.assign({}, thing);
                     thing.superType = {
                         $class: `${MetaModelNamespace}.TypeIdentified`,
                         name: 'Asset',
                     };
                 }
                 this.declarations.push( new AssetDeclaration(this, thing) );
-            }
-            else if(thing.$class === `${MetaModelNamespace}.TransactionDeclaration`) {
+                break;
+            case `${MetaModelNamespace}.TransactionDeclaration`:
                 // Default super type for transaction
                 if (!thing.superType) {
+                    thing = Object.assign({}, thing);
                     thing.superType = {
                         $class: `${MetaModelNamespace}.TypeIdentified`,
                         name: 'Transaction',
                     };
                 }
                 this.declarations.push( new TransactionDeclaration(this, thing) );
-            }
-            else if(thing.$class === `${MetaModelNamespace}.EventDeclaration`) {
+                break;
+            case `${MetaModelNamespace}.EventDeclaration`:
                 // Default super type for event
                 if (!thing.superType) {
+                    thing = Object.assign({}, thing);
                     thing.superType = {
                         $class: `${MetaModelNamespace}.TypeIdentified`,
                         name: 'Event',
                     };
                 }
                 this.declarations.push( new EventDeclaration(this, thing) );
-            }
-            else if(thing.$class === `${MetaModelNamespace}.ParticipantDeclaration`) {
+                break;
+            case `${MetaModelNamespace}.ParticipantDeclaration`:
                 // Default super type for participant
                 if (!thing.superType) {
+                    thing = Object.assign({}, thing);
                     thing.superType = {
                         $class: `${MetaModelNamespace}.TypeIdentified`,
                         name: 'Participant',
                     };
                 }
                 this.declarations.push( new ParticipantDeclaration(this, thing) );
-            }
-            else if(thing.$class === `${MetaModelNamespace}.EnumDeclaration`) {
+                break;
+            case `${MetaModelNamespace}.EnumDeclaration`:
                 this.declarations.push( new EnumDeclaration(this, thing) );
-            }
-            else if(thing.$class === `${MetaModelNamespace}.MapDeclaration`) {
+                break;
+            case `${MetaModelNamespace}.MapDeclaration`:
                 this.declarations.push( new MapDeclaration(this, thing) );
-            }
-            else if(thing.$class === `${MetaModelNamespace}.ConceptDeclaration`) {
+                break;
+            case `${MetaModelNamespace}.ConceptDeclaration`:
                 this.declarations.push( new ConceptDeclaration(this, thing) );
-            }
-            else if([
-                `${MetaModelNamespace}.BooleanScalar`,
-                `${MetaModelNamespace}.IntegerScalar`,
-                `${MetaModelNamespace}.LongScalar`,
-                `${MetaModelNamespace}.DoubleScalar`,
-                `${MetaModelNamespace}.StringScalar`,
-                `${MetaModelNamespace}.DateTimeScalar`,
-            ].includes(thing.$class)) {
+                break;
+            case `${MetaModelNamespace}.BooleanScalar`:
+            case `${MetaModelNamespace}.IntegerScalar`:
+            case `${MetaModelNamespace}.LongScalar`:
+            case `${MetaModelNamespace}.DoubleScalar`:
+            case `${MetaModelNamespace}.StringScalar`:
+            case `${MetaModelNamespace}.DateTimeScalar`:
                 this.declarations.push( new ScalarDeclaration(this, thing) );
-            }
-            else {
+                break;
+            default: {
                 let formatter = Globalize('en').messageFormatter('modelfile-constructor-unrecmodelelem');
 
                 throw new IllegalModelException(formatter({
                     'type': thing.$class,
                 }),this);
+            }
             }
         }
     }


### PR DESCRIPTION
<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #<CORRESPONDING ISSUE NUMBER>
<!--- Provide an overall summary of the pull request -->

- Replace unconditional `Object.assign` clone on every declaration with conditional clone only when adding default superType, eliminates N allocations for models with superTypes already set (e.g. in decorateModels hot path)
- Replace `if/else` chain + `array.includes()` for declaration type dispatch with a switch statement, engine-optimised jump table, removes per-iteration 6-element array allocation for scalar check
- Hoist `getModelFile/getModelManager/getDecoratorFactories` calls out of per-decorator inner loop in `Decorated.process()`; avoids redundant method calls when processing many decorators
- Skip decorator factory iteration entirely when no factories are registered (common case)
- Avoid Map allocation for ImportTypes without aliases, hoist namespace reference outside types loop


### Flags
<!--- Provide context or concerns a reviewer should be aware of -->
- <ONE>
- <TWO>

### Screenshots or Video
<!--- Provide an easily accessible demonstration of the changes, if applicable -->

### Related Issues
- Issue #<NUMBER>
- Pull Request #<NUMBER>

### Author Checklist
- [ ] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [ ] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ ] Merging to `main` from `fork:branchname`
