### PR TITLE
feat(concerto-core): add DeserializeOptions for deserialization validation (#1273)

### DIFF
--- a/packages/concerto-core/src/basemodelmanager.ts
+++ b/packages/concerto-core/src/basemodelmanager.ts
@@ -26,6 +26,7 @@ const Serializer = require('./serializer');
 const TypeNotFoundException = require('./typenotfoundexception');
 const MetamodelException = require('./metamodelexception');
 import type { ModelFileSource, ModelManagerOptions } from './types';
+import { STRICT_VALIDATE_OPTIONS } from './types';
 type ModelFileInstance = InstanceType<typeof ModelFile>;
 type ModelFileInput = string | ModelFileInstance;
 
@@ -291,7 +292,7 @@ class BaseModelManager {
 
         try {
             // Use deserialization to validate the AST
-            this.getSerializer().fromJSON(modelFile.getAst());
+            this.getSerializer().fromJSON(modelFile.getAst(), STRICT_VALIDATE_OPTIONS);
         } catch (err: unknown) {
             const error = err as Error;
             throw new MetamodelException(error.message);

--- a/packages/concerto-core/src/index.ts
+++ b/packages/concerto-core/src/index.ts
@@ -55,6 +55,9 @@ import Serializer = require("./serializer");
 import ModelUtil = require("./modelutil");
 import DateTimeUtil = require("./datetimeutil");
 import MetaModel = require("./introspect/metamodel");
+import { STRICT_VALIDATE_OPTIONS } from "./types";
+
+export type { DeserializeOptions } from "./types";
 
 // Re-exporting ModelManager here makes it available as 'import { ModelManager }' to the outside world
 export { 
@@ -98,5 +101,6 @@ export {
     ModelUtil, 
     ModelLoader, 
     DateTimeUtil, 
-    MetaModel 
+    MetaModel,
+    STRICT_VALIDATE_OPTIONS
 };

--- a/packages/concerto-core/src/introspect/metamodel.ts
+++ b/packages/concerto-core/src/introspect/metamodel.ts
@@ -41,9 +41,9 @@ function newMetaModelManager() {
 /**
  * Validate metamodel instance against the metamodel
  * @param {object} input - the metamodel instance in JSON
- * @param {object} [options] - serializer options (see {@link Serializer#fromJSON})
- * @param {boolean} [options.strict] - reject unknown properties and fail fast on required
- * fields set to null during deserialization
+ * @param {object} [options] - deserialize options (see {@link Serializer#fromJSON})
+ * @param {boolean} [options.rejectUnknownKeys] - error on extra fields not in the model
+ * @param {boolean} [options.rejectRequiredNull] - fail fast when a required field is explicitly null
  * @return {object} the validated metamodel instance in JSON
  */
 function validateMetaModel(input, options?) {

--- a/packages/concerto-core/src/introspect/metamodel.ts
+++ b/packages/concerto-core/src/introspect/metamodel.ts
@@ -41,15 +41,18 @@ function newMetaModelManager() {
 /**
  * Validate metamodel instance against the metamodel
  * @param {object} input - the metamodel instance in JSON
+ * @param {object} [options] - serializer options (see {@link Serializer#fromJSON})
+ * @param {boolean} [options.strict] - reject unknown properties and fail fast on required
+ * fields set to null during deserialization
  * @return {object} the validated metamodel instance in JSON
  */
-function validateMetaModel(input) {
+function validateMetaModel(input, options?) {
     const metaModelManager = newMetaModelManager();
     const factory = new Factory(metaModelManager);
     const serializer = new Serializer(factory, metaModelManager);
 
     // validate the metaModel
-    serializer.fromJSON(input);
+    serializer.fromJSON(input, options);
 
     return input;
 }

--- a/packages/concerto-core/src/serializer.ts
+++ b/packages/concerto-core/src/serializer.ts
@@ -151,9 +151,8 @@ class Serializer {
      * with its model prior to serialization (default to true)
      * @param {number} [options.utcOffset] - UTC Offset for DateTime values.
      * @param {boolean} [options.strictQualifiedDateTimes] - Only allow fully-qualified date-times with offsets.
-     * @param {boolean} [options.strict] - Reject unknown properties and fail fast on required
-     * fields set to null during deserialization. Shared option for instance and metamodel
-     * validation paths (see also {@link module:concerto-core.MetaModel.validateMetaModel}).
+     * @param {boolean} [options.rejectUnknownKeys] - Error on extra fields not in the model.
+     * @param {boolean} [options.rejectRequiredNull] - Fail fast when a required field is explicitly null.
      * @return {Resource} The new populated resource
      */
     fromJSON(jsonObject, options?) {
@@ -197,7 +196,16 @@ class Serializer {
         parameters.resourceStack = new TypedStack(resource);
         parameters.modelManager = this.modelManager;
         parameters.factory = this.factory;
-        const populator = new JSONPopulator(options.acceptResourcesForRelationships === true, false, options.utcOffset, options.strictQualifiedDateTimes === true, options.strict === true);
+        const populator = new JSONPopulator(
+            options.acceptResourcesForRelationships === true,
+            false,
+            options.utcOffset,
+            options.strictQualifiedDateTimes === true,
+            {
+                rejectUnknownKeys: options.rejectUnknownKeys === true,
+                rejectRequiredNull: options.rejectRequiredNull === true,
+            }
+        );
         classDeclaration.accept(populator, parameters);
 
         // validate the resource against the model

--- a/packages/concerto-core/src/serializer.ts
+++ b/packages/concerto-core/src/serializer.ts
@@ -151,6 +151,9 @@ class Serializer {
      * with its model prior to serialization (default to true)
      * @param {number} [options.utcOffset] - UTC Offset for DateTime values.
      * @param {boolean} [options.strictQualifiedDateTimes] - Only allow fully-qualified date-times with offsets.
+     * @param {boolean} [options.strict] - Reject unknown properties and fail fast on required
+     * fields set to null during deserialization. Shared option for instance and metamodel
+     * validation paths (see also {@link module:concerto-core.MetaModel.validateMetaModel}).
      * @return {Resource} The new populated resource
      */
     fromJSON(jsonObject, options?) {
@@ -194,7 +197,7 @@ class Serializer {
         parameters.resourceStack = new TypedStack(resource);
         parameters.modelManager = this.modelManager;
         parameters.factory = this.factory;
-        const populator = new JSONPopulator(options.acceptResourcesForRelationships === true, false, options.utcOffset, options.strictQualifiedDateTimes === true);
+        const populator = new JSONPopulator(options.acceptResourcesForRelationships === true, false, options.utcOffset, options.strictQualifiedDateTimes === true, options.strict === true);
         classDeclaration.accept(populator, parameters);
 
         // validate the resource against the model

--- a/packages/concerto-core/src/serializer/jsonpopulator.ts
+++ b/packages/concerto-core/src/serializer/jsonpopulator.ts
@@ -99,6 +99,46 @@ function getAssignableProperties(resourceData, classDeclaration) {
     });
 }
 
+function rejectUnknownProperty(
+    property: string,
+    value: unknown,
+    classDeclaration: ClassDeclaration,
+    path: string,
+    rejectUnknownKeys: boolean
+) {
+    if (!rejectUnknownKeys && Util.isNull(value)) {
+        return;
+    }
+    throw new ValidationException(
+        `Unexpected properties for type ${classDeclaration.getFullyQualifiedName()}: ${property}`,
+        undefined,
+        { path, code: 'UNKNOWN_PROPERTY' }
+    );
+}
+
+function rejectRequiredNullProperty(
+    property: string,
+    classProperty: Declaration,
+    parentPath: string,
+    rejectRequiredNull: boolean
+) {
+    if (!rejectRequiredNull || classProperty.isOptional?.()) {
+        return;
+    }
+    const propertyPath = `${parentPath}.${property}`;
+    const expectedType = classProperty.getFullyQualifiedTypeName();
+    throw new ValidationException(
+        `Expected value at path \`${propertyPath}\` to be of type \`${expectedType}\`, but got null`,
+        undefined,
+        {
+            path: propertyPath,
+            code: 'TYPE_VIOLATION',
+            expected: expectedType,
+            actual: 'null',
+        }
+    );
+}
+
 /**
  * Populates a Resource with data from a JSON object graph. The JSON objects
  * should be the result of calling Serializer.toJSON and then JSON.parse.
@@ -174,13 +214,15 @@ class JSONPopulator {
     visitClassDeclaration(classDeclaration: ClassDeclaration, parameters: JsonPopulatorParameters) {
         const jsonObj = parameters.jsonStack.pop();
         const resourceObj = parameters.resourceStack.pop();
-        parameters.path ?? (parameters.path = new TypedStack('$'));
+        const path = parameters.path ?? new TypedStack('$');
+        parameters.path = path;
 
         validateReservedProperties(jsonObj, classDeclaration);
 
-        const currentPath = parameters.path?.stack.join('');
+        const currentPath = path.stack.join('');
 
         for (const property of Object.keys(jsonObj)) {
+            // $class, $identifier, etc. are handled outside this property loop.
             if (ModelUtil.isSystemProperty(property)) {
                 continue;
             }
@@ -189,39 +231,24 @@ class JSONPopulator {
             const classProperty = classDeclaration.getProperty(property);
 
             if (!classProperty) {
-                if (this.rejectUnknownKeys || !Util.isNull(value)) {
-                    const errorText = `Unexpected properties for type ${classDeclaration.getFullyQualifiedName()}: ${property}`;
-                    throw new ValidationException(errorText, undefined, {
-                        path: currentPath,
-                        code: 'UNKNOWN_PROPERTY',
-                    });
-                }
+                // Unknown null-valued keys are ignored unless rejectUnknownKeys is enabled.
+                rejectUnknownProperty(property, value, classDeclaration, currentPath, this.rejectUnknownKeys);
                 continue;
             }
 
             if (Util.isNull(value)) {
-                if (!classProperty.isOptional?.() && this.rejectRequiredNull) {
-                    const propertyPath = `${currentPath}.${property}`;
-                    const expectedType = classProperty.getFullyQualifiedTypeName();
-                    throw new ValidationException(
-                        `Expected value at path \`${propertyPath}\` to be of type \`${expectedType}\`, but got null`,
-                        undefined,
-                        {
-                            path: propertyPath,
-                            code: 'TYPE_VIOLATION',
-                            expected: expectedType,
-                            actual: 'null',
-                        }
-                    );
-                }
+                // Required nulls are deferred to ResourceValidator unless rejectRequiredNull is enabled.
+                rejectRequiredNullProperty(property, classProperty, currentPath, this.rejectRequiredNull);
                 continue;
             }
 
-            parameters.path?.push(`.${property}`);
+            // Track path for nested validation errors during recursive population.
+            path.push(`.${property}`);
             parameters.jsonStack.push(value);
             resourceObj[property] = classProperty.accept(this, parameters);
-            parameters.path?.pop();
+            path.pop();
         }
+
         return resourceObj;
     }
 

--- a/packages/concerto-core/src/serializer/jsonpopulator.ts
+++ b/packages/concerto-core/src/serializer/jsonpopulator.ts
@@ -66,7 +66,7 @@ type VisitorTarget = Declaration | Field | ClassDeclaration | MapDeclaration | R
  * @return {Array} property names.
  * @private
  */
-function getAssignableProperties(resourceData, classDeclaration) {
+function getAssignableProperties(resourceData, classDeclaration, strict = false) {
     const properties = Object.keys(resourceData);
     const privateProperties = properties.filter(ModelUtil.isPrivateSystemProperty);
     if (privateProperties.length > 0){
@@ -82,6 +82,12 @@ function getAssignableProperties(resourceData, classDeclaration) {
         throw new ValidationException(errorText);
     }
 
+    if (strict) {
+        return properties.filter((property) => {
+            return !ModelUtil.isSystemProperty(property);
+        });
+    }
+
     return properties.filter((property) => {
         return !ModelUtil.isSystemProperty(property) && !Util.isNull(resourceData[property]);
     });
@@ -94,7 +100,7 @@ function getAssignableProperties(resourceData, classDeclaration) {
  * @throws {ValidationException} if any properties are not defined by the class declaration.
  * @private
  */
-function validateProperties(properties, classDeclaration) {
+function validateProperties(properties, classDeclaration, path?) {
     const expectedProperties = classDeclaration
         .getProperties()
         .map((property) => property.getName());
@@ -103,7 +109,10 @@ function validateProperties(properties, classDeclaration) {
     if (invalidProperties.length > 0) {
         const errorText = `Unexpected properties for type ${classDeclaration.getFullyQualifiedName()}: ` +
             invalidProperties.join(', ');
-        throw new ValidationException(errorText);
+        throw new ValidationException(errorText, undefined, {
+            path,
+            code: 'UNKNOWN_PROPERTY',
+        });
     }
 }
 
@@ -123,6 +132,7 @@ class JSONPopulator {
     acceptResourcesForRelationships: boolean | undefined;
     utcOffset: number;
     strictQualifiedDateTimes: boolean;
+    strict: boolean;
     /**
      * Constructor.
      * @param {boolean} [acceptResourcesForRelationships] Permit resources in the
@@ -130,12 +140,14 @@ class JSONPopulator {
      * @param {boolean} [ergo] - Deprecated - This is a dummy parameter to avoid breaking any consumers. It will be removed in a future release.
      * @param {number} [utcOffset] - UTC Offset for DateTime values.
      * @param {boolean} [strictQualifiedDateTimes=true] - Only allow fully-qualified date-times with offsets.
+     * @param {boolean} [strict=false] - Throw on unknown or unmapped properties during deserialization.
 
      */
-    constructor(acceptResourcesForRelationships, ergo, utcOffset, strictQualifiedDateTimes) {
+    constructor(acceptResourcesForRelationships, ergo, utcOffset, strictQualifiedDateTimes, strict?) {
         this.acceptResourcesForRelationships = acceptResourcesForRelationships;
         this.utcOffset = utcOffset || 0; // Defaults to UTC
         this.strictQualifiedDateTimes = strictQualifiedDateTimes !== undefined ? strictQualifiedDateTimes : true;
+        this.strict = strict || false;
 
         if (process.env.TZ){
             debug(`Environment variable 'TZ' is set to '${process.env.TZ}', this can cause unexpected behaviour when using unqualified date time formats.`);
@@ -179,8 +191,9 @@ class JSONPopulator {
         const resourceObj = parameters.resourceStack.pop();
         parameters.path ?? (parameters.path = new TypedStack('$'));
 
-        const properties = getAssignableProperties(jsonObj, classDeclaration);
-        validateProperties(properties, classDeclaration);
+        const properties = getAssignableProperties(jsonObj, classDeclaration, this.strict);
+        const currentPath = parameters.path?.stack.join('');
+        validateProperties(properties, classDeclaration, currentPath);
 
         properties.forEach((property) => {
             let value = jsonObj[property];
@@ -190,6 +203,22 @@ class JSONPopulator {
                 const classProperty = classDeclaration.getProperty(property);
                 resourceObj[property] = classProperty.accept(this,parameters);
                 parameters.path?.pop();
+            } else if (this.strict) {
+                const classProperty = classDeclaration.getProperty(property);
+                if (!classProperty.isOptional?.()) {
+                    const propertyPath = `${currentPath}.${property}`;
+                    const expectedType = classProperty.getFullyQualifiedTypeName();
+                    throw new ValidationException(
+                        `Expected value at path \`${propertyPath}\` to be of type \`${expectedType}\`, but got null`,
+                        undefined,
+                        {
+                            path: propertyPath,
+                            code: 'TYPE_VIOLATION',
+                            expected: expectedType,
+                            actual: 'null',
+                        }
+                    );
+                }
             }
         });
         return resourceObj;

--- a/packages/concerto-core/src/serializer/jsonpopulator.ts
+++ b/packages/concerto-core/src/serializer/jsonpopulator.ts
@@ -37,6 +37,7 @@ import type RelationshipDeclaration = require('../introspect/relationshipdeclara
 import type MapDeclaration = require('../introspect/mapdeclaration');
 import type Resource = require('../model/resource');
 import Field = require('../introspect/field');
+import type { DeserializeOptions } from '../types';
 
 
 type Stack<T> = {
@@ -60,13 +61,12 @@ type JsonPopulatorParameters = {
 type VisitorTarget = Declaration | Field | ClassDeclaration | MapDeclaration | RelationshipDeclaration;
 
 /**
- * Get all properties on a resource object that both have a value and are not system properties.
+ * Validate reserved/system property constraints on JSON data.
  * @param {Object} resourceData JSON object representation of a resource.
  * @param {ClassDeclaration} classDeclaration class declaration.
- * @return {Array} property names.
  * @private
  */
-function getAssignableProperties(resourceData, classDeclaration, strict = false) {
+function validateReservedProperties(resourceData, classDeclaration) {
     const properties = Object.keys(resourceData);
     const privateProperties = properties.filter(ModelUtil.isPrivateSystemProperty);
     if (privateProperties.length > 0){
@@ -81,39 +81,22 @@ function getAssignableProperties(resourceData, classDeclaration, strict = false)
         const errorText = `Unexpected property for type ${classDeclaration.getFullyQualifiedName()}: $timestamp`;
         throw new ValidationException(errorText);
     }
-
-    if (strict) {
-        return properties.filter((property) => {
-            return !ModelUtil.isSystemProperty(property);
-        });
-    }
-
-    return properties.filter((property) => {
-        return !ModelUtil.isSystemProperty(property) && !Util.isNull(resourceData[property]);
-    });
 }
 
 /**
- * Assert that all resource properties exist in a given class declaration.
- * @param {Array} properties Property names.
+ * Get all properties on a resource object that both have a value and are not system properties.
+ * @param {Object} resourceData JSON object representation of a resource.
  * @param {ClassDeclaration} classDeclaration class declaration.
- * @throws {ValidationException} if any properties are not defined by the class declaration.
+ * @return {Array} property names.
  * @private
  */
-function validateProperties(properties, classDeclaration, path?) {
-    const expectedProperties = classDeclaration
-        .getProperties()
-        .map((property) => property.getName());
+function getAssignableProperties(resourceData, classDeclaration) {
+    validateReservedProperties(resourceData, classDeclaration);
 
-    const invalidProperties = properties.filter((property) => !expectedProperties.includes(property));
-    if (invalidProperties.length > 0) {
-        const errorText = `Unexpected properties for type ${classDeclaration.getFullyQualifiedName()}: ` +
-            invalidProperties.join(', ');
-        throw new ValidationException(errorText, undefined, {
-            path,
-            code: 'UNKNOWN_PROPERTY',
-        });
-    }
+    const properties = Object.keys(resourceData);
+    return properties.filter((property) => {
+        return !ModelUtil.isSystemProperty(property) && !Util.isNull(resourceData[property]);
+    });
 }
 
 /**
@@ -132,7 +115,8 @@ class JSONPopulator {
     acceptResourcesForRelationships: boolean | undefined;
     utcOffset: number;
     strictQualifiedDateTimes: boolean;
-    strict: boolean;
+    rejectUnknownKeys: boolean;
+    rejectRequiredNull: boolean;
     /**
      * Constructor.
      * @param {boolean} [acceptResourcesForRelationships] Permit resources in the
@@ -140,14 +124,15 @@ class JSONPopulator {
      * @param {boolean} [ergo] - Deprecated - This is a dummy parameter to avoid breaking any consumers. It will be removed in a future release.
      * @param {number} [utcOffset] - UTC Offset for DateTime values.
      * @param {boolean} [strictQualifiedDateTimes=true] - Only allow fully-qualified date-times with offsets.
-     * @param {boolean} [strict=false] - Throw on unknown or unmapped properties during deserialization.
+     * @param {DeserializeOptions} [deserializeOptions] - Deserialize-time validation flags.
 
      */
-    constructor(acceptResourcesForRelationships, ergo, utcOffset, strictQualifiedDateTimes, strict?) {
+    constructor(acceptResourcesForRelationships, ergo, utcOffset, strictQualifiedDateTimes, deserializeOptions?: DeserializeOptions) {
         this.acceptResourcesForRelationships = acceptResourcesForRelationships;
         this.utcOffset = utcOffset || 0; // Defaults to UTC
         this.strictQualifiedDateTimes = strictQualifiedDateTimes !== undefined ? strictQualifiedDateTimes : true;
-        this.strict = strict || false;
+        this.rejectUnknownKeys = deserializeOptions?.rejectUnknownKeys === true;
+        this.rejectRequiredNull = deserializeOptions?.rejectRequiredNull === true;
 
         if (process.env.TZ){
             debug(`Environment variable 'TZ' is set to '${process.env.TZ}', this can cause unexpected behaviour when using unqualified date time formats.`);
@@ -191,21 +176,31 @@ class JSONPopulator {
         const resourceObj = parameters.resourceStack.pop();
         parameters.path ?? (parameters.path = new TypedStack('$'));
 
-        const properties = getAssignableProperties(jsonObj, classDeclaration, this.strict);
-        const currentPath = parameters.path?.stack.join('');
-        validateProperties(properties, classDeclaration, currentPath);
+        validateReservedProperties(jsonObj, classDeclaration);
 
-        properties.forEach((property) => {
-            let value = jsonObj[property];
-            if (value !== null) {
-                parameters.path?.push(`.${property}`);
-                parameters.jsonStack.push(value);
-                const classProperty = classDeclaration.getProperty(property);
-                resourceObj[property] = classProperty.accept(this,parameters);
-                parameters.path?.pop();
-            } else if (this.strict) {
-                const classProperty = classDeclaration.getProperty(property);
-                if (!classProperty.isOptional?.()) {
+        const currentPath = parameters.path?.stack.join('');
+
+        for (const property of Object.keys(jsonObj)) {
+            if (ModelUtil.isSystemProperty(property)) {
+                continue;
+            }
+
+            const value = jsonObj[property];
+            const classProperty = classDeclaration.getProperty(property);
+
+            if (!classProperty) {
+                if (this.rejectUnknownKeys || !Util.isNull(value)) {
+                    const errorText = `Unexpected properties for type ${classDeclaration.getFullyQualifiedName()}: ${property}`;
+                    throw new ValidationException(errorText, undefined, {
+                        path: currentPath,
+                        code: 'UNKNOWN_PROPERTY',
+                    });
+                }
+                continue;
+            }
+
+            if (Util.isNull(value)) {
+                if (!classProperty.isOptional?.() && this.rejectRequiredNull) {
                     const propertyPath = `${currentPath}.${property}`;
                     const expectedType = classProperty.getFullyQualifiedTypeName();
                     throw new ValidationException(
@@ -219,8 +214,14 @@ class JSONPopulator {
                         }
                     );
                 }
+                continue;
             }
-        });
+
+            parameters.path?.push(`.${property}`);
+            parameters.jsonStack.push(value);
+            resourceObj[property] = classProperty.accept(this, parameters);
+            parameters.path?.pop();
+        }
         return resourceObj;
     }
 

--- a/packages/concerto-core/src/serializer/jsonpopulator.ts
+++ b/packages/concerto-core/src/serializer/jsonpopulator.ts
@@ -99,18 +99,16 @@ function getAssignableProperties(resourceData, classDeclaration) {
     });
 }
 
-function rejectUnknownProperty(
-    property: string,
-    value: unknown,
+function throwUnknownProperties(
+    unknownProperties: string[],
     classDeclaration: ClassDeclaration,
     path: string,
-    rejectUnknownKeys: boolean
 ) {
-    if (!rejectUnknownKeys && Util.isNull(value)) {
+    if (unknownProperties.length === 0) {
         return;
     }
     throw new ValidationException(
-        `Unexpected properties for type ${classDeclaration.getFullyQualifiedName()}: ${property}`,
+        `Unexpected properties for type ${classDeclaration.getFullyQualifiedName()}: ${unknownProperties.join(', ')}`,
         undefined,
         { path, code: 'UNKNOWN_PROPERTY' }
     );
@@ -220,6 +218,7 @@ class JSONPopulator {
         validateReservedProperties(jsonObj, classDeclaration);
 
         const currentPath = path.stack.join('');
+        const unknownProperties: string[] = [];
 
         for (const property of Object.keys(jsonObj)) {
             // $class, $identifier, etc. are handled outside this property loop.
@@ -231,8 +230,10 @@ class JSONPopulator {
             const classProperty = classDeclaration.getProperty(property);
 
             if (!classProperty) {
-                // Unknown null-valued keys are ignored unless rejectUnknownKeys is enabled.
-                rejectUnknownProperty(property, value, classDeclaration, currentPath, this.rejectUnknownKeys);
+                // Null-valued unknown keys are ignored unless rejectUnknownKeys is enabled.
+                if (this.rejectUnknownKeys || !Util.isNull(value)) {
+                    unknownProperties.push(property);
+                }
                 continue;
             }
 
@@ -248,6 +249,8 @@ class JSONPopulator {
             resourceObj[property] = classProperty.accept(this, parameters);
             path.pop();
         }
+
+        throwUnknownProperties(unknownProperties, classDeclaration, currentPath);
 
         return resourceObj;
     }

--- a/packages/concerto-core/src/serializer/validationexception.ts
+++ b/packages/concerto-core/src/serializer/validationexception.ts
@@ -17,6 +17,16 @@
 const BaseException = require('@accordproject/concerto-util').BaseException;
 
 /**
+ * Optional structured details for a validation failure.
+ * Intended for conversion to Diagnostic objects by higher-level validation APIs.
+ * @typedef {Object} ValidationExceptionDetails
+ * @property {string} [path] - JSON path to the invalid value (e.g. `$.declarations[0].name`)
+ * @property {string} [code] - Machine-readable code (e.g. `UNKNOWN_PROPERTY`, `TYPE_VIOLATION`)
+ * @property {string} [expected] - Expected type or value description
+ * @property {string} [actual] - Actual type or value description
+ */
+
+/**
  * Exception thrown when a resource fails to model against the model
  * @extends BaseException
  * @see See {@link  BaseException}
@@ -25,14 +35,24 @@ const BaseException = require('@accordproject/concerto-util').BaseException;
  * @private
  */
 class ValidationException extends BaseException {
+    details?: {
+        path?: string;
+        code?: string;
+        expected?: string;
+        actual?: string;
+    };
 
     /**
      * Create a ValidationException
      * @param {string} message - the message for the exception
-     * @param {string} component - the optional component which throws this error
+     * @param {string} [component] - the optional component which throws this error
+     * @param {ValidationExceptionDetails} [details] - optional structured details for diagnostic conversion
      */
-    constructor(message, component) {
+    constructor(message, component?, details?) {
         super(message, component);
+        if (details) {
+            this.details = details;
+        }
     }
 }
 

--- a/packages/concerto-core/src/types.ts
+++ b/packages/concerto-core/src/types.ts
@@ -35,3 +35,21 @@ export interface ModelFileSource {
     definitions: string | null;
     fileName: string;
 }
+
+/**
+ * Options controlling deserialization-time validation in Serializer.fromJSON.
+ */
+export interface DeserializeOptions {
+    /** Error on extra fields not in the model (Zod .strict()). Default false. */
+    rejectUnknownKeys?: boolean;
+    /** Fail fast when a required field is explicitly null. Default false. */
+    rejectRequiredNull?: boolean;
+    /** Type-only; strip as default deferred to #1239. */
+    unknownKeys?: 'strip';
+}
+
+/** Preset for strict metamodel validation and future validateInstance callers. */
+export const STRICT_VALIDATE_OPTIONS: DeserializeOptions = {
+    rejectUnknownKeys: true,
+    rejectRequiredNull: true,
+};

--- a/packages/concerto-core/test/1.0.0/validate.js
+++ b/packages/concerto-core/test/1.0.0/validate.js
@@ -87,7 +87,7 @@ const negative = [{
     name: 'root hierarchy',
     sample: './data/hierarchy2err.json',
     ctoFiles: ['./models/hierarchy2.cto'],
-    error: 'Unexpected properties for type org.test@1.0.0.C: c, t',
+    error: 'Unexpected properties for type org.test@1.0.0.C: c',
     errorFunctional: 'Instance "undefined" has a property named "c", which is not declared in "org.test@1.0.0.C".'
 }, {
     name: 'user defined identifier',

--- a/packages/concerto-core/test/1.0.0/validate.js
+++ b/packages/concerto-core/test/1.0.0/validate.js
@@ -87,7 +87,7 @@ const negative = [{
     name: 'root hierarchy',
     sample: './data/hierarchy2err.json',
     ctoFiles: ['./models/hierarchy2.cto'],
-    error: 'Unexpected properties for type org.test@1.0.0.C: c',
+    error: 'Unexpected properties for type org.test@1.0.0.C: c, t',
     errorFunctional: 'Instance "undefined" has a property named "c", which is not declared in "org.test@1.0.0.C".'
 }, {
     name: 'user defined identifier',

--- a/packages/concerto-core/test/introspect/metamodel.js
+++ b/packages/concerto-core/test/introspect/metamodel.js
@@ -20,6 +20,7 @@ const {
     validateMetaModel,
     modelManagerFromMetaModel
 } = require('../../src/introspect/metamodel');
+const { STRICT_VALIDATE_OPTIONS } = require('../../src');
 const ParserUtil = require('./parserutility');
 
 const { Parser, Printer } = require('@accordproject/concerto-cto');
@@ -231,7 +232,7 @@ describe('MetaModel (Parent - Child (Import Aliasing))', () => {
     });
 });
 
-describe('#validateMetaModel strict mode', () => {
+describe('#validateMetaModel deserialize options', () => {
     const emptyMetaModel = JSON.parse(fs.readFileSync(path.resolve(__dirname, '../data/model/empty.json'), 'utf8'));
 
     const baseModelAst = {
@@ -262,12 +263,12 @@ describe('#validateMetaModel strict mode', () => {
         (() => validateMetaModel(ast)).should.not.throw();
     });
 
-    it('should reject null-valued unknown properties when strict is true', () => {
+    it('should reject null-valued unknown properties when rejectUnknownKeys is true', () => {
         const ast = JSON.parse(JSON.stringify(baseModelAst));
         ast.declarations[0].properties[0]['not-required-key'] = null;
         let error;
         try {
-            validateMetaModel(ast, { strict: true });
+            validateMetaModel(ast, { rejectUnknownKeys: true });
         } catch (e) {
             error = e;
         }
@@ -282,12 +283,12 @@ describe('#validateMetaModel strict mode', () => {
         (() => validateMetaModel(ast)).should.throw(ValidationException, /Unexpected properties/);
     });
 
-    it('should fail fast on required fields set to null when strict is true', () => {
+    it('should fail fast on required fields set to null when rejectRequiredNull is true', () => {
         const ast = JSON.parse(JSON.stringify(baseModelAst));
         ast.declarations[0].properties[0].name = null;
         let error;
         try {
-            validateMetaModel(ast, { strict: true });
+            validateMetaModel(ast, { rejectRequiredNull: true });
         } catch (e) {
             error = e;
         }
@@ -299,14 +300,43 @@ describe('#validateMetaModel strict mode', () => {
         error.details.actual.should.equal('null');
     });
 
-    it('should allow optional properties set to null when strict is true', () => {
+    it('should not reject null-valued unknown properties when only rejectRequiredNull is true', () => {
         const ast = JSON.parse(JSON.stringify(baseModelAst));
-        ast.declarations[0].properties[0].validator = null;
-        (() => validateMetaModel(ast, { strict: true })).should.not.throw();
+        ast.declarations[0].properties[0]['not-required-key'] = null;
+        (() => validateMetaModel(ast, { rejectRequiredNull: true })).should.not.throw();
     });
 
-    it('should validate a well-formed metamodel when strict is true', () => {
-        (() => validateMetaModel(emptyMetaModel, { strict: true })).should.not.throw();
-        (() => validateMetaModel(baseModelAst, { strict: true })).should.not.throw();
+    it('should defer required null when only rejectUnknownKeys is true', () => {
+        const ast = JSON.parse(JSON.stringify(baseModelAst));
+        ast.declarations[0].properties[0].name = null;
+        (() => validateMetaModel(ast, { rejectUnknownKeys: true })).should.throw(/missing the required field/);
+    });
+
+    it('should allow optional properties set to null when rejectRequiredNull is true', () => {
+        const ast = JSON.parse(JSON.stringify(baseModelAst));
+        ast.declarations[0].properties[0].validator = null;
+        (() => validateMetaModel(ast, { rejectRequiredNull: true })).should.not.throw();
+    });
+
+    it('should validate a well-formed metamodel with STRICT_VALIDATE_OPTIONS', () => {
+        (() => validateMetaModel(emptyMetaModel, STRICT_VALIDATE_OPTIONS)).should.not.throw();
+        (() => validateMetaModel(baseModelAst, STRICT_VALIDATE_OPTIONS)).should.not.throw();
+    });
+
+    it('should reject null unknown and required null with STRICT_VALIDATE_OPTIONS', () => {
+        const astUnknown = JSON.parse(JSON.stringify(baseModelAst));
+        astUnknown.declarations[0].properties[0]['not-required-key'] = null;
+        (() => validateMetaModel(astUnknown, STRICT_VALIDATE_OPTIONS)).should.throw(ValidationException);
+
+        const astRequiredNull = JSON.parse(JSON.stringify(baseModelAst));
+        astRequiredNull.declarations[0].properties[0].name = null;
+        let requiredNullError;
+        try {
+            validateMetaModel(astRequiredNull, STRICT_VALIDATE_OPTIONS);
+        } catch (e) {
+            requiredNullError = e;
+        }
+        requiredNullError.should.be.an.instanceOf(ValidationException);
+        requiredNullError.details.code.should.equal('TYPE_VIOLATION');
     });
 });

--- a/packages/concerto-core/test/introspect/metamodel.js
+++ b/packages/concerto-core/test/introspect/metamodel.js
@@ -31,6 +31,8 @@ const chai = require('chai');
 chai.should();
 chai.use(require('chai-things'));
 
+const ValidationException = require('../../src/serializer/validationexception');
+
 describe('MetaModel (Person)', () => {
     const personModelPath = path.resolve(__dirname, '../data/model/person.cto');
     const timeModelPath = path.resolve(__dirname, '../data/model/@models.accordproject.org.time@0.3.0.cto');
@@ -226,5 +228,85 @@ describe('MetaModel (Parent - Child (Import Aliasing))', () => {
             const mf3 = ParserUtil.newModelFile(modelManager, resolvedModelPrint);
             mf3.getAst().should.deep.equal(parentMetaModel);
         });
+    });
+});
+
+describe('#validateMetaModel strict mode', () => {
+    const emptyMetaModel = JSON.parse(fs.readFileSync(path.resolve(__dirname, '../data/model/empty.json'), 'utf8'));
+
+    const baseModelAst = {
+        $class: 'concerto.metamodel@1.0.0.Model',
+        decorators: [],
+        namespace: 'test.strict@1.0.0',
+        declarations: [
+            {
+                $class: 'concerto.metamodel@1.0.0.ConceptDeclaration',
+                name: 'Hello',
+                isAbstract: false,
+                properties: [
+                    {
+                        $class: 'concerto.metamodel@1.0.0.StringProperty',
+                        name: 'a',
+                        isArray: false,
+                        isOptional: false,
+                        decorators: []
+                    }
+                ]
+            }
+        ]
+    };
+
+    it('should tolerate null-valued unknown properties by default', () => {
+        const ast = JSON.parse(JSON.stringify(baseModelAst));
+        ast.declarations[0].properties[0]['not-required-key'] = null;
+        (() => validateMetaModel(ast)).should.not.throw();
+    });
+
+    it('should reject null-valued unknown properties when strict is true', () => {
+        const ast = JSON.parse(JSON.stringify(baseModelAst));
+        ast.declarations[0].properties[0]['not-required-key'] = null;
+        let error;
+        try {
+            validateMetaModel(ast, { strict: true });
+        } catch (e) {
+            error = e;
+        }
+        error.should.be.an.instanceOf(ValidationException);
+        error.details.code.should.equal('UNKNOWN_PROPERTY');
+        error.details.path.should.include('properties[0]');
+    });
+
+    it('should reject non-null unknown properties by default (legacy behavior)', () => {
+        const ast = JSON.parse(JSON.stringify(baseModelAst));
+        ast.declarations[0].properties[0]['not-required-key'] = 'value';
+        (() => validateMetaModel(ast)).should.throw(ValidationException, /Unexpected properties/);
+    });
+
+    it('should fail fast on required fields set to null when strict is true', () => {
+        const ast = JSON.parse(JSON.stringify(baseModelAst));
+        ast.declarations[0].properties[0].name = null;
+        let error;
+        try {
+            validateMetaModel(ast, { strict: true });
+        } catch (e) {
+            error = e;
+        }
+        error.should.be.an.instanceOf(ValidationException);
+        error.message.should.match(/Expected value at path `.*` to be of type `String`, but got null/);
+        error.details.code.should.equal('TYPE_VIOLATION');
+        error.details.path.should.equal('$.declarations[0].properties[0].name');
+        error.details.expected.should.equal('String');
+        error.details.actual.should.equal('null');
+    });
+
+    it('should allow optional properties set to null when strict is true', () => {
+        const ast = JSON.parse(JSON.stringify(baseModelAst));
+        ast.declarations[0].properties[0].validator = null;
+        (() => validateMetaModel(ast, { strict: true })).should.not.throw();
+    });
+
+    it('should validate a well-formed metamodel when strict is true', () => {
+        (() => validateMetaModel(emptyMetaModel, { strict: true })).should.not.throw();
+        (() => validateMetaModel(baseModelAst, { strict: true })).should.not.throw();
     });
 });

--- a/packages/concerto-core/test/modelmanager.js
+++ b/packages/concerto-core/test/modelmanager.js
@@ -297,6 +297,20 @@ describe('ModelManager', () => {
                 basemodelmanager.addModel(ast, undefined, 'origFile');
             }).should.throw('Model file version 99.0.0 does not match metamodel version 1.0.0');
         });
+
+        it('should reject null-valued unknown properties in metamodel AST validation', () => {
+            const basemodelmanager = new BaseModelManager({ metamodelValidation: true });
+            const ast = {
+                $class: `${MetaModelNamespace}.Model`,
+                namespace: 'org.acme@1.0.0',
+                declarations: [],
+                decorators: [],
+                'not-required-key': null
+            };
+            (() => {
+                basemodelmanager.addModel(ast, undefined, 'origFile');
+            }).should.throw(/Unexpected properties.*not-required-key/);
+        });
     });
 
     describe('#addModelFiles', () => {

--- a/packages/concerto-core/test/serializer.js
+++ b/packages/concerto-core/test/serializer.js
@@ -507,7 +507,7 @@ describe('Serializer', () => {
             roundTrip.isPrivate.should.be.false;
         });
 
-        it('should throw on unknown null-valued properties when strict is true', () => {
+        it('should throw on unknown null-valued properties when rejectUnknownKeys is true', () => {
             const json = {
                 $class: 'org.acme.sample@1.0.0.SampleParticipant',
                 participantId: 'alphablock',
@@ -516,11 +516,11 @@ describe('Serializer', () => {
                 unknownField: null
             };
             (() =>
-                serializer.fromJSON(json, { strict: true, validate: false })
+                serializer.fromJSON(json, { rejectUnknownKeys: true, validate: false })
             ).should.throw(/Unexpected properties.*unknownField/);
         });
 
-        it('should attach structured details when strict hydrate fails with validate false', () => {
+        it('should attach structured details when hydrate fails with validate false', () => {
             const json = {
                 $class: 'org.acme.sample@1.0.0.SampleParticipant',
                 participantId: 'alphablock',
@@ -530,7 +530,7 @@ describe('Serializer', () => {
             };
             let error;
             try {
-                serializer.fromJSON(json, { strict: true, validate: false });
+                serializer.fromJSON(json, { rejectUnknownKeys: true, validate: false });
             } catch (e) {
                 error = e;
             }
@@ -539,7 +539,7 @@ describe('Serializer', () => {
             error.details.path.should.equal('$');
         });
 
-        it('should not throw on unknown null-valued properties when strict is false', () => {
+        it('should not throw on unknown null-valued properties by default', () => {
             const json = {
                 $class: 'org.acme.sample@1.0.0.SampleParticipant',
                 participantId: 'alphablock',
@@ -547,7 +547,7 @@ describe('Serializer', () => {
                 lastName: 'Norris',
                 unknownField: null
             };
-            const result = serializer.fromJSON(json, { strict: false, validate: false });
+            const result = serializer.fromJSON(json, { validate: false });
             result.should.be.an.instanceOf(Resource);
         });
 

--- a/packages/concerto-core/test/serializer.js
+++ b/packages/concerto-core/test/serializer.js
@@ -507,6 +507,50 @@ describe('Serializer', () => {
             roundTrip.isPrivate.should.be.false;
         });
 
+        it('should throw on unknown null-valued properties when strict is true', () => {
+            const json = {
+                $class: 'org.acme.sample@1.0.0.SampleParticipant',
+                participantId: 'alphablock',
+                firstName: 'Block',
+                lastName: 'Norris',
+                unknownField: null
+            };
+            (() =>
+                serializer.fromJSON(json, { strict: true, validate: false })
+            ).should.throw(/Unexpected properties.*unknownField/);
+        });
+
+        it('should attach structured details when strict hydrate fails with validate false', () => {
+            const json = {
+                $class: 'org.acme.sample@1.0.0.SampleParticipant',
+                participantId: 'alphablock',
+                firstName: 'Block',
+                lastName: 'Norris',
+                unknownField: null
+            };
+            let error;
+            try {
+                serializer.fromJSON(json, { strict: true, validate: false });
+            } catch (e) {
+                error = e;
+            }
+            error.should.be.an.instanceOf(require('../src/serializer/validationexception'));
+            error.details.code.should.equal('UNKNOWN_PROPERTY');
+            error.details.path.should.equal('$');
+        });
+
+        it('should not throw on unknown null-valued properties when strict is false', () => {
+            const json = {
+                $class: 'org.acme.sample@1.0.0.SampleParticipant',
+                participantId: 'alphablock',
+                firstName: 'Block',
+                lastName: 'Norris',
+                unknownField: null
+            };
+            const result = serializer.fromJSON(json, { strict: false, validate: false });
+            result.should.be.an.instanceOf(Resource);
+        });
+
         const json = {
             $class : 'org.acme.sample@1.0.0.DateTimeTest',
         };

--- a/packages/concerto-core/test/serializer/jsonpopulator.js
+++ b/packages/concerto-core/test/serializer/jsonpopulator.js
@@ -864,4 +864,141 @@ describe('JSONPopulator', () => {
 
     });
 
+    describe('#strict mode', () => {
+
+        let strictPopulator;
+
+        beforeEach(() => {
+            strictPopulator = new JSONPopulator(false, false, 0, true, true);
+        });
+
+        it('should throw on unknown properties with null values when strict is true', () => {
+            const classDeclaration = modelManager.getType('org.acme@1.0.0.MyAsset1');
+            const resource = {};
+            const json = {
+                $class: 'org.acme@1.0.0.MyAsset1',
+                assetId: 'asset1',
+                unknownProp: null
+            };
+            const parameters = {
+                jsonStack: new TypedStack(json),
+                resourceStack: new TypedStack(resource),
+                factory: mockFactory,
+                modelManager: modelManager
+            };
+            (() => {
+                strictPopulator.visitClassDeclaration(classDeclaration, parameters);
+            }).should.throw(ValidationException, /Unexpected properties.*unknownProp/);
+        });
+
+        it('should attach structured details for unknown properties when strict is true', () => {
+            const classDeclaration = modelManager.getType('org.acme@1.0.0.MyAsset1');
+            const resource = {};
+            const json = {
+                $class: 'org.acme@1.0.0.MyAsset1',
+                assetId: 'asset1',
+                unknownProp: null
+            };
+            const parameters = {
+                jsonStack: new TypedStack(json),
+                resourceStack: new TypedStack(resource),
+                factory: mockFactory,
+                modelManager: modelManager
+            };
+            let error;
+            try {
+                strictPopulator.visitClassDeclaration(classDeclaration, parameters);
+            } catch (e) {
+                error = e;
+            }
+            error.should.be.an.instanceOf(ValidationException);
+            error.details.code.should.equal('UNKNOWN_PROPERTY');
+            error.details.path.should.equal('$');
+        });
+
+        it('should attach structured details for required null fields when strict is true', () => {
+            const classDeclaration = modelManager.getType('org.acme@1.0.0.MyAsset1');
+            const resource = {};
+            const json = {
+                $class: 'org.acme@1.0.0.MyAsset1',
+                assetId: null
+            };
+            const parameters = {
+                jsonStack: new TypedStack(json),
+                resourceStack: new TypedStack(resource),
+                factory: mockFactory,
+                modelManager: modelManager
+            };
+            let error;
+            try {
+                strictPopulator.visitClassDeclaration(classDeclaration, parameters);
+            } catch (e) {
+                error = e;
+            }
+            error.should.be.an.instanceOf(ValidationException);
+            error.details.code.should.equal('TYPE_VIOLATION');
+            error.details.path.should.equal('$.assetId');
+            error.details.expected.should.equal('String');
+            error.details.actual.should.equal('null');
+        });
+
+        it('should not throw on known properties with null values when strict is true', () => {
+            const classDeclaration = modelManager.getType('org.acme@1.0.0.MyAsset1');
+            const resource = {};
+            const json = {
+                $class: 'org.acme@1.0.0.MyAsset1',
+                assetId: 'asset1',
+                assetValue: null
+            };
+            const parameters = {
+                jsonStack: new TypedStack(json),
+                resourceStack: new TypedStack(resource),
+                factory: mockFactory,
+                modelManager: modelManager
+            };
+            (() => {
+                strictPopulator.visitClassDeclaration(classDeclaration, parameters);
+            }).should.not.throw();
+        });
+
+        it('should silently ignore unknown null-valued properties when strict is false', () => {
+            const classDeclaration = modelManager.getType('org.acme@1.0.0.MyAsset1');
+            const resource = {};
+            const json = {
+                $class: 'org.acme@1.0.0.MyAsset1',
+                assetId: 'asset1',
+                unknownProp: null
+            };
+            const parameters = {
+                jsonStack: new TypedStack(json),
+                resourceStack: new TypedStack(resource),
+                factory: mockFactory,
+                modelManager: modelManager
+            };
+            (() => {
+                jsonPopulator.visitClassDeclaration(classDeclaration, parameters);
+            }).should.not.throw();
+        });
+
+        it('should not throw on system properties ($class, $identifier) when strict is true', () => {
+            const classDeclaration = modelManager.getType('org.acme@1.0.0.MyAsset1');
+            const resource = {};
+            const json = {
+                $class: 'org.acme@1.0.0.MyAsset1',
+                $identifier: 'asset1',
+                assetId: 'asset1'
+            };
+            const parameters = {
+                jsonStack: new TypedStack(json),
+                resourceStack: new TypedStack(resource),
+                factory: mockFactory,
+                modelManager: modelManager
+            };
+            (() => {
+                strictPopulator.visitClassDeclaration(classDeclaration, parameters);
+            }).should.not.throw();
+        });
+
+    });
+
 });

--- a/packages/concerto-core/test/serializer/jsonpopulator.js
+++ b/packages/concerto-core/test/serializer/jsonpopulator.js
@@ -22,6 +22,7 @@ const ModelManager = require('../../src/modelmanager');
 const Relationship = require('../../src/model/relationship');
 const Resource = require('../../src/model/resource');
 const ValidationException = require('../../src/serializer/validationexception');
+const { STRICT_VALIDATE_OPTIONS } = require('../../src');
 const TypeNotFoundException = require('../../src/typenotfoundexception');
 const Util = require('../composer/composermodelutility');
 const dayjs = require('dayjs');
@@ -864,15 +865,19 @@ describe('JSONPopulator', () => {
 
     });
 
-    describe('#strict mode', () => {
+    describe('#deserialize options', () => {
 
         let strictPopulator;
+        let rejectUnknownKeysPopulator;
+        let rejectRequiredNullPopulator;
 
         beforeEach(() => {
-            strictPopulator = new JSONPopulator(false, false, 0, true, true);
+            strictPopulator = new JSONPopulator(false, false, 0, true, STRICT_VALIDATE_OPTIONS);
+            rejectUnknownKeysPopulator = new JSONPopulator(false, false, 0, true, { rejectUnknownKeys: true });
+            rejectRequiredNullPopulator = new JSONPopulator(false, false, 0, true, { rejectRequiredNull: true });
         });
 
-        it('should throw on unknown properties with null values when strict is true', () => {
+        it('should throw on unknown properties with null values when rejectUnknownKeys is true', () => {
             const classDeclaration = modelManager.getType('org.acme@1.0.0.MyAsset1');
             const resource = {};
             const json = {
@@ -887,11 +892,11 @@ describe('JSONPopulator', () => {
                 modelManager: modelManager
             };
             (() => {
-                strictPopulator.visitClassDeclaration(classDeclaration, parameters);
+                rejectUnknownKeysPopulator.visitClassDeclaration(classDeclaration, parameters);
             }).should.throw(ValidationException, /Unexpected properties.*unknownProp/);
         });
 
-        it('should attach structured details for unknown properties when strict is true', () => {
+        it('should attach structured details for unknown properties when rejectUnknownKeys is true', () => {
             const classDeclaration = modelManager.getType('org.acme@1.0.0.MyAsset1');
             const resource = {};
             const json = {
@@ -907,7 +912,7 @@ describe('JSONPopulator', () => {
             };
             let error;
             try {
-                strictPopulator.visitClassDeclaration(classDeclaration, parameters);
+                rejectUnknownKeysPopulator.visitClassDeclaration(classDeclaration, parameters);
             } catch (e) {
                 error = e;
             }
@@ -916,7 +921,7 @@ describe('JSONPopulator', () => {
             error.details.path.should.equal('$');
         });
 
-        it('should attach structured details for required null fields when strict is true', () => {
+        it('should attach structured details for required null fields when rejectRequiredNull is true', () => {
             const classDeclaration = modelManager.getType('org.acme@1.0.0.MyAsset1');
             const resource = {};
             const json = {
@@ -931,7 +936,7 @@ describe('JSONPopulator', () => {
             };
             let error;
             try {
-                strictPopulator.visitClassDeclaration(classDeclaration, parameters);
+                rejectRequiredNullPopulator.visitClassDeclaration(classDeclaration, parameters);
             } catch (e) {
                 error = e;
             }
@@ -942,7 +947,7 @@ describe('JSONPopulator', () => {
             error.details.actual.should.equal('null');
         });
 
-        it('should not throw on known properties with null values when strict is true', () => {
+        it('should not throw on known optional null values when rejectRequiredNull is true', () => {
             const classDeclaration = modelManager.getType('org.acme@1.0.0.MyAsset1');
             const resource = {};
             const json = {
@@ -957,11 +962,11 @@ describe('JSONPopulator', () => {
                 modelManager: modelManager
             };
             (() => {
-                strictPopulator.visitClassDeclaration(classDeclaration, parameters);
+                rejectRequiredNullPopulator.visitClassDeclaration(classDeclaration, parameters);
             }).should.not.throw();
         });
 
-        it('should silently ignore unknown null-valued properties when strict is false', () => {
+        it('should silently ignore unknown null-valued properties by default', () => {
             const classDeclaration = modelManager.getType('org.acme@1.0.0.MyAsset1');
             const resource = {};
             const json = {
@@ -980,7 +985,7 @@ describe('JSONPopulator', () => {
             }).should.not.throw();
         });
 
-        it('should not throw on system properties ($class, $identifier) when strict is true', () => {
+        it('should not throw on system properties ($class, $identifier) with STRICT_VALIDATE_OPTIONS', () => {
             const classDeclaration = modelManager.getType('org.acme@1.0.0.MyAsset1');
             const resource = {};
             const json = {
@@ -996,6 +1001,24 @@ describe('JSONPopulator', () => {
             };
             (() => {
                 strictPopulator.visitClassDeclaration(classDeclaration, parameters);
+            }).should.not.throw();
+        });
+
+        it('should not reject required null when only rejectUnknownKeys is true', () => {
+            const classDeclaration = modelManager.getType('org.acme@1.0.0.MyAsset1');
+            const resource = {};
+            const json = {
+                $class: 'org.acme@1.0.0.MyAsset1',
+                assetId: null
+            };
+            const parameters = {
+                jsonStack: new TypedStack(json),
+                resourceStack: new TypedStack(resource),
+                factory: mockFactory,
+                modelManager: modelManager
+            };
+            (() => {
+                rejectUnknownKeysPopulator.visitClassDeclaration(classDeclaration, parameters);
             }).should.not.throw();
         });
 


### PR DESCRIPTION
## Summary

Introduces a shared **`DeserializeOptions`** bag on `Serializer.fromJSON` and `validateMetaModel`, with two independent populate-time flags:

- **`rejectUnknownKeys`** — error on extra fields not in the model (Zod `.strict()`)
- **`rejectRequiredNull`** — fail fast when a required field is explicitly `null`, with path + type (`TYPE_VIOLATION`)

Also adds:

- **`STRICT_VALIDATE_OPTIONS`** preset (`{ rejectUnknownKeys: true, rejectRequiredNull: true }`) exported from `concerto-core`
- **`ValidationException.details`** — optional `{ path, code, expected, actual }` for structured errors (foundation for #1239)
- **`BaseModelManager.validateAst`** wired to `STRICT_VALIDATE_OPTIONS` when `metamodelValidation: true`, so metamodel AST validation rejects null-valued unknown keys

**Instance deserialization defaults are unchanged** (`rejectUnknownKeys: false`, `rejectRequiredNull: false`).

Closes #1273

## Usage

```js
const { MetaModel, STRICT_VALIDATE_OPTIONS } = require('@accordproject/concerto-core');

// Explicit flags
MetaModel.validateMetaModel(ast, {
  rejectUnknownKeys: true,
  rejectRequiredNull: true,
});

// Or use the preset
MetaModel.validateMetaModel(ast, STRICT_VALIDATE_OPTIONS);

// Same options on Serializer.fromJSON
serializer.fromJSON(json, { rejectUnknownKeys: true, validate: false });
```

## Behavior matrix

| Scenario | Default | `rejectUnknownKeys: true` | `rejectRequiredNull: true` |
| --- | --- | --- | --- |
| Unknown field = `null` | Silently ignored | Error (`UNKNOWN_PROPERTY`) | — |
| Unknown field = non-null | Error (legacy) | Error (`UNKNOWN_PROPERTY`) | — |
| Required field = `null` | `ResourceValidator` (generic message) | — | Immediate error with path + type (`TYPE_VIOLATION`) |
| Optional field = `null` | Silently skipped | Silently skipped | Silently skipped |

Flags compose independently — e.g. `rejectRequiredNull` alone does not reject null-valued unknown keys.

## Changes

| File | What changed |
| --- | --- |
| `types.ts` | `DeserializeOptions` interface + `STRICT_VALIDATE_OPTIONS` preset |
| `index.ts` | Export `DeserializeOptions` type and `STRICT_VALIDATE_OPTIONS` |
| `metamodel.ts` | `validateMetaModel(input, options?)` forwards options to `Serializer.fromJSON` |
| `serializer.ts` | Plumbs `rejectUnknownKeys` / `rejectRequiredNull` into `JSONPopulator` |
| `jsonpopulator.ts` | Partition known vs unknown keys; structured `ValidationException.details` on failure |
| `validationexception.ts` | Optional `details` field on constructor |
| `basemodelmanager.ts` | `validateAst` uses `STRICT_VALIDATE_OPTIONS` for metamodel validation |

## Relationship to #1239

This PR is **foundation work** for [#1239](https://github.com/accordproject/concerto/issues/1239) (instance validation API):

- Shared deserialize path and options type — no second options bag in a follow-up PR
- `ValidationException.details` supports future conversion to `Diagnostic`
- Does **not** implement `validateInstance`, diagnostic aggregation, `unknownKeys: 'strip'` default, or `unknownKeys: 'passthrough'`

## Out of scope

- Bundled `strict` boolean (use explicit flags or `STRICT_VALIDATE_OPTIONS`)
- Global `unknownKeys: 'strip'` as instance default (semver-major; deferred to #1239)
- `validateInstance` / `ResourceValidator` collecting mode / `Diagnostic[]`

## Test plan

- [x] `#validateMetaModel deserialize options` — default tolerance, per-flag behavior, preset, structured `details` paths
- [x] `#deserialize options` in `jsonpopulator.js` — unknown-null, required-null, optional-null, system properties, flag independence
- [x] `Serializer.fromJSON` — `rejectUnknownKeys` with `validate: false` and structured `details`
- [x] `ModelManager#addModel` — metamodel AST validation rejects null-valued unknown properties via `STRICT_VALIDATE_OPTIONS`
- [x] Full `concerto-core` test suite passes
- [x] Lint passes