### PR TITLE
feat(core): add class-hierarchy assignability helpers (#1281)

### DIFF
--- a/packages/concerto-core/src/basemodelmanager.ts
+++ b/packages/concerto-core/src/basemodelmanager.ts
@@ -787,6 +787,45 @@ class BaseModelManager {
     }
 
     /**
+     * Concrete (non-abstract) declarations assignable to baseFqn: the base itself
+     * (when concrete) plus all subclasses. Empty array if baseFqn is not in the model.
+     * @param {string} baseFqn The fully qualified type name
+     * @returns {ClassDeclaration[]} An array of concrete ClassDeclaration that are assignable to baseFqn
+     */
+    getAssignableConcreteTypes(baseFqn: string): any[] {
+        let typeDeclaration;
+        try {
+            typeDeclaration = this.getType(baseFqn);
+        } catch (e) {
+            return []; // Empty array if baseFqn is not in the model
+        }
+
+        const assignable = typeDeclaration.getAssignableClassDeclarations();
+        return assignable.filter(decl => !decl.isAbstract());
+    }
+
+    /**
+     * True when fqn is, or extends, baseFqn (restricted to concrete types).
+     * @param {string} fqn The candidate fully qualified type name
+     * @param {string} baseFqn The fully qualified type name it may be derived from
+     * @returns {boolean} True if fqn is assignable to baseFqn
+     */
+    isAssignableTo(fqn: string, baseFqn: string): boolean {
+        let typeDeclaration;
+        try {
+            typeDeclaration = this.getType(fqn);
+        } catch (e) {
+            return false;
+        }
+
+        if (typeDeclaration.isAbstract()) {
+            return false;
+        }
+
+        return this.derivesFrom(fqn, baseFqn);
+    }
+
+    /**
      * Resolve the namespace for names in the metamodel
      * @param {object} metaModel - the MetaModel
      * @return {object} the resolved metamodel

--- a/packages/concerto-core/test/modelmanager.js
+++ b/packages/concerto-core/test/modelmanager.js
@@ -1172,6 +1172,63 @@ concept Bar {
         });
     });
 
+    describe('#getAssignableConcreteTypes', () => {
+
+        it('should get assignable concrete types for an abstract base type', () => {
+            modelManager.addCTOModel(concertoModel);
+            const result = modelManager.getAssignableConcreteTypes('org.accordproject.test@1.0.0.Person');
+            result.length.should.equal(3);
+            result.map(d => d.getName()).should.include.members(['Employee', 'Manager', 'Customer']);
+        });
+
+        it('should get assignable concrete types for a concrete base type', () => {
+            modelManager.addCTOModel(concertoModel);
+            const result = modelManager.getAssignableConcreteTypes('org.accordproject.test@1.0.0.Employee');
+            result.length.should.equal(1);
+            result[0].getName().should.equal('Employee');
+        });
+
+        it('should return empty array for an absent base type', () => {
+            modelManager.addCTOModel(concertoModel);
+            const result = modelManager.getAssignableConcreteTypes('org.accordproject.test@1.0.0.DoesNotExist');
+            result.length.should.equal(0);
+        });
+
+    });
+
+    describe('#isAssignableTo', () => {
+
+        it('should return true when fqn is a subclass of the base type', () => {
+            modelManager.addCTOModel(concertoModel);
+            const result = modelManager.isAssignableTo('org.accordproject.test@1.0.0.Employee', 'org.accordproject.test@1.0.0.Person');
+            result.should.be.true;
+        });
+
+        it('should return true when fqn is the same concrete base type', () => {
+            modelManager.addCTOModel(concertoModel);
+            const result = modelManager.isAssignableTo('org.accordproject.test@1.0.0.Employee', 'org.accordproject.test@1.0.0.Employee');
+            result.should.be.true;
+        });
+
+        it('should return false when fqn is abstract', () => {
+            modelManager.addCTOModel(concertoModel);
+            const result = modelManager.isAssignableTo('org.accordproject.test@1.0.0.Person', 'org.accordproject.test@1.0.0.Person');
+            result.should.be.false;
+        });
+
+        it('should return false for unrelated types', () => {
+            modelManager.addCTOModel(concertoModel);
+            const result = modelManager.isAssignableTo('org.accordproject.test@1.0.0.Product', 'org.accordproject.test@1.0.0.Person');
+            result.should.be.false;
+        });
+
+        it('should return false for an absent candidate type', () => {
+            modelManager.addCTOModel(concertoModel);
+            const result = modelManager.isAssignableTo('org.accordproject.test@1.0.0.DoesNotExist', 'org.accordproject.test@1.0.0.Person');
+            result.should.be.false;
+        });
+    });
+
     describe('#filter', () => {
         it('should return true for a valid ModelManager', () => {
             modelManager.addModelFiles([composerModel, modelBase, farm2fork, concertoModel]);


### PR DESCRIPTION


<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #1281
<!--- Provide an overall summary of the pull request -->
This PR adds two new pure helper methods to the BaseModelManager API to simplify checking class-hierarchy assignability for downstream projects.

### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
- Added `getAssignableConcreteTypes(baseFqn)` to `BaseModelManager` to fetch all concrete class declarations assignable to a given base type.
- Added `isAssignableTo(fqn, baseFqn)` to `BaseModelManager` to check if a candidate type is assignable to a base type.
- Added comprehensive unit tests for both helpers covering edge cases.

### Flags
<!--- Provide context or concerns a reviewer should be aware of -->
- None

### Screenshots or Video
<!--- Provide an easily accessible demonstration of the changes, if applicable -->
N/A

### Related Issues
- Issue #1281

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [x] Merging to `main` from `fork:branchname`
