### PR TITLE
feat(concerto-analysis): add size validator compatibility comparers and tests

### DIFF
--- a/packages/concerto-analysis/src/compare-config.ts
+++ b/packages/concerto-analysis/src/compare-config.ts
@@ -63,6 +63,7 @@ export const defaultCompareConfig: CompareConfig = {
         'property-validator-added': CompareResult.MAJOR,
         'property-validator-removed': CompareResult.PATCH,
         'property-validator-changed': CompareResult.MAJOR,
+        'property-validator-loosened': CompareResult.PATCH,
         'map-key-type-changed': CompareResult.MAJOR,
         'map-value-type-changed': CompareResult.MAJOR,
         'scalar-extends-changed': CompareResult.MAJOR,

--- a/packages/concerto-analysis/src/comparers/properties.ts
+++ b/packages/concerto-analysis/src/comparers/properties.ts
@@ -292,4 +292,42 @@ const propertyDefaultChanged: ComparerFactory = (context) => ({
     }
 });
 
-export const propertyComparerFactories = [propertyAdded, propertyRemoved, propertyTypeChanged, propertyValidatorChanged, propertyOptionalChanged, propertyDefaultChanged];
+const propertySizeValidatorChanged: ComparerFactory = (context) => ({
+    compareProperty: (a, b) => {
+        if (!a || !b || a instanceof EnumValueDeclaration || b instanceof EnumValueDeclaration) {
+            return;
+        }
+        const aValidator = a.getSizeValidator();
+        const bValidator = b.getSizeValidator();
+        const classDeclarationType = getDeclarationType(a.getParent());
+        if (!aValidator && !bValidator) {
+            return;
+        } else if (!aValidator && bValidator) {
+            context.report({
+                key: 'property-validator-added',
+                message: `A collection size validator was added to the ${getPropertyType(a)} "${a.getName()}" in the ${classDeclarationType} "${a.getParent().getName()}"`,
+                element: a
+            });
+        } else if (aValidator && !bValidator) {
+            context.report({
+                key: 'property-validator-removed',
+                message: `A collection size validator was removed from the ${getPropertyType(a)} "${a.getName()}" in the ${classDeclarationType} "${a.getParent().getName()}"`,
+                element: a
+            });
+        } else if (!aValidator.compatibleWith(bValidator)) {
+            context.report({
+                key: 'property-validator-changed',
+                message: `A collection size validator for the ${getPropertyType(a)} "${a.getName()}" in the ${classDeclarationType} "${a.getParent().getName()}" was changed and is no longer compatible`,
+                element: a
+            });
+        } else if (aValidator.getMinSize() !== bValidator.getMinSize() || aValidator.getMaxSize() !== bValidator.getMaxSize()) {
+            context.report({
+                key: 'property-validator-loosened',
+                message: `A collection size validator for the ${getPropertyType(a)} "${a.getName()}" in the ${classDeclarationType} "${a.getParent().getName()}" was loosened`,
+                element: a
+            });
+        }
+    }
+});
+
+export const propertyComparerFactories = [propertyAdded, propertyRemoved, propertyTypeChanged, propertyValidatorChanged, propertySizeValidatorChanged, propertyOptionalChanged, propertyDefaultChanged];

--- a/packages/concerto-analysis/test/fixtures/size-validator-added.cto
+++ b/packages/concerto-analysis/test/fixtures/size-validator-added.cto
@@ -1,0 +1,5 @@
+namespace org.accordproject.concerto.test@1.2.3
+
+concept Thing {
+    o String[] values size=[1,4]
+}

--- a/packages/concerto-analysis/test/fixtures/size-validator-changed-loosened.cto
+++ b/packages/concerto-analysis/test/fixtures/size-validator-changed-loosened.cto
@@ -1,0 +1,5 @@
+namespace org.accordproject.concerto.test@1.2.3
+
+concept Thing {
+    o String[] values size=[0,5]
+}

--- a/packages/concerto-analysis/test/fixtures/size-validator-changed-tightened.cto
+++ b/packages/concerto-analysis/test/fixtures/size-validator-changed-tightened.cto
@@ -1,0 +1,5 @@
+namespace org.accordproject.concerto.test@1.2.3
+
+concept Thing {
+    o String[] values size=[2,3]
+}

--- a/packages/concerto-analysis/test/fixtures/size-validators.cto
+++ b/packages/concerto-analysis/test/fixtures/size-validators.cto
@@ -1,0 +1,5 @@
+namespace org.accordproject.concerto.test@1.2.3
+
+concept Thing {
+    o String[] values
+}

--- a/packages/concerto-analysis/test/unit/compare-config.test.ts
+++ b/packages/concerto-analysis/test/unit/compare-config.test.ts
@@ -14,8 +14,8 @@ describe('CompareConfigBuilder', () => {
         const builder = new CompareConfigBuilder();
 
         const actual = builder.default().build();
-        expect(actual.comparerFactories.length).toEqual(14);
-        expect(Object.keys(actual.rules).length).toEqual(29);
+        expect(actual.comparerFactories.length).toEqual(15);
+        expect(Object.keys(actual.rules).length).toEqual(30);
         expect(actual.rules['class-declaration-added']).toEqual(CompareResult.MINOR);
         expect(actual.rules['optional-property-added']).toEqual(CompareResult.PATCH);
         expect(actual.rules['map-value-type-changed']).toEqual(CompareResult.MAJOR);
@@ -35,8 +35,8 @@ describe('CompareConfigBuilder', () => {
 
         const actual = builder.default().extend(toExtend).build();
 
-        expect(actual.comparerFactories.length).toEqual(15);
-        expect(Object.keys(actual.rules).length).toEqual(30);
+        expect(actual.comparerFactories.length).toEqual(16);
+        expect(Object.keys(actual.rules).length).toEqual(31);
         expect(actual.rules['a-new-rule']).toEqual(CompareResult.MAJOR);
     });
 
@@ -45,8 +45,8 @@ describe('CompareConfigBuilder', () => {
 
         const actual = builder.default().addComparerFactory(() => ({})).build();
 
-        expect(actual.comparerFactories.length).toEqual(15);
-        expect(Object.keys(actual.rules).length).toEqual(29);
+        expect(actual.comparerFactories.length).toEqual(16);
+        expect(Object.keys(actual.rules).length).toEqual(30);
     });
 
     it('Should add a new rule', () => {
@@ -54,8 +54,8 @@ describe('CompareConfigBuilder', () => {
 
         const actual = builder.default().addRule('a-new-rule', CompareResult.MAJOR).build();
 
-        expect(actual.comparerFactories.length).toEqual(14);
-        expect(Object.keys(actual.rules).length).toEqual(30);
+        expect(actual.comparerFactories.length).toEqual(15);
+        expect(Object.keys(actual.rules).length).toEqual(31);
         expect(actual.rules['a-new-rule']).toEqual(CompareResult.MAJOR);
     });
 
@@ -64,8 +64,8 @@ describe('CompareConfigBuilder', () => {
 
         const actual = builder.default().removeRule('optional-property-added').build();
 
-        expect(actual.comparerFactories.length).toEqual(14);
-        expect(Object.keys(actual.rules).length).toEqual(28);
+        expect(actual.comparerFactories.length).toEqual(15);
+        expect(Object.keys(actual.rules).length).toEqual(29);
         expect(actual.rules['optional-property-added']).toBeFalsy();
     });
 

--- a/packages/concerto-analysis/test/unit/compare.test.ts
+++ b/packages/concerto-analysis/test/unit/compare.test.ts
@@ -803,3 +803,58 @@ test('should detect a default value being removed from a property', async () => 
     ]));
     expect(results.result).toBe(CompareResult.PATCH);
 });
+
+test('should detect a size validator being added to a property', async () => {
+    const [a, b] = await getModelFiles('size-validators.cto', 'size-validator-added.cto');
+    const results = new Compare().compare(a, b);
+    expect(results.findings).toEqual(expect.arrayContaining([
+        expect.objectContaining({
+            key: 'property-validator-added',
+            message: 'A collection size validator was added to the field "values" in the concept "Thing"'
+        })
+    ]));
+    expect(results.result).toBe(CompareResult.MAJOR);
+});
+
+test('should detect a size validator being removed from a property', async () => {
+    const [a, b] = await getModelFiles('size-validator-added.cto', 'size-validators.cto');
+    const results = new Compare().compare(a, b);
+    expect(results.findings).toEqual(expect.arrayContaining([
+        expect.objectContaining({
+            key: 'property-validator-removed',
+            message: 'A collection size validator was removed from the field "values" in the concept "Thing"'
+        })
+    ]));
+    expect(results.result).toBe(CompareResult.PATCH);
+});
+
+test('should detect a size validator being tightened on a property (incompatible)', async () => {
+    const [a, b] = await getModelFiles('size-validator-added.cto', 'size-validator-changed-tightened.cto');
+    const results = new Compare().compare(a, b);
+    expect(results.findings).toEqual(expect.arrayContaining([
+        expect.objectContaining({
+            key: 'property-validator-changed',
+            message: 'A collection size validator for the field "values" in the concept "Thing" was changed and is no longer compatible'
+        })
+    ]));
+    expect(results.result).toBe(CompareResult.MAJOR);
+});
+
+test('should detect a size validator being loosened on a property', async () => {
+    const [a, b] = await getModelFiles('size-validator-added.cto', 'size-validator-changed-loosened.cto');
+    const results = new Compare().compare(a, b);
+    expect(results.findings).toEqual(expect.arrayContaining([
+        expect.objectContaining({
+            key: 'property-validator-loosened',
+            message: 'A collection size validator for the field "values" in the concept "Thing" was loosened'
+        })
+    ]));
+    expect(results.result).toBe(CompareResult.PATCH);
+});
+
+test('should not detect a size validator change when identical', async () => {
+    const [a, b] = await getModelFiles('size-validator-added.cto', 'size-validator-added.cto');
+    const results = new Compare().compare(a, b);
+    expect(results.findings).toEqual([]);
+    expect(results.result).toBe(CompareResult.NONE);
+});


### PR DESCRIPTION
<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #[1292](https://github.com/accordproject/concerto/issues/1292)
<!--- Provide an overall summary of the pull request -->
Add compatibility analysis for collection size validators, detecting breaking and non-breaking changes when size constraints are added, removed, tightened, or loosened.

### Changes
- Add `propertySizeValidatorChanged` comparer to detect size validator changes on properties
- Add `property-validator-loosened` rule mapped to PATCH
- Gate "loosened" reports to only fire when bounds actually differ (identical validators produce no findings)
- Add CTO fixture files for size validator comparison scenarios
- Add comparison tests

#### Compatibility rules

| Change | Classification |
|--------|---------------|
| Size validator added | MAJOR |
| Size validator removed | PATCH |
| Bounds tightened (incompatible) | MAJOR |
| Bounds loosened (compatible) | PATCH |
| No change (identical) | NONE |


### Author Checklist
- [ ] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [ ] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ ] Merging to `main` from `fork:branchname`
