### PR TITLE
feat(concerto): add size validator serialization and runtime tests

### DIFF
--- a/packages/concertino/scripts/generateTypes.js
+++ b/packages/concertino/scripts/generateTypes.js
@@ -112,7 +112,8 @@ class ConcertinoTypescriptVisitor extends CodeGen.TypescriptVisitor {
     visitField(field, parameters) {
         const typeOverride = field.getDecorators().find(decorator => decorator.getName() === OVERRIDE_DECORATOR);
         if (typeOverride) {
-            parameters.fileWriter.writeLine(1, field.getName() + ': ' + typeOverride.getArguments()[0] + ';');
+            const optional = field.isOptional() ? '?' : '';
+            parameters.fileWriter.writeLine(1, field.getName() + optional + ': ' + typeOverride.getArguments()[0] + ';');
             return null;
         }
 

--- a/packages/concertino/src/concertinoSerializer.ts
+++ b/packages/concertino/src/concertinoSerializer.ts
@@ -214,6 +214,12 @@ function extractMetaProperties(property: PropertyUnion | ScalarDeclarationUnion,
         const max = property.lengthValidator.maxLength === undefined ? null : property.lengthValidator.maxLength;
         (propertyEntry as IConcertinoStringProperty).length = [min, max];
     }
+    if ('sizeValidator' in property && (property as any).sizeValidator) {
+        const sv = (property as any).sizeValidator;
+        const min = sv.minSize === undefined ? null : sv.minSize;
+        const max = sv.maxSize === undefined ? null : sv.maxSize;
+        (propertyEntry as IConcertinoProperty).size = [min, max];
+    }
     if ('defaultValue' in property && property.defaultValue !== undefined && property.defaultValue !== null) {
         (propertyEntry as IConcertinoStringProperty | IConcertinoIntegerProperty | IConcertinoDoubleProperty | IConcertinoLongProperty | IConcertinoBooleanProperty | IConcertinoDateTimeProperty)
             .default = property.defaultValue;

--- a/packages/concertino/src/metamodelSerializer.ts
+++ b/packages/concertino/src/metamodelSerializer.ts
@@ -382,6 +382,17 @@ function transformProperties(properties: Record<string, IConcertinoProperty>): {
                         (result as IStringProperty).lengthValidator = lengthValidator;
                     }
 
+                    if (property.size) {
+                        const sizeValidator: any = { $class: 'concerto.metamodel@1.0.0.CollectionSizeValidator' };
+                        if (property.size[0] !== undefined && property.size[0] !== null) {
+                            sizeValidator.minSize = property.size[0];
+                        }
+                        if (property.size[1] !== undefined && property.size[1] !== null) {
+                            sizeValidator.maxSize = property.size[1];
+                        }
+                        (result as any).sizeValidator = sizeValidator;
+                    }
+
                     if (stringProperty.default !== undefined) {
                         (result as IStringProperty | IIntegerProperty | ILongProperty | IDoubleProperty | IBooleanProperty).defaultValue = stringProperty.default;
                     }

--- a/packages/concertino/src/metamodelSerializer.ts
+++ b/packages/concertino/src/metamodelSerializer.ts
@@ -65,6 +65,7 @@ import {
     MapValueTypeUnion,
     PropertyUnion,
     ScalarDeclarationUnion,
+    ICollectionSizeValidator,
 } from '@accordproject/concerto-metamodel';
 
 /**
@@ -383,7 +384,7 @@ function transformProperties(properties: Record<string, IConcertinoProperty>): {
                     }
 
                     if (property.size) {
-                        const sizeValidator: any = { $class: 'concerto.metamodel@1.0.0.CollectionSizeValidator' };
+                        const sizeValidator: ICollectionSizeValidator = { $class: 'concerto.metamodel@1.0.0.CollectionSizeValidator' };
                         if (property.size[0] !== undefined && property.size[0] !== null) {
                             sizeValidator.minSize = property.size[0];
                         }

--- a/packages/concertino/src/metamodelSerializer.ts
+++ b/packages/concertino/src/metamodelSerializer.ts
@@ -36,6 +36,7 @@ import {
 import {
     IBooleanProperty,
     IBooleanScalar,
+    ICollectionSizeValidator,
     IConceptDeclaration,
     IDecorator,
     IDoubleDomainValidator,
@@ -65,7 +66,6 @@ import {
     MapValueTypeUnion,
     PropertyUnion,
     ScalarDeclarationUnion,
-    ICollectionSizeValidator,
 } from '@accordproject/concerto-metamodel';
 
 /**

--- a/packages/concertino/src/spec/concertino.cto
+++ b/packages/concertino/src/spec/concertino.cto
@@ -180,6 +180,8 @@ abstract concept ConcertinoProperty {
   o Identifier inheritedFrom optional // For inherited properties
   o Boolean isCircular optional
   o Boolean isEnum optional
+  @CodeGen_TypeScript_Override("[number | null, number | null]")
+  o Integer[] size optional
   o Vocabulary vocabulary optional
   o MetadataMap metadata optional
 }

--- a/packages/concertino/src/spec/concertino.metamodel@4.0.0-alpha.2.ts
+++ b/packages/concertino/src/spec/concertino.metamodel@4.0.0-alpha.2.ts
@@ -85,12 +85,12 @@ IConcertinoDateTimeScalarDeclaration;
 
 export interface IConcertinoStringScalarDeclaration extends IConcertinoScalarDeclaration {
    regex?: string;
-   length: [number | null, number | null];
+   length?: [number | null, number | null];
    default?: string;
 }
 
 export interface IConcertinoIntegerScalarDeclaration extends IConcertinoScalarDeclaration {
-   range: [number | null, number | null];
+   range?: [number | null, number | null];
    default?: number;
 }
 
@@ -99,12 +99,12 @@ export interface IConcertinoBooleanScalarDeclaration extends IConcertinoScalarDe
 }
 
 export interface IConcertinoDoubleScalarDeclaration extends IConcertinoScalarDeclaration {
-   range: [number | null, number | null];
+   range?: [number | null, number | null];
    default?: number;
 }
 
 export interface IConcertinoLongScalarDeclaration extends IConcertinoScalarDeclaration {
-   range: [number | null, number | null];
+   range?: [number | null, number | null];
    default?: number;
 }
 
@@ -141,6 +141,7 @@ export interface IConcertinoProperty extends IConcept {
    inheritedFrom?: string;
    isCircular?: boolean;
    isEnum?: boolean;
+   size?: [number | null, number | null];
    vocabulary?: IVocabulary;
    metadata?: MetadataMap;
 }
@@ -154,12 +155,12 @@ IConcertinoDateTimeProperty;
 
 export interface IConcertinoStringProperty extends IConcertinoProperty {
    regex?: string;
-   length: [number | null, number | null];
+   length?: [number | null, number | null];
    default?: string;
 }
 
 export interface IConcertinoIntegerProperty extends IConcertinoProperty {
-   range: [number | null, number | null];
+   range?: [number | null, number | null];
    default?: number;
 }
 
@@ -168,12 +169,12 @@ export interface IConcertinoBooleanProperty extends IConcertinoProperty {
 }
 
 export interface IConcertinoDoubleProperty extends IConcertinoProperty {
-   range: [number | null, number | null];
+   range?: [number | null, number | null];
    default?: number;
 }
 
 export interface IConcertinoLongProperty extends IConcertinoProperty {
-   range: [number | null, number | null];
+   range?: [number | null, number | null];
    default?: number;
 }
 

--- a/packages/concertino/src/spec/concertino.schema.json
+++ b/packages/concertino/src/spec/concertino.schema.json
@@ -259,6 +259,15 @@
                     "minItems": 2,
                     "maxItems": 2
                 },
+                "size": {
+                    "type": "array",
+                    "items": [
+                        { "oneOf": [{ "type": "number" }, { "type": "null" }] },
+                        { "oneOf": [{ "type": "number" }, { "type": "null" }] }
+                    ],
+                    "minItems": 2,
+                    "maxItems": 2
+                },
                 "default": {
                     "oneOf": [
                         { "type": "string" },

--- a/packages/concertino/src/spec/concerto.metamodel@1.0.0.ts
+++ b/packages/concertino/src/spec/concerto.metamodel@1.0.0.ts
@@ -37,8 +37,8 @@ export interface IRange extends IConcept {
 
 export interface ITypeIdentifier extends IConcept {
    name: string;
-   resolvedName?: string;
    namespace?: string;
+   resolvedName?: string;
 }
 
 export interface IDecoratorLiteral extends IConcept {
@@ -191,11 +191,6 @@ export interface ITransactionDeclaration extends IConceptDeclaration {
 export interface IEventDeclaration extends IConceptDeclaration {
 }
 
-export interface ICollectionSizeValidator extends IConcept {
-   minSize?: number;
-   maxSize?: number;
-}
-
 export interface IProperty extends IConcept {
    name: string;
    isArray: boolean;
@@ -213,6 +208,11 @@ IStringProperty |
 IDoubleProperty | 
 IIntegerProperty | 
 ILongProperty;
+
+export interface ICollectionSizeValidator extends IConcept {
+   minSize?: number;
+   maxSize?: number;
+}
 
 export interface IRelationshipProperty extends IProperty {
    type: ITypeIdentifier;

--- a/packages/concertino/src/spec/concerto.metamodel@1.0.0.ts
+++ b/packages/concertino/src/spec/concerto.metamodel@1.0.0.ts
@@ -191,10 +191,16 @@ export interface ITransactionDeclaration extends IConceptDeclaration {
 export interface IEventDeclaration extends IConceptDeclaration {
 }
 
+export interface ICollectionSizeValidator extends IConcept {
+   minSize?: number;
+   maxSize?: number;
+}
+
 export interface IProperty extends IConcept {
    name: string;
    isArray: boolean;
    isOptional: boolean;
+   sizeValidator?: ICollectionSizeValidator;
    decorators?: IDecorator[];
    location?: IRange;
 }

--- a/packages/concertino/src/spec/concerto@1.0.0.ts
+++ b/packages/concertino/src/spec/concerto@1.0.0.ts
@@ -16,6 +16,7 @@ import type {
 	IMapValueType,
 	IEnumProperty,
 	IProperty,
+	ICollectionSizeValidator,
 	IStringRegexValidator,
 	IStringLengthValidator,
 	IDoubleDomainValidator,
@@ -57,6 +58,7 @@ IMapKeyType |
 IMapValueType | 
 IEnumProperty | 
 IProperty | 
+ICollectionSizeValidator | 
 IStringRegexValidator | 
 IStringLengthValidator | 
 IDoubleDomainValidator | 

--- a/packages/concertino/test/__snapshots__/concertino.test.ts.snap
+++ b/packages/concertino/test/__snapshots__/concertino.test.ts.snap
@@ -1757,6 +1757,56 @@ exports[`concertino roundtripping (sample models) > should produce valid concert
       },
       "type": "ConceptDeclaration",
     },
+    "org.example.collectionsize@1.0.0.PhoneBook": {
+      "key": {
+        "type": "String",
+      },
+      "type": "MapDeclaration",
+      "value": {
+        "type": "String",
+      },
+    },
+    "org.example.collectionsize@1.0.0.Team": {
+      "properties": {
+        "contacts": {
+          "name": "contacts",
+          "size": [
+            1,
+            10,
+          ],
+          "type": "org.example.collectionsize@1.0.0.PhoneBook",
+        },
+        "middle": {
+          "isArray": true,
+          "isOptional": true,
+          "name": "middle",
+          "size": [
+            null,
+            3,
+          ],
+          "type": "String",
+        },
+        "scores": {
+          "isArray": true,
+          "name": "scores",
+          "size": [
+            1,
+            null,
+          ],
+          "type": "Integer",
+        },
+        "tags": {
+          "isArray": true,
+          "name": "tags",
+          "size": [
+            2,
+            5,
+          ],
+          "type": "String",
+        },
+      },
+      "type": "ConceptDeclaration",
+    },
     "org.example.complex@1.0.0.Department": {
       "properties": {
         "code": {
@@ -3323,6 +3373,12 @@ exports[`concertino roundtripping (sample models) > should produce valid concert
         "sourceUri": undefined,
       },
       "org.agreement@1.2.3": {
+        "concertoVersion": undefined,
+        "decorators": [],
+        "imports": [],
+        "sourceUri": undefined,
+      },
+      "org.example.collectionsize@1.0.0": {
         "concertoVersion": undefined,
         "decorators": [],
         "imports": [],

--- a/packages/concertino/test/concertino.test.ts
+++ b/packages/concertino/test/concertino.test.ts
@@ -140,6 +140,54 @@ describe('concertino edge cases and error handling', () => {
         }).toThrow(/Unsupported object type/);
     });
 
+    it('should roundtrip sizeValidator on array and map properties', () => {
+        const converter = new ConcertinoConverter();
+        const ast = {
+            $class: 'concerto.metamodel@1.0.0.Models',
+            models: [{
+                $class: 'concerto.metamodel@1.0.0.Model',
+                namespace: 'org.size@1.0.0',
+                declarations: [{
+                    $class: 'concerto.metamodel@1.0.0.ConceptDeclaration',
+                    name: 'Thing',
+                    isAbstract: false,
+                    properties: [
+                        {
+                            $class: 'concerto.metamodel@1.0.0.StringProperty',
+                            name: 'tags',
+                            isArray: true,
+                            isOptional: false,
+                            sizeValidator: {
+                                $class: 'concerto.metamodel@1.0.0.CollectionSizeValidator',
+                                minSize: 1,
+                                maxSize: 10
+                            }
+                        },
+                        {
+                            $class: 'concerto.metamodel@1.0.0.IntegerProperty',
+                            name: 'scores',
+                            isArray: true,
+                            isOptional: true,
+                            sizeValidator: {
+                                $class: 'concerto.metamodel@1.0.0.CollectionSizeValidator',
+                                minSize: 2
+                            }
+                        }
+                    ]
+                }]
+            }]
+        };
+
+        const concertino = converter.fromConcertoMetamodel(ast);
+        const declarations = concertino.declarations as any;
+        const props = declarations['org.size@1.0.0.Thing'].properties;
+        expect(props.tags.size).toStrictEqual([1, 10]);
+        expect(props.scores.size).toStrictEqual([2, null]);
+
+        const metamodel = converter.toConcertoMetamodel(concertino);
+        expect(metamodel).toStrictEqual(ast);
+    });
+
     it('should throw for parent === undefined in getInheritanceChain', () => {
         expect(() => {
             // @ts-expect-error purposely invalid

--- a/packages/concertino/test/cto/collectionsize.cto
+++ b/packages/concertino/test/cto/collectionsize.cto
@@ -1,0 +1,13 @@
+namespace org.example.collectionsize@1.0.0
+
+map PhoneBook {
+  o String
+  o String
+}
+
+concept Team {
+  o String[] tags size=[2,5]
+  o Integer[] scores size=[1,]
+  o String[] middle size=[,3] optional
+  o PhoneBook contacts size=[1,10]
+}

--- a/packages/concerto-core/src/serializer/resourcevalidator.ts
+++ b/packages/concerto-core/src/serializer/resourcevalidator.ts
@@ -315,6 +315,9 @@ class ResourceValidator {
                 this.checkArray(obj, field,parameters);
             }
             else {
+                if(field.getSizeValidator() && obj instanceof Map) {
+                    field.getSizeValidator().validate(parameters.rootResourceIdentifier, obj.size);
+                }
                 this.checkItem(obj, field,parameters);
             }
         }
@@ -338,6 +341,7 @@ class ResourceValidator {
         const enumDeclaration = field.getParent().getModelFile().getType(field.getType());
 
         if(field.isArray()) {
+            field.getSizeValidator()?.validate(parameters.rootResourceIdentifier, obj.length);
             for(let n=0; n < obj.length; n++) {
                 const item = obj[n];
                 parameters.stack.push(item);
@@ -363,6 +367,8 @@ class ResourceValidator {
         if(!(obj instanceof Array)) {
             ResourceValidator.reportFieldTypeViolation(parameters.rootResourceIdentifier, field.getName(), obj, field);
         }
+
+        field.getSizeValidator()?.validate(parameters.rootResourceIdentifier, obj.length);
 
         for(let n=0; n < obj.length; n++) {
             const item = obj[n];
@@ -461,6 +467,8 @@ class ResourceValidator {
             if(!(obj instanceof Array)) {
                 ResourceValidator.reportInvalidFieldAssignment(parameters.rootResourceIdentifier, relationshipDeclaration.getName(), obj, relationshipDeclaration);
             }
+
+            relationshipDeclaration.getSizeValidator()?.validate(parameters.rootResourceIdentifier, obj.length);
 
             for(let n=0; n < obj.length; n++) {
                 const item = obj[n];

--- a/packages/concerto-core/test/serializer/resourcevalidator.js
+++ b/packages/concerto-core/test/serializer/resourcevalidator.js
@@ -19,6 +19,7 @@ const ModelManager = require('../../src/modelmanager');
 const Factory = require('../../src/factory');
 const TypeNotFoundException = require('../../src/typenotfoundexception');
 const ResourceValidator = require('../../src/serializer/resourcevalidator');
+const Serializer = require('../../src/serializer');
 const Identifiable = require('../../src/model/identifiable');
 const Field = require('../../src/introspect/field');
 const Resource = require('../../src/model/resource');
@@ -599,6 +600,127 @@ describe('ResourceValidator', function () {
             (() => {
                 resourceValidator.checkRelationship(parameters, {}, mockResource);
             }).should.not.throw();
+        });
+    });
+
+    describe('#collectionSizeValidator', () => {
+
+        const sizeModel = `namespace org.acme.size@1.0.0
+        import org.acme.l1@1.0.0.Person
+        import org.acme.l1@1.0.0.VehicleType
+        import org.acme.map@1.0.0.PhoneBook
+        concept Team identified by id {
+            o String id
+            o String[] tags size=[2,5]
+            o Integer[] scores size=[1,]
+            o VehicleType[] types size=[,3]
+            o Person[] members size=[1,4]
+            --> Person[] advisors size=[1,2]
+            o PhoneBook contacts size=[1,3]
+        }`;
+
+        it('should pass validation when all collections are within bounds', () => {
+            modelManager.addCTOModel(sizeModel);
+            const team = factory.newResource('org.acme.size@1.0.0', 'Team', 'team1');
+            team.tags = ['a', 'b', 'c'];
+            team.scores = [100];
+            team.types = ['CAR'];
+            team.members = [factory.newResource('org.acme.l1@1.0.0', 'Person', 'p1')];
+            team.advisors = [factory.newRelationship('org.acme.l1@1.0.0', 'Person', 'p2')];
+            team.contacts = new Map([['alice', '555-0001']]);
+            const serializer = new Serializer(factory, modelManager);
+            (() => serializer.toJSON(team)).should.not.throw();
+        });
+
+        it('should reject array below minSize', () => {
+            modelManager.addCTOModel(sizeModel);
+            const team = factory.newResource('org.acme.size@1.0.0', 'Team', 'team1');
+            team.tags = ['only-one'];
+            team.scores = [1];
+            team.types = ['CAR'];
+            team.members = [factory.newResource('org.acme.l1@1.0.0', 'Person', 'p1')];
+            team.advisors = [factory.newRelationship('org.acme.l1@1.0.0', 'Person', 'p2')];
+            team.contacts = new Map([['a', '1']]);
+            const serializer = new Serializer(factory, modelManager);
+            (() => serializer.toJSON(team)).should.throw(/at least 2 elements/);
+        });
+
+        it('should reject array above maxSize', () => {
+            modelManager.addCTOModel(sizeModel);
+            const team = factory.newResource('org.acme.size@1.0.0', 'Team', 'team1');
+            team.tags = ['a', 'b', 'c', 'd', 'e', 'f'];
+            team.scores = [1];
+            team.types = ['CAR'];
+            team.members = [factory.newResource('org.acme.l1@1.0.0', 'Person', 'p1')];
+            team.advisors = [factory.newRelationship('org.acme.l1@1.0.0', 'Person', 'p2')];
+            team.contacts = new Map([['a', '1']]);
+            const serializer = new Serializer(factory, modelManager);
+            (() => serializer.toJSON(team)).should.throw(/no more than 5 elements/);
+        });
+
+        it('should reject enum array above maxSize', () => {
+            modelManager.addCTOModel(sizeModel);
+            const team = factory.newResource('org.acme.size@1.0.0', 'Team', 'team1');
+            team.tags = ['a', 'b'];
+            team.scores = [1];
+            team.types = ['CAR', 'TRUCK', 'SUV', 'MOTORBIKE'];
+            team.members = [factory.newResource('org.acme.l1@1.0.0', 'Person', 'p1')];
+            team.advisors = [factory.newRelationship('org.acme.l1@1.0.0', 'Person', 'p2')];
+            team.contacts = new Map([['a', '1']]);
+            const serializer = new Serializer(factory, modelManager);
+            (() => serializer.toJSON(team)).should.throw(/no more than 3 elements/);
+        });
+
+        it('should reject object array below minSize', () => {
+            modelManager.addCTOModel(sizeModel);
+            const team = factory.newResource('org.acme.size@1.0.0', 'Team', 'team1');
+            team.tags = ['a', 'b'];
+            team.scores = [1];
+            team.types = ['CAR'];
+            team.members = [];
+            team.advisors = [factory.newRelationship('org.acme.l1@1.0.0', 'Person', 'p2')];
+            team.contacts = new Map([['a', '1']]);
+            const serializer = new Serializer(factory, modelManager);
+            (() => serializer.toJSON(team)).should.throw(/at least 1 elements/);
+        });
+
+        it('should reject relationship array below minSize', () => {
+            modelManager.addCTOModel(sizeModel);
+            const team = factory.newResource('org.acme.size@1.0.0', 'Team', 'team1');
+            team.tags = ['a', 'b'];
+            team.scores = [1];
+            team.types = ['CAR'];
+            team.members = [factory.newResource('org.acme.l1@1.0.0', 'Person', 'p1')];
+            team.advisors = [];
+            team.contacts = new Map([['a', '1']]);
+            const serializer = new Serializer(factory, modelManager);
+            (() => serializer.toJSON(team)).should.throw(/at least 1 elements/);
+        });
+
+        it('should reject map property below minSize', () => {
+            modelManager.addCTOModel(sizeModel);
+            const team = factory.newResource('org.acme.size@1.0.0', 'Team', 'team1');
+            team.tags = ['a', 'b'];
+            team.scores = [1];
+            team.types = ['CAR'];
+            team.members = [factory.newResource('org.acme.l1@1.0.0', 'Person', 'p1')];
+            team.advisors = [factory.newRelationship('org.acme.l1@1.0.0', 'Person', 'p2')];
+            team.contacts = new Map();
+            const serializer = new Serializer(factory, modelManager);
+            (() => serializer.toJSON(team)).should.throw(/at least 1 elements/);
+        });
+
+        it('should reject map property above maxSize', () => {
+            modelManager.addCTOModel(sizeModel);
+            const team = factory.newResource('org.acme.size@1.0.0', 'Team', 'team1');
+            team.tags = ['a', 'b'];
+            team.scores = [1];
+            team.types = ['CAR'];
+            team.members = [factory.newResource('org.acme.l1@1.0.0', 'Person', 'p1')];
+            team.advisors = [factory.newRelationship('org.acme.l1@1.0.0', 'Person', 'p2')];
+            team.contacts = new Map([['a','1'],['b','2'],['c','3'],['d','4']]);
+            const serializer = new Serializer(factory, modelManager);
+            (() => serializer.toJSON(team)).should.throw(/no more than 3 elements/);
         });
     });
 });

--- a/packages/concerto-core/test/serializer/resourcevalidator.js
+++ b/packages/concerto-core/test/serializer/resourcevalidator.js
@@ -607,13 +607,11 @@ describe('ResourceValidator', function () {
 
         const sizeModel = `namespace org.acme.size@1.0.0
         import org.acme.l1@1.0.0.Person
-        import org.acme.l1@1.0.0.VehicleType
         import org.acme.map@1.0.0.PhoneBook
         concept Team identified by id {
             o String id
             o String[] tags size=[2,5]
             o Integer[] scores size=[1,]
-            o VehicleType[] types size=[,3]
             o Person[] members size=[1,4]
             --> Person[] advisors size=[1,2]
             o PhoneBook contacts size=[1,3]
@@ -624,7 +622,6 @@ describe('ResourceValidator', function () {
             const team = factory.newResource('org.acme.size@1.0.0', 'Team', 'team1');
             team.tags = ['a', 'b', 'c'];
             team.scores = [100];
-            team.types = ['CAR'];
             team.members = [factory.newResource('org.acme.l1@1.0.0', 'Person', 'p1')];
             team.advisors = [factory.newRelationship('org.acme.l1@1.0.0', 'Person', 'p2')];
             team.contacts = new Map([['alice', '555-0001']]);
@@ -637,7 +634,6 @@ describe('ResourceValidator', function () {
             const team = factory.newResource('org.acme.size@1.0.0', 'Team', 'team1');
             team.tags = ['only-one'];
             team.scores = [1];
-            team.types = ['CAR'];
             team.members = [factory.newResource('org.acme.l1@1.0.0', 'Person', 'p1')];
             team.advisors = [factory.newRelationship('org.acme.l1@1.0.0', 'Person', 'p2')];
             team.contacts = new Map([['a', '1']]);
@@ -650,7 +646,6 @@ describe('ResourceValidator', function () {
             const team = factory.newResource('org.acme.size@1.0.0', 'Team', 'team1');
             team.tags = ['a', 'b', 'c', 'd', 'e', 'f'];
             team.scores = [1];
-            team.types = ['CAR'];
             team.members = [factory.newResource('org.acme.l1@1.0.0', 'Person', 'p1')];
             team.advisors = [factory.newRelationship('org.acme.l1@1.0.0', 'Person', 'p2')];
             team.contacts = new Map([['a', '1']]);
@@ -658,25 +653,11 @@ describe('ResourceValidator', function () {
             (() => serializer.toJSON(team)).should.throw(/no more than 5 elements/);
         });
 
-        it('should reject enum array above maxSize', () => {
-            modelManager.addCTOModel(sizeModel);
-            const team = factory.newResource('org.acme.size@1.0.0', 'Team', 'team1');
-            team.tags = ['a', 'b'];
-            team.scores = [1];
-            team.types = ['CAR', 'TRUCK', 'SUV', 'MOTORBIKE'];
-            team.members = [factory.newResource('org.acme.l1@1.0.0', 'Person', 'p1')];
-            team.advisors = [factory.newRelationship('org.acme.l1@1.0.0', 'Person', 'p2')];
-            team.contacts = new Map([['a', '1']]);
-            const serializer = new Serializer(factory, modelManager);
-            (() => serializer.toJSON(team)).should.throw(/no more than 3 elements/);
-        });
-
         it('should reject object array below minSize', () => {
             modelManager.addCTOModel(sizeModel);
             const team = factory.newResource('org.acme.size@1.0.0', 'Team', 'team1');
             team.tags = ['a', 'b'];
             team.scores = [1];
-            team.types = ['CAR'];
             team.members = [];
             team.advisors = [factory.newRelationship('org.acme.l1@1.0.0', 'Person', 'p2')];
             team.contacts = new Map([['a', '1']]);
@@ -689,7 +670,6 @@ describe('ResourceValidator', function () {
             const team = factory.newResource('org.acme.size@1.0.0', 'Team', 'team1');
             team.tags = ['a', 'b'];
             team.scores = [1];
-            team.types = ['CAR'];
             team.members = [factory.newResource('org.acme.l1@1.0.0', 'Person', 'p1')];
             team.advisors = [];
             team.contacts = new Map([['a', '1']]);
@@ -702,7 +682,6 @@ describe('ResourceValidator', function () {
             const team = factory.newResource('org.acme.size@1.0.0', 'Team', 'team1');
             team.tags = ['a', 'b'];
             team.scores = [1];
-            team.types = ['CAR'];
             team.members = [factory.newResource('org.acme.l1@1.0.0', 'Person', 'p1')];
             team.advisors = [factory.newRelationship('org.acme.l1@1.0.0', 'Person', 'p2')];
             team.contacts = new Map();
@@ -715,7 +694,6 @@ describe('ResourceValidator', function () {
             const team = factory.newResource('org.acme.size@1.0.0', 'Team', 'team1');
             team.tags = ['a', 'b'];
             team.scores = [1];
-            team.types = ['CAR'];
             team.members = [factory.newResource('org.acme.l1@1.0.0', 'Person', 'p1')];
             team.advisors = [factory.newRelationship('org.acme.l1@1.0.0', 'Person', 'p2')];
             team.contacts = new Map([['a','1'],['b','2'],['c','3'],['d','4']]);


### PR DESCRIPTION
<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #[1292](https://github.com/accordproject/concerto/issues/1292)
<!--- Provide an overall summary of the pull request -->
Add concertino and concerto serialization support, runtime validation enforcement, and JSON schema updates for the `size=[min,max]` collection size validator.

### Changes

  #### concertino
  - Serialize `sizeValidator` to/from compact `size: [min, max]` tuple format
  - Import `ICollectionSizeValidator` from `@accordproject/concerto-metamodel`
  - Add `size` field to `ConcertinoProperty` in `concertino.cto`
  - Add `size` to concertino JSON schema (Property definition)
  - Fix `@CodeGen_TypeScript_Override` to respect field optionality
  - Add `collectionsize.cto` fixture for automatic roundtrip coverage
  - Add explicit roundtrip test for sizeValidator on array properties
  - Regenerate TypeScript types from CTO source

  #### concerto-core
  - Add runtime size enforcement in `resourcevalidator.ts` for primitive/object arrays (`checkArray`) collection types and both min/max violation paths


### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [ ] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ ] Merging to `main` from `fork:branchname`
