### PR TITLE
fix(serializer): enhance null value handling and validation options in fromJSON method

### DIFF
--- a/packages/concerto-core/src/serializer.ts
+++ b/packages/concerto-core/src/serializer.ts
@@ -26,6 +26,7 @@ const { utcOffset: defaultUtcOffset } = DateTimeUtil.setCurrentTime();
 const baseDefaultOptions = {
     validate: true,
     utcOffset: defaultUtcOffset,
+    allowNullValues: true, // TODO: remove in next major — always validate property names regardless of value
 };
 
 // Types needed for TypeScript generation.
@@ -147,10 +148,14 @@ class Serializer {
      * @param {Object} [options] - the optional serialization options
      * @param {boolean} options.acceptResourcesForRelationships - handle JSON objects
      * in the place of strings for relationships, defaults to false.
-     * @param {boolean} options.validate - validate the structure of the Resource
-     * with its model prior to serialization (default to true)
+     * @param {boolean} [options.validate=true] - Validate property names and run full
+     * model validation after population. Exists to allow trusted internal round-trips
+     * (e.g. storage → memory) to skip the overhead of re-checking already-valid data.
      * @param {number} [options.utcOffset] - UTC Offset for DateTime values.
      * @param {boolean} [options.strictQualifiedDateTimes] - Only allow fully-qualified date-times with offsets.
+     * @param {boolean} [options.allowNullValues=true] - When true, null-valued properties are
+     * included in property iteration but bypass name validation and are never set on the resource.
+     * Set to false to treat null the same as undefined (filter out entirely).
      * @return {Resource} The new populated resource
      */
     fromJSON(jsonObject, options?) {
@@ -194,6 +199,8 @@ class Serializer {
         parameters.resourceStack = new TypedStack(resource);
         parameters.modelManager = this.modelManager;
         parameters.factory = this.factory;
+        parameters.validate = options.validate;
+        parameters.allowNullValues = options.allowNullValues === true;
         const populator = new JSONPopulator(options.acceptResourcesForRelationships === true, false, options.utcOffset, options.strictQualifiedDateTimes === true);
         classDeclaration.accept(populator, parameters);
 

--- a/packages/concerto-core/src/serializer.ts
+++ b/packages/concerto-core/src/serializer.ts
@@ -155,7 +155,8 @@ class Serializer {
      * @param {boolean} [options.strictQualifiedDateTimes] - Only allow fully-qualified date-times with offsets.
      * @param {boolean} [options.allowNullValues=true] - When true, null-valued properties are
      * included in property iteration but bypass name validation and are never set on the resource.
-     * Set to false to treat null the same as undefined (filter out entirely).
+     * When false, null-valued properties are excluded from assignment but still validated against
+     * the model — unknown null-valued properties will throw a ValidationException if validate is true.
      * @return {Resource} The new populated resource
      */
     fromJSON(jsonObject, options?) {
@@ -200,7 +201,7 @@ class Serializer {
         parameters.modelManager = this.modelManager;
         parameters.factory = this.factory;
         parameters.validate = options.validate;
-        parameters.allowNullValues = options.allowNullValues === true;
+        parameters.allowNullValues = options.allowNullValues !== false;
         const populator = new JSONPopulator(options.acceptResourcesForRelationships === true, false, options.utcOffset, options.strictQualifiedDateTimes === true);
         classDeclaration.accept(populator, parameters);
 

--- a/packages/concerto-core/src/serializer/jsonpopulator.ts
+++ b/packages/concerto-core/src/serializer/jsonpopulator.ts
@@ -55,18 +55,22 @@ type JsonPopulatorParameters = {
     acceptResourcesForRelationships?: boolean;
     utcOffset?: number;
     strictQualifiedDateTimes?: boolean;
+    validate?: boolean;
+    allowNullValues?: boolean;
 };
 
 type VisitorTarget = Declaration | Field | ClassDeclaration | MapDeclaration | RelationshipDeclaration;
 
 /**
- * Get all properties on a resource object that both have a value and are not system properties.
+ * Get all properties on a resource object that have a value and are not system properties.
  * @param {Object} resourceData JSON object representation of a resource.
  * @param {ClassDeclaration} classDeclaration class declaration.
+ * @param {boolean} [allowNullValues=true] - When true, null-valued properties are included
+ * in the returned list. When false, both null and undefined are treated as absent.
  * @return {Array} property names.
  * @private
  */
-function getAssignableProperties(resourceData, classDeclaration) {
+function getAssignableProperties(resourceData, classDeclaration, allowNullValues = true) {
     const properties = Object.keys(resourceData);
     const privateProperties = properties.filter(ModelUtil.isPrivateSystemProperty);
     if (privateProperties.length > 0){
@@ -82,9 +86,24 @@ function getAssignableProperties(resourceData, classDeclaration) {
         throw new ValidationException(errorText);
     }
 
-    return properties.filter((property) => {
-        return !ModelUtil.isSystemProperty(property) && !Util.isNull(resourceData[property]);
+    // All explicitly present (non-undefined) user properties
+    const allProperties = properties.filter((property) => {
+        return !ModelUtil.isSystemProperty(property) && resourceData[property] !== undefined;
     });
+
+    // Properties to write onto the resource: exclude nulls when allowNullValues=false
+    const assignable = allowNullValues
+        ? allProperties
+        : allProperties.filter(p => !Util.isNull(resourceData[p]));
+
+    // Properties to validate against the model:
+    // - allowNullValues=true: skip null props from type-checking (legacy permissive)
+    // - allowNullValues=false: validate ALL present props so unknown null fields are caught
+    const validatable = allowNullValues
+        ? allProperties.filter(p => !Util.isNull(resourceData[p]))
+        : allProperties;
+
+    return { assignable, validatable };
 }
 
 /**
@@ -130,7 +149,6 @@ class JSONPopulator {
      * @param {boolean} [ergo] - Deprecated - This is a dummy parameter to avoid breaking any consumers. It will be removed in a future release.
      * @param {number} [utcOffset] - UTC Offset for DateTime values.
      * @param {boolean} [strictQualifiedDateTimes=true] - Only allow fully-qualified date-times with offsets.
-
      */
     constructor(acceptResourcesForRelationships, ergo, utcOffset, strictQualifiedDateTimes) {
         this.acceptResourcesForRelationships = acceptResourcesForRelationships;
@@ -179,15 +197,21 @@ class JSONPopulator {
         const resourceObj = parameters.resourceStack.pop();
         parameters.path ?? (parameters.path = new TypedStack('$'));
 
-        const properties = getAssignableProperties(jsonObj, classDeclaration);
-        validateProperties(properties, classDeclaration);
+        // Default to true when not explicitly set (preserves backward compatibility)
+        const { assignable, validatable } = getAssignableProperties(jsonObj, classDeclaration, parameters.allowNullValues !== false);
+        if (parameters.validate !== false) {
+            validateProperties(validatable, classDeclaration);
+        }
 
-        properties.forEach((property) => {
+        assignable.forEach((property) => {
             let value = jsonObj[property];
             if (value !== null) {
+                const classProperty = classDeclaration.getProperty(property);
+                if (!classProperty) {
+                    return;
+                }
                 parameters.path?.push(`.${property}`);
                 parameters.jsonStack.push(value);
-                const classProperty = classDeclaration.getProperty(property);
                 resourceObj[property] = classProperty.accept(this,parameters);
                 parameters.path?.pop();
             }

--- a/packages/concerto-core/src/serializer/jsonpopulator.ts
+++ b/packages/concerto-core/src/serializer/jsonpopulator.ts
@@ -62,12 +62,19 @@ type JsonPopulatorParameters = {
 type VisitorTarget = Declaration | Field | ClassDeclaration | MapDeclaration | RelationshipDeclaration;
 
 /**
- * Get all properties on a resource object that have a value and are not system properties.
+ * Get non-system, non-undefined properties from a resource object, split into two sets:
+ * - `assignable`: properties to write onto the resource instance.
+ * - `validatable`: properties to validate against the class declaration.
+ *
+ * When `allowNullValues` is true (default), null-valued properties are assignable but
+ * excluded from validation (legacy permissive behaviour). When false, null-valued
+ * properties are excluded from assignment but included in validation so that unknown
+ * null fields are caught.
+ *
  * @param {Object} resourceData JSON object representation of a resource.
  * @param {ClassDeclaration} classDeclaration class declaration.
- * @param {boolean} [allowNullValues=true] - When true, null-valued properties are included
- * in the returned list. When false, both null and undefined are treated as absent.
- * @return {Array} property names.
+ * @param {boolean} [allowNullValues=true] - Controls how null-valued properties are handled.
+ * @return {{assignable: string[], validatable: string[]}} property name sets.
  * @private
  */
 function getAssignableProperties(resourceData, classDeclaration, allowNullValues = true) {

--- a/packages/concerto-core/test/serializer.js
+++ b/packages/concerto-core/test/serializer.js
@@ -507,6 +507,69 @@ describe('Serializer', () => {
             roundTrip.isPrivate.should.be.false;
         });
 
+        it('should not throw on unknown null-valued properties with default options', () => {
+            const json = {
+                $class: 'org.acme.sample@1.0.0.SampleParticipant',
+                participantId: 'alphablock',
+                firstName: 'Block',
+                lastName: 'Norris',
+                unknownField: null
+            };
+            let resource = serializer.fromJSON(json);
+            resource.should.be.an.instanceOf(Resource);
+            should.equal(resource.unknownField, undefined);
+        });
+
+        it('should not throw on unknown null-valued properties when allowNullValues is false', () => {
+            const json = {
+                $class: 'org.acme.sample@1.0.0.SampleParticipant',
+                participantId: 'alphablock',
+                firstName: 'Block',
+                lastName: 'Norris',
+                unknownField: null
+            };
+            (() => serializer.fromJSON(json, { allowNullValues: false, validate: true }))
+                .should.throw(/Unexpected properties.*unknownField/);
+        });
+
+        it('should throw on unknown non-null properties when validate is true', () => {
+            const json = {
+                $class: 'org.acme.sample@1.0.0.SampleParticipant',
+                participantId: 'alphablock',
+                firstName: 'Block',
+                lastName: 'Norris',
+                unknownField: 'not null'
+            };
+            (() => serializer.fromJSON(json, { validate: true }))
+                .should.throw(/Unexpected properties.*unknownField/);
+        });
+
+        it('should not throw on unknown null-valued properties when validate is false', () => {
+            const json = {
+                $class: 'org.acme.sample@1.0.0.SampleParticipant',
+                participantId: 'alphablock',
+                firstName: 'Block',
+                lastName: 'Norris',
+                unknownField: null
+            };
+            let resource = serializer.fromJSON(json, { allowNullValues: true, validate: false });
+            resource.should.be.an.instanceOf(Resource);
+            should.equal(resource.unknownField, undefined);
+        });
+
+        it('should not throw on unknown non-null properties when validate is false', () => {
+            const json = {
+                $class: 'org.acme.sample@1.0.0.SampleParticipant',
+                participantId: 'alphablock',
+                firstName: 'Block',
+                lastName: 'Norris',
+                unknownField: 'not null'
+            };
+            let resource = serializer.fromJSON(json, { allowNullValues: true, validate: false });
+            resource.should.be.an.instanceOf(Resource);
+            should.equal(resource.unknownField, undefined);
+        });
+
         const json = {
             $class : 'org.acme.sample@1.0.0.DateTimeTest',
         };

--- a/packages/concerto-core/test/serializer.js
+++ b/packages/concerto-core/test/serializer.js
@@ -520,7 +520,7 @@ describe('Serializer', () => {
             should.equal(resource.unknownField, undefined);
         });
 
-        it('should not throw on unknown null-valued properties when allowNullValues is false', () => {
+        it('should throw on unknown null-valued properties when allowNullValues is false', () => {
             const json = {
                 $class: 'org.acme.sample@1.0.0.SampleParticipant',
                 participantId: 'alphablock',

--- a/packages/concerto-core/test/serializer.js
+++ b/packages/concerto-core/test/serializer.js
@@ -532,6 +532,19 @@ describe('Serializer', () => {
                 .should.throw(/Unexpected properties.*unknownField/);
         });
 
+        it('should not throw on unknown null-valued properties when allowNullValues is undefined', () => {
+            const json = {
+                $class: 'org.acme.sample@1.0.0.SampleParticipant',
+                participantId: 'alphabblock',
+                firstName: 'Block',
+                lastName: 'Norris',
+                unknownField: null
+            };
+            let resource = serializer.fromJSON(json, { allowNullValues: undefined, validate: true });
+            resource.should.be.an.instanceOf(Resource);
+            should.equal(resource.unknownField, undefined);
+        });
+
         it('should throw on unknown non-null properties when validate is true', () => {
             const json = {
                 $class: 'org.acme.sample@1.0.0.SampleParticipant',

--- a/packages/concerto-core/test/serializer/jsonpopulator.js
+++ b/packages/concerto-core/test/serializer/jsonpopulator.js
@@ -864,4 +864,150 @@ describe('JSONPopulator', () => {
 
     });
 
+    describe('#null property handling', () => {
+
+        it('should not throw on unknown null-valued properties when allowNullValues is not set', () => {
+            const classDeclaration = modelManager.getType('org.acme@1.0.0.MyAsset1');
+            const resource = {};
+            const json = {
+                $class: 'org.acme@1.0.0.MyAsset1',
+                assetId: 'asset1',
+                unknownProp: null
+            };
+            const parameters = {
+                jsonStack: new TypedStack(json),
+                resourceStack: new TypedStack(resource),
+                factory: mockFactory,
+                modelManager: modelManager
+            };
+            (() => {
+                jsonPopulator.visitClassDeclaration(classDeclaration, parameters);
+            }).should.not.throw();
+        });
+
+        it('should not throw on unknown null-valued properties when allowNullValues is true', () => {
+            const classDeclaration = modelManager.getType('org.acme@1.0.0.MyAsset1');
+            const resource = {};
+            const json = {
+                $class: 'org.acme@1.0.0.MyAsset1',
+                assetId: 'asset1',
+                unknownProp: null
+            };
+            const parameters = {
+                jsonStack: new TypedStack(json),
+                resourceStack: new TypedStack(resource),
+                factory: mockFactory,
+                modelManager: modelManager,
+                allowNullValues: true,
+                validate: true
+            };
+            (() => {
+                jsonPopulator.visitClassDeclaration(classDeclaration, parameters);
+            }).should.not.throw();
+        });
+
+        it('should throw on unknown non-null properties when validate is true', () => {
+            const classDeclaration = modelManager.getType('org.acme@1.0.0.MyAsset1');
+            const resource = {};
+            const json = {
+                $class: 'org.acme@1.0.0.MyAsset1',
+                assetId: 'asset1',
+                unknownProp: 'not null'
+            };
+            const parameters = {
+                jsonStack: new TypedStack(json),
+                resourceStack: new TypedStack(resource),
+                factory: mockFactory,
+                modelManager: modelManager,
+                allowNullValues: true,
+                validate: true
+            };
+            (() => {
+                jsonPopulator.visitClassDeclaration(classDeclaration, parameters);
+            }).should.throw(/Unexpected properties.*unknownProp/);
+        });
+
+        it('should not throw on unknown null-valued properties when validate is false', () => {
+            const classDeclaration = modelManager.getType('org.acme@1.0.0.MyAsset1');
+            const resource = {};
+            const json = {
+                $class: 'org.acme@1.0.0.MyAsset1',
+                assetId: 'asset1',
+                unknownProp: null
+            };
+            const parameters = {
+                jsonStack: new TypedStack(json),
+                resourceStack: new TypedStack(resource),
+                factory: mockFactory,
+                modelManager: modelManager,
+                allowNullValues: true,
+                validate: false
+            };
+            (() => {
+                jsonPopulator.visitClassDeclaration(classDeclaration, parameters);
+            }).should.not.throw();
+        });
+
+        it('should not throw on known null-valued properties when allowNullValues is true', () => {
+            const classDeclaration = modelManager.getType('org.acme@1.0.0.MyAsset1');
+            const resource = {};
+            const json = {
+                $class: 'org.acme@1.0.0.MyAsset1',
+                assetId: 'asset1',
+                assetValue: null
+            };
+            const parameters = {
+                jsonStack: new TypedStack(json),
+                resourceStack: new TypedStack(resource),
+                factory: mockFactory,
+                modelManager: modelManager,
+                allowNullValues: true
+            };
+            (() => {
+                jsonPopulator.visitClassDeclaration(classDeclaration, parameters);
+            }).should.not.throw();
+        });
+
+        it('should not throw on system properties ($class, $identifier)', () => {
+            const classDeclaration = modelManager.getType('org.acme@1.0.0.MyAsset1');
+            const resource = {};
+            const json = {
+                $class: 'org.acme@1.0.0.MyAsset1',
+                $identifier: 'asset1',
+                assetId: 'asset1'
+            };
+            const parameters = {
+                jsonStack: new TypedStack(json),
+                resourceStack: new TypedStack(resource),
+                factory: mockFactory,
+                modelManager: modelManager
+            };
+            (() => {
+                jsonPopulator.visitClassDeclaration(classDeclaration, parameters);
+            }).should.not.throw();
+        });
+
+        it('should throw on unknown properties', () => {
+            const classDeclaration = modelManager.getType('org.acme@1.0.0.MyAsset1');
+            const resource = {};
+            const json = {
+                $class: 'org.acme@1.0.0.MyAsset1',
+                $identifier: 'asset1',
+                assetId: 'asset1',
+                unknownProp: null
+            };
+            const parameters = {
+                jsonStack: new TypedStack(json),
+                resourceStack: new TypedStack(resource),
+                factory: mockFactory,
+                modelManager: modelManager,
+                allowNullValues: false,
+            };
+            (() => {
+                jsonPopulator.visitClassDeclaration(classDeclaration, parameters);
+            }).should.throw();
+        });
+
+    });
+
 });


### PR DESCRIPTION
Closes #1273 

This PR enhances the Serializer.fromJSON method to support configurable null value handling and property validation, allowing consumers to control strictness when deserializing JSON into Concerto resources.

Changes

- Add allowNullValues option to fromJSON (default true) — when enabled, null-valued properties bypass name validation and are never set on the resource; when disabled, null is treated like any other value and validated against the model
- Add validate parameter passthrough to JSONPopulator.visitClassDeclaration so property name validation can be skipped for trusted internal round-trips
- Refactor getAssignableProperties to return separate assignable and validatable property lists, enabling fine-grained control over which properties are written vs. checked
- Add defensive classProperty null-check in the populator loop to avoid errors when allowNullValues includes unknown properties in the assignable set
- Add comprehensive unit tests for both Serializer and JSONPopulator covering all combinations of allowNullValues and validate

Flags

- allowNullValues defaults to true for backward compatibility — existing consumers will not see behavior changes
- Marked with a TODO to remove permissive default in next major version
- getAssignableProperties now returns an object { assignable, validatable } instead of a plain array — this is an internal (non-exported) function so no public API breakage

Screenshots or Video

N/A — backend serialization logic only.

Related Issues

- Issue #1273 

Author Checklist

- [x] Ensure you provide a DCO sign-off for your commits using the --signoff option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow AP format
- [ ] Extend the documentation, if necessary
- [x] Merging to main from fork:branchname