### PR TITLE
test(concerto-core): mock failed GitHub model request

### DIFF
--- a/packages/concerto-core/test/modelmanager.js
+++ b/packages/concerto-core/test/modelmanager.js
@@ -714,6 +714,11 @@ concept Bar {
 
         it('should fail using bad URL and default model file loader', () => {
 
+            sandbox.stub(global, 'fetch').resolves({
+                ok: false,
+                status: 404
+            });
+
             // disable validation, we are using an external model
             modelManager.addCTOModel(`namespace org.acme@1.0.0
 import org.external@1.0.0.Foo from github://external.cto
@@ -724,7 +729,7 @@ concept Bar {
             modelManager.getModelFile('org.acme@1.0.0').should.not.be.null;
 
             // import all external models
-            return modelManager.updateExternalModels().should.be.rejectedWith(Error, 'Failed to load model file. Job: github://external.cto Details: Error: HTTP request failed with status: 400');
+            return modelManager.updateExternalModels().should.be.rejectedWith(Error, 'Failed to load model file. Job: github://external.cto Details: Error: HTTP request failed with status: 404');
         });
 
         it('should fail using bad protocol and default model file loader', () => {


### PR DESCRIPTION
## Summary

- Stub the existing `global.fetch` call with the test's Sinon sandbox.
- Return a controlled HTTP 404 response for the invalid GitHub model URL.
- Update the rejection assertion to match the mocked response.

## Why

The test for `github://external.cto` currently makes a live request to `raw.githubusercontent.com`. GitHub changed the malformed URL response from HTTP 400 to HTTP 404, causing the Core suite to fail. Updating only the expected status would leave the test dependent on external service behavior.

This change keeps coverage of the default model loader path while making the test deterministic and safe to run offline.

Fixes #1286.

Related: #1287.

## Validation

- Isolated ModelManager regression test passes.
- `npm run test -w @accordproject/concerto-core` passes: 1,234 passing, 8 pending.
- Core lint, dependency-boundary, license, documentation, and coverage checks pass.

## Author checklist

- [x] Commit includes DCO sign-off.
- [x] Change is limited to the affected test.
- [x] Relevant package test suite passes.
