### PR TITLE
fix(concerto-vocabulary): look up terms by own property only

### DIFF
--- a/packages/concerto-vocabulary/src/vocabulary.ts
+++ b/packages/concerto-vocabulary/src/vocabulary.ts
@@ -131,7 +131,7 @@ class Vocabulary {
             return identifier ? decl[identifier] : decl[declarationName];
         }
         else {
-            const property = decl.properties ? decl.properties.find((d: any) => propertyName in d) : null;
+            const property = decl.properties ? decl.properties.find((d: any) => Object.prototype.hasOwnProperty.call(d, propertyName)) : null;
             return property ? identifier ? property[identifier] : property[propertyName] : null;
         }
     }
@@ -154,7 +154,7 @@ class Vocabulary {
             return decl;
         }
         else {
-            const property = decl.properties ? decl.properties.find((d: any) => propertyName in d) : null;
+            const property = decl.properties ? decl.properties.find((d: any) => Object.prototype.hasOwnProperty.call(d, propertyName)) : null;
             return property;
         }
     }

--- a/packages/concerto-vocabulary/test/vocabulary.js
+++ b/packages/concerto-vocabulary/test/vocabulary.js
@@ -191,4 +191,56 @@ describe('Vocabulary', () => {
             terms.label.should.equal('');
         });
     });
+
+    describe('getTerm / getElementTerms - property names that shadow Object.prototype', () => {
+        let voc;
+        beforeEach(() => {
+            voc = new Vocabulary({}, {
+                locale: 'en',
+                namespace: 'org.proto@1.0.0',
+                declarations: [
+                    {
+                        Book: 'A book',
+                        properties: [
+                            { title: 'The title' },
+                            { constructor: 'Constructor term' },
+                            { toString: 'ToString term' },
+                            { hasOwnProperty: 'HasOwnProperty term' }
+                        ]
+                    }
+                ]
+            });
+        });
+
+        it('getTerm - returns the term for a property named constructor', () => {
+            const term = voc.getTerm('Book', 'constructor');
+            term.should.equal('Constructor term');
+        });
+
+        it('getTerm - returns the term for a property named toString', () => {
+            const term = voc.getTerm('Book', 'toString');
+            term.should.equal('ToString term');
+        });
+
+        it('getTerm - returns the term for a property named hasOwnProperty', () => {
+            const term = voc.getTerm('Book', 'hasOwnProperty');
+            term.should.equal('HasOwnProperty term');
+        });
+
+        it('getTerm - returns null for an undeclared Object.prototype property name', () => {
+            const term = voc.getTerm('Book', 'valueOf');
+            should.equal(term, null);
+        });
+
+        it('getElementTerms - returns the property for a name that shadows Object.prototype', () => {
+            const terms = voc.getElementTerms('Book', 'toString');
+            should.exist(terms);
+            terms.toString.should.equal('ToString term');
+        });
+
+        it('getElementTerms - returns null for an undeclared Object.prototype property name', () => {
+            const terms = voc.getElementTerms('Book', 'valueOf');
+            should.not.exist(terms);
+        });
+    });
 });


### PR DESCRIPTION
# Closes #1241

`Vocabulary.getTerm` and `getElementTerms` matched a property's term with `propertyName in d`, which walks the prototype chain. A property named after an `Object.prototype` member (`hasOwnProperty`, `constructor`, `toString`, `valueOf`) matched every declaration object and returned a built-in `Function` instead of the term, or a `Function` instead of `null` for an undeclared name.

### Changes

- Both methods now use an own-property check, `Object.prototype.hasOwnProperty.call(d, propertyName)`, so a term comes back only for a property actually declared on the object.
- Tests in `test/vocabulary.js` cover `constructor`/`toString`/`hasOwnProperty` resolving to their own terms and undeclared prototype names returning `null`; they fail on revert. Suite (95), lint and coverage green.

### Flags

- Used `hasOwnProperty.call` rather than `Object.hasOwn`, which reads cleaner but isn't in the package's `es2020` TS lib.
- Fixed `getElementTerms` alongside `getTerm` since it has the identical defect, happy to narrow to `getTerm`.
- Also covers the property-existence half of #1183.

### Related Issues

- Issue #1241
- Issue #1183 (partly addressed)

### Author Checklist

- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [x] Merging to `main` from `fork:branchname`