### PR TITLE
fix(concerto-vocabulary): add safe YAML vocabulary parser to prevent flow-style value misinterpretation

### DIFF
--- a/packages/concerto-vocabulary/src/vocabularymanager.ts
+++ b/packages/concerto-vocabulary/src/vocabularymanager.ts
@@ -16,6 +16,7 @@ import YAML from 'yaml';
 import { MetaModelNamespace } from '@accordproject/concerto-metamodel';
 import Vocabulary = require('./vocabulary');
 import { ModelUtil, ModelManager } from '@accordproject/concerto-core';
+import { parseVocabularyYaml } from './yamlparser';
 
 const DC_NAMESPACE = 'org.accordproject.decoratorcommands@0.4.0';
 
@@ -88,13 +89,15 @@ class VocabularyManager {
     /**
      * Adds a vocabulary to the vocabulary manager
      * @param {string} contents the YAML string for the vocabulary
+     * @param {*} [options] options to configure vocabulary parsing
+     * @param {boolean} [options.enableSafeVocabParsing] When true, ensures vocabulary values are resolved correctly as strings
      * @returns {Vocabulary} the vocabulary the was added
      */
-    addVocabulary(contents: any): Vocabulary {
+    addVocabulary(contents: any, options?: any): Vocabulary {
         if (!contents) {
             throw new Error('Vocabulary contents must be specified');
         }
-        const voc = new Vocabulary(this, YAML.parse(contents));
+        const voc = new Vocabulary(this, options?.enableSafeVocabParsing ? parseVocabularyYaml(contents) : YAML.parse(contents));
 
         if (this.vocabularies[voc.getIdentifier()]) {
             throw new Error('Vocabulary has already been added.');

--- a/packages/concerto-vocabulary/src/yamlparser.ts
+++ b/packages/concerto-vocabulary/src/yamlparser.ts
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import YAML from 'yaml';
+
+/**
+ * Parses vocabulary YAML, ensuring all non-structural collection values remain strings.
+ * YAML.parse can incorrectly interpret flow syntax (e.g. {Човек} or [value])
+ * as objects/arrays — in vocabularies, these should be preserved as literal strings.
+ * Only 'declarations' and 'properties' are kept as actual collections.
+ * @param {string} yamlStr the YAML string to parse
+ * @returns {*} the parsed vocabulary object
+ */
+export function parseVocabularyYaml(yamlStr: string): any {
+    const doc = YAML.parseDocument(yamlStr);
+    if (doc.errors.length > 0) {
+        throw doc.errors[0];
+    }
+    YAML.visit(doc, {
+        Pair(_, pair) {
+            const key = (pair.key as YAML.Scalar).value;
+            const value = pair.value;
+
+            if (key === 'declarations' || key === 'properties') {
+                return;
+            }
+
+            if (YAML.isScalar(value) && typeof value.value !== 'string') {
+                pair.value = new YAML.Scalar(String(value.value));
+                return;
+            }
+
+            if (YAML.isCollection(value)) {
+                if (value.range) {
+                    const [start, end] = value.range as [number, number, number];
+                    pair.value = new YAML.Scalar(yamlStr.substring(start, end));
+                } else {
+                    pair.value = new YAML.Scalar(JSON.stringify(value.toJSON()));
+                }
+            }
+        },
+    });
+    return doc.toJSON();
+}

--- a/packages/concerto-vocabulary/test/vocabularymanager.js
+++ b/packages/concerto-vocabulary/test/vocabularymanager.js
@@ -497,4 +497,48 @@ declarations:
         const ssnDecorator = ssnDeclaration.getDecorator('Term');
         ssnDecorator.getArguments()[0].should.equal('SSN');
     });
+
+    it('addVocabulary - preserves flow-style collections as strings', () => {
+        const yaml = `locale: en
+namespace: org.test@1.0.0
+declarations:
+  - Person: "{Човек}"
+  - Vehicle: A road vehicle
+`;
+        const vm = new VocabularyManager();
+        const voc = vm.addVocabulary(yaml);
+        voc.getTerm('Person').should.equal('{Човек}');
+        voc.getTerm('Vehicle').should.equal('A road vehicle');
+    });
+
+    it('addVocabulary - converts unquoted flow collections to strings with enableSafeVocabParsing', () => {
+        const yaml = `locale: en
+namespace: org.test@1.0.0
+declarations:
+  - Person: {name: value}
+  - Vehicle: [car, truck]
+`;
+        const vm = new VocabularyManager();
+        const voc = vm.addVocabulary(yaml, { enableSafeVocabParsing: true });
+        voc.getTerm('Person').should.be.a('string');
+        voc.getTerm('Vehicle').should.be.a('string');
+    });
+
+    it('addVocabulary - throws on malformed YAML', () => {
+        const { parseVocabularyYaml } = require('../src/yamlparser');
+        should.Throw(() => parseVocabularyYaml('{{{{invalid'), Error);
+    });
+
+    it('addVocabulary - enableSafeVocabParsing coerces non-string scalars to strings', () => {
+        const yaml = `locale: en
+namespace: org.test@1.0.0
+declarations:
+  - Active: true
+  - Count: 42
+`;
+        const vm = new VocabularyManager();
+        const voc = vm.addVocabulary(yaml, { enableSafeVocabParsing: true });
+        voc.getTerm('Active').should.equal('true');
+        voc.getTerm('Count').should.equal('42');
+    });
 });

--- a/packages/concerto-vocabulary/test/vocabularymanager.js
+++ b/packages/concerto-vocabulary/test/vocabularymanager.js
@@ -520,8 +520,8 @@ declarations:
 `;
         const vm = new VocabularyManager();
         const voc = vm.addVocabulary(yaml, { enableSafeVocabParsing: true });
-        voc.getTerm('Person').should.be.a('string');
-        voc.getTerm('Vehicle').should.be.a('string');
+        voc.getTerm('Person').should.equal('{name: value}');
+        voc.getTerm('Vehicle').should.equal('[car, truck]');
     });
 
     it('addVocabulary - throws on malformed YAML', () => {


### PR DESCRIPTION
<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #<CORRESPONDING ISSUE NUMBER>
<!--- Provide an overall summary of the pull request -->

- Adds `parseVocabularyYaml` utility that ensures YAML flow-style syntax such as `{Човек}`, `[value]` are preserved as literal strings instead of being incorrectly interpreted as objects/arrays by the YAML parser

- Introduces `enableSafeVocabParsing` option on `addVocabulary()` to opt into the corrected parsing behavior without breaking existing consumers
- Fixes a bug where decorated models with non-string scalar vocabulary values `(booleans, numbers)` would fail validation due to a mismatch between the expecting a `string` but receiving `false` or `0`

### Author Checklist
- [ ] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [ ] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ ] Merging to `main` from `fork:branchname`
