### PR TITLE
fix(build): bind process in the browser ESM build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,6 +47,12 @@ jobs:
           NODE_OPTIONS: "--max_old_space_size=4096"
         run: npm test
 
+      # The unit suites run against src/ through ts-node, so this is the only
+      # job that exercises what a consumer actually resolves: the emitted ESM,
+      # and specifically the dist/esm graph Node takes.
+      - name: ESM smoke test
+        run: npm run test:esm
+
       - name: Archive npm failure logs
         uses: actions/upload-artifact@v4
         if: failure()

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -156,6 +156,47 @@ why the packages deliberately do **not** widen their `exports` map to re-expose 
 `types/` tree. If a type you need is not reachable from the root, please open an issue
 asking for it to be exported rather than deep-importing the declaration file.
 
+### Mixing `import` and `require` in one Node process
+
+In 4.x a package had no `exports` map and no `module` field, so `import` and `require`
+both resolved to the same CommonJS file: one copy of every class, in one process. From
+5.0.0 they resolve to different files, and Node loads each independently. A process
+that reaches a package both ways therefore holds **two copies** of it, with two sets of
+class identities:
+
+```js
+import { ModelManager, Factory } from '@accordproject/concerto-core';
+const concerto = createRequire(import.meta.url)('@accordproject/concerto-core');
+
+ModelManager === concerto.ModelManager;   // 4.x: true — 5.0.0: false
+```
+
+Most of the API is duck-typed and survives this, but the `instanceof` guards do not.
+The failure is not subtle when it happens:
+
+```js
+const resource = new Factory(modelManager).newResource('org.example@1.0.0', 'Order', 'o1');
+new concerto.Serializer(...).toJSON(resource);
+// Error: "Serializer.toJSON" only accepts "Concept", "Event", "Asset",
+// "Participant" or "Transaction".
+```
+
+This is the standard dual-package hazard, and it is inherent to shipping both module
+systems. It only bites a process that loads a package twice, so:
+
+- **Pick one module system per process for a given package.** In an ESM application,
+  `import` the package; don't also `createRequire` it.
+- **Watch for a CommonJS dependency in an ESM app.** A library that still uses
+  `require('@accordproject/concerto-core')` internally has its own copy. Objects can
+  cross that boundary safely, but `Resource`s and `ClassDeclaration`s created on one
+  side must be handed back to that same side to be serialized or validated. Where a
+  library re-exports concerto types for you (`@accordproject/template-engine` re-exports
+  `ModelManager` for exactly this reason), import them from the library rather than from
+  `@accordproject/concerto-core` directly.
+- **Check for a duplicate before debugging anything stranger.** If an `instanceof` or a
+  `Serializer` guard fails on an object that is obviously the right type, run
+  `npm ls @accordproject/concerto-core` and confirm you aren't loading it twice.
+
 ## Not breaking
 
 Root-package imports are unaffected — this is true for both CommonJS and ESM, and for
@@ -236,9 +277,9 @@ To benefit from the tree-shaking this release enables:
 - `@accordproject/concerto-util` declares `"sideEffects": false`, so a compliant
   bundler can drop any export you don't import.
 - `@accordproject/concerto-core` declares `"sideEffects": ["./dist/dayjs-setup.js",
-  "./dist/esm/dayjs-setup.mjs"]` — everything else is safe to drop, but those two
-  modules run global setup code (`dayjs` plugin registration) as a side effect and are
-  always kept.
+  "./dist/esm/dayjs-setup.mjs", "./dist/esm-browser/dayjs-setup.mjs"]` — everything
+  else is safe to drop, but those modules run global setup code (`dayjs` plugin
+  registration) as a side effect and are always kept.
 
 The ESM build ships one output module per source module (with shared code hoisted into
 chunks), mirroring the CJS build, so your bundler can drop whole modules you never
@@ -278,6 +319,7 @@ Every package's `exports` map has the same shape (shown here for `concerto-core`
 "exports": {
   ".": {
     "types": "./dist/index.d.ts",
+    "browser": "./dist/esm-browser/index.mjs",
     "import": "./dist/esm/index.mjs",
     "require": "./dist/index.js"
   },
@@ -285,6 +327,20 @@ Every package's `exports` map has the same shape (shown here for `concerto-core`
   "./dist/*": "./dist/*"
 }
 ```
+
+Two ESM graphs are published, built from the same entry points and exposing the same
+named exports. They differ only in how Node builtins are handled:
+
+| Graph | Selected by | Node builtins |
+|---|---|---|
+| `dist/esm` | the `import` condition — Node, and node-target bundlers | real `fs`/`path`, imported normally |
+| `dist/esm-browser` | the `browser` condition — webpack, Vite, Rollup and friends targeting the web | stubbed to empty modules, as the UMD build does via `resolve.fallback` |
+
+The split matters for the handful of APIs that touch the file system —
+`FileWriter`, `ModelWriter.writeModelsToFileSystem` and `ModelLoader`. In the browser
+graph those are inert by construction (they always were: the UMD bundle stubs `fs`
+too); under Node they behave exactly as they do in CommonJS. Nothing in your code
+selects between the graphs — your runtime or bundler does.
 
 The `"./dist/*"` subpath is what still permits deep imports at all (it is not removed
 in this release) — it is the compiled *shape* of those modules, described above, that

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "coverage": "node ./scripts/coverage.js \"packages/concerto-*\" && nyc report -t coverage --cwd . --report-dir coverage --reporter=lcov && cat ./coverage/lcov.info",
     "pretest": "npm run licchk",
     "test": "npm run test --workspaces --if-present",
+    "test:esm": "node ./scripts/smoke-esm.mjs",
     "licchk": "license-check-and-add",
     "build": "npm run build:ordered",
     "build:ordered": "npm run build:level0 && npm run build:level1 && npm run build:level2",
@@ -98,7 +99,7 @@
     ],
     "insert_license": false,
     "license_formats": {
-      "js|njk|pegjs|cto|acl|qry": {
+      "js|mjs|njk|pegjs|cto|acl|qry": {
         "prepend": "/*",
         "append": " */",
         "eachLine": {

--- a/scripts/browser-process-shim.js
+++ b/scripts/browser-process-shim.js
@@ -1,0 +1,59 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Injected into the browser ESM build (see scripts/build-esm.js) to bind the
+ * free `process` identifier the sources and their dependencies use —
+ * `process.env.TZ` in the serializer, `process.emitWarning` in warning.ts,
+ * `process.env.NODE_ENV` inside bundled deps.
+ *
+ * Leaving it free pushes the problem onto every downstream browser bundler.
+ * webpack consumers in particular inject `process: 'process/browser'` through
+ * ProvidePlugin, and that extensionless request is rejected as not fully
+ * specified when the module it lands in is a .mjs file:
+ *
+ *     Module not found: Can't resolve 'process/browser'
+ *     BREAKING CHANGE: ... resolved as fully specified
+ *
+ * The shim defers to a real `globalThis.process` whenever the page has one, so
+ * a consumer's own polyfill still wins; the fallback only covers what these
+ * packages actually read.
+ */
+
+const globals = typeof globalThis !== 'undefined' ? globalThis : {};
+
+const fallback = {
+    env: {},
+    platform: 'browser',
+    /**
+     * Stand-in for Node's process.emitWarning.
+     *
+     * @param {string} message - the warning text
+     * @param {string} [type] - the warning type
+     */
+    emitWarning(message, type) {
+        // eslint-disable-next-line no-console
+        console.warn(type ? `${type}: ${message}` : message);
+    },
+    /**
+     * Stand-in for Node's process.cwd.
+     *
+     * @return {string} the notional working directory
+     */
+    cwd() {
+        return '/';
+    },
+};
+
+export const process = globals.process || fallback;

--- a/scripts/build-esm.js
+++ b/scripts/build-esm.js
@@ -138,7 +138,17 @@ function buildOptionsFor(target) {
         // `import ... from "module"`, which would break downstream bundlers.
         ...(isNode
             ? { banner: { js: 'import { createRequire as __createRequire } from "module";\nconst require = __createRequire(import.meta.url);' } }
-            : { plugins: [stubNodeBuiltinsPlugin] }),
+            : {
+                plugins: [stubNodeBuiltinsPlugin],
+                // The sources and their dependencies read `process.env` and
+                // `process.emitWarning`. Left free, that identifier is every
+                // downstream browser bundler's problem — and a webpack
+                // consumer's ProvidePlugin answers it with an extensionless
+                // `process/browser` request, which webpack rejects as not
+                // fully specified once the importing module is a .mjs file.
+                // Binding it here keeps the browser build self-contained.
+                inject: [path.join(__dirname, 'browser-process-shim.js')],
+            }),
     };
 }
 

--- a/scripts/smoke-esm.mjs
+++ b/scripts/smoke-esm.mjs
@@ -1,0 +1,186 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Smoke test for the published ESM entry points, run under Node.
+ *
+ * The unit suites all execute against src/ through ts-node, so nothing else in
+ * the repo exercises what a consumer actually resolves: `import` under Node
+ * lands on dist/esm, a different artifact from both the CJS dist/ tree the
+ * tests see and the dist/esm-browser graph a bundler takes through the
+ * `browser` condition.
+ *
+ * Run with `npm run test:esm`, after `npm run build`.
+ */
+
+import assert from 'assert';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { createRequire } from 'module';
+
+import { ModelManager, Factory, Serializer, ModelLoader, ModelUtil } from '@accordproject/concerto-core';
+import { FileWriter, InMemoryWriter, TypedStack, ModelWriter } from '@accordproject/concerto-util';
+import { Parser, Printer } from '@accordproject/concerto-cto';
+import { VocabularyManager } from '@accordproject/concerto-vocabulary';
+
+const require = createRequire(import.meta.url);
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'concerto-esm-smoke-'));
+const packagesDir = path.join(path.dirname(new URL(import.meta.url).pathname), '..', 'packages');
+
+const MODEL = `namespace smoke@1.0.0
+concept Ping identified by id {
+  o String id
+  o DateTime when
+}`;
+
+const checks = [];
+
+/**
+ * Register a named check.
+ *
+ * @param {string} name - what the check covers
+ * @param {Function} fn - the check body; throws to fail
+ */
+function check(name, fn) {
+    checks.push([name, fn]);
+}
+
+check('Node resolves the import condition, not the browser build', async () => {
+    const resolved = import.meta.resolve('@accordproject/concerto-core');
+    assert.ok(
+        resolved.includes('/dist/esm/') && !resolved.includes('/dist/esm-browser/'),
+        `expected Node to select dist/esm, got ${resolved}`
+    );
+});
+
+check('model round-trips through Factory and Serializer', () => {
+    const modelManager = new ModelManager();
+    modelManager.addCTOModel(MODEL, 'smoke.cto');
+    const serializer = new Serializer(new Factory(modelManager), modelManager);
+    const json = { $class: 'smoke@1.0.0.Ping', id: 'e1', when: '2020-01-01T12:00:00.000Z' };
+    const resource = serializer.fromJSON(json);
+    assert.strictEqual(resource.getIdentifier(), 'e1');
+    // A DateTime only parses into a dayjs instance with the utc plugin
+    // registered, which is the one module-level side effect in the tree and so
+    // the thing most at risk from tree shaking.
+    assert.strictEqual(typeof resource.when.utcOffset, 'function');
+    assert.strictEqual(serializer.toJSON(resource).when, json.when);
+    assert.strictEqual(ModelUtil.getNamespace('smoke@1.0.0.Ping'), 'smoke@1.0.0');
+});
+
+check('CTO parses and prints', () => {
+    const ast = Parser.parse(MODEL, 'smoke.cto');
+    assert.ok(Printer.toCTO(ast).includes('concept Ping'));
+});
+
+// Node builtins are stubbed out of the browser graph, so anything that reaches
+// fs or path is exactly what serving that graph to Node silently breaks.
+check('FileWriter writes to disk', () => {
+    const target = path.join(tmpDir, 'writer.txt');
+    const writer = new FileWriter(tmpDir);
+    writer.openFile(target);
+    writer.writeLine(0, 'hello');
+    writer.closeFile();
+    assert.match(fs.readFileSync(target, 'utf8'), /hello/);
+});
+
+check('ModelWriter writes models to the file system', () => {
+    const modelManager = new ModelManager();
+    modelManager.addCTOModel(MODEL, 'smoke.cto');
+    const target = path.join(tmpDir, 'models');
+    fs.mkdirSync(target, { recursive: true });
+    ModelWriter.writeModelsToFileSystem(modelManager.getModelFiles(), target);
+    assert.ok(fs.readdirSync(target).length > 0);
+});
+
+check('ModelLoader loads a model from disk', async () => {
+    const target = path.join(tmpDir, 'loader.cto');
+    fs.writeFileSync(target, MODEL);
+    const modelManager = await ModelLoader.loadModelManager([target]);
+    assert.ok(modelManager.getModelFile('smoke@1.0.0'));
+});
+
+check('in-memory writer and typed stack', () => {
+    const writer = new InMemoryWriter();
+    writer.openFile('a.txt');
+    writer.writeLine(0, 'x');
+    writer.closeFile();
+    assert.ok(writer.getFilesInMemory().has('a.txt'));
+    const stack = new TypedStack('root');
+    assert.strictEqual(stack.pop(), 'root');
+});
+
+check('vocabulary manager constructs', () => {
+    assert.ok(new VocabularyManager());
+});
+
+// The browser graph is shipped to bundlers we do not control. A free `process`
+// there is answered by a webpack consumer's ProvidePlugin with an extensionless
+// `process/browser` request, which webpack rejects as not fully specified from
+// a .mjs origin — a downstream build failure with no signal on this side.
+check('the browser graph leaves no free process identifier', () => {
+    const offenders = [];
+    for (const name of ['concerto-core', 'concerto-util', 'concerto-cto', 'concerto-vocabulary']) {
+        const dir = path.join(packagesDir, name, 'dist', 'esm-browser');
+        if (!fs.existsSync(dir)) {
+            continue;
+        }
+        for (const file of fs.readdirSync(dir).filter(entry => entry.endsWith('.mjs'))) {
+            const source = fs.readFileSync(path.join(dir, file), 'utf8');
+            if (!/\bprocess\s*\./.test(source)) {
+                continue;
+            }
+            // Bound either by the injected shim's own declaration or by an
+            // import of it from the chunk the shim was hoisted into.
+            const bound = /\bvar\b[^;\n]*\bprocess\b/.test(source)
+                || /^\s*process,?\s*$/m.test(source);
+            if (!bound) {
+                offenders.push(`${name}/dist/esm-browser/${file}`);
+            }
+        }
+    }
+    assert.deepStrictEqual(offenders, [], 'browser modules reference an unbound `process`');
+});
+
+check('ESM and CJS entry points expose the same names', async () => {
+    for (const name of [
+        '@accordproject/concerto-core',
+        '@accordproject/concerto-util',
+        '@accordproject/concerto-cto',
+        '@accordproject/concerto-vocabulary',
+    ]) {
+        const esm = Object.keys(await import(name)).filter(key => key !== 'default').sort();
+        const cjs = Object.keys(require(name)).sort();
+        assert.deepStrictEqual(esm, cjs, `${name} export names differ between ESM and CJS`);
+    }
+});
+
+let failures = 0;
+for (const [name, fn] of checks) {
+    try {
+        await fn();
+        console.log(`ok   ${name}`);
+    } catch (err) {
+        failures++;
+        console.error(`FAIL ${name}\n     ${err.message}`);
+    }
+}
+fs.rmSync(tmpDir, { recursive: true, force: true });
+
+if (failures > 0) {
+    console.error(`\n${failures} of ${checks.length} ESM smoke checks failed`);
+    process.exit(1);
+}
+console.log(`\n${checks.length} ESM smoke checks passed`);


### PR DESCRIPTION
# Closes #1304 (partially — proposed fixes for #1306)

Proposed on top of [#1306](https://github.com/accordproject/concerto/pull/1306), from validating that branch against `accordproject/template-engine` and `accordproject/concerto-playground`. Rebased onto `3cb7b87`, so the diff is only what's still additive on top of it.

**Update after `3cb7b87`.** My original first commit fixed the Node-ESM stubbing; `3cb7b87` fixes the same bug independently and is now the base, so that commit is dropped. Re-validating the new base against both downstream repos surfaced a new break, which is what this PR now leads with.

### Changes

- **`fix(build)`: bind `process` in the browser ESM build.** `3cb7b87` routes browser bundlers to `dist/esm-browser` through a new `browser` condition. That graph leaves `process` free — the serializer reads `process.env.TZ`, `warning.ts` reads `process.emitWarning`, bundled deps read `process.env.NODE_ENV`. Inside this repo the three UMD configs answer that with `ProvidePlugin`, and the new `.mjs` `fullySpecified` rule keeps them building. Downstream, neither applies:

  ```
  ERROR in ./node_modules/@accordproject/concerto-util/dist/esm-browser/chunk-GG6UL5GV.mjs
  Module not found: Error: Can't resolve 'process/browser'
  BREAKING CHANGE: ... resolved as fully specified
  ```

  That's `accordproject/template-engine`'s `npm run webpack`, which is part of its `build:dist` and `prepublishOnly` — so publishing it against 5.0.0 fails. Its config aliases `concerto-core` to the UMD bundle but not `concerto-util`, so `concerto-util` resolves through the new condition and webpack's `ProvidePlugin` injects an extensionless `process/browser` request into a `.mjs` module.

  The fix injects a `process` shim into the browser build, so the graph is self-contained and no consumer needs a polyfill or a resolver rule. It defers to a real `globalThis.process` when the page has one, so an existing consumer polyfill still wins; the fallback covers only what these packages read. (Once this lands, the three webpack `.mjs` rules from `3cb7b87` are no longer load-bearing — left in place, since removing them is your call.)

- **`test(esm)`: `scripts/smoke-esm.mjs`, run in CI as `npm run test:esm`.** Every unit suite runs against `src/` through ts-node, so nothing exercises the emitted ESM — which is why both of these regressions were invisible on this side. It imports each package the way a consumer does and asserts the fs-backed APIs touch disk, that ESM and CJS expose the same names, and that the browser graph leaves no unbound `process`. Verified to fail on both bugs and pass on both fixes.

- **`docs(esm)`: MIGRATION.md.** The exports reference still showed the pre-`3cb7b87` single-graph shape; it now shows the `browser` condition and which graph a given runtime selects. Plus a new section on the dual-package hazard (below).

### Flags

- **The dual-package hazard is documented, not fixed.** In 4.x `import` and `require` resolved to the same CommonJS file — one copy per process. From 5.0.0 they resolve to different files, so a process reaching a package both ways holds two sets of class identities and concerto's `instanceof` guards reject objects that are obviously the right type:

  ```
  Error: "Serializer.toJSON" only accepts "Concept", "Event", "Asset", "Participant" or "Transaction".
  ```

  Verified A/B: identical script, 4.2.0 succeeds, this branch throws. Inherent to shipping both module systems rather than something the build can fix, so MIGRATION.md explains how to avoid it — but it's a real 5.0.0 behaviour change that isn't in #1306's description, and worth a maintainer decision.

- **`Buffer` and `global` are still free in `dist/esm-browser`**, and are not addressed here. Neither breaks a build today — `global` sits behind a `typeof` guard, and a bare `buffer` request resolves where `process/browser` doesn't — but `Buffer` (reached via `rfdc`'s `instanceof Buffer`) is a `ReferenceError` waiting for a browser consumer who doesn't polyfill it, where the UMD build always did. Same class of problem as the `process` fix; worth deciding whether the shim should cover them too.

- **`mjs` added to the root `license-check-and-add` format list**, so the new script's header is checked with the same comment style as `.js`.

### Verification

- template-engine: `npm run webpack` back to 0 errors, `npm run build` clean, 109/109 tests
- concerto-playground: `tsc --noEmit` clean, `vite build` clean, 328/328 unit, 104/104 Playwright e2e
- this repo: 1276 / 163 / 151 / 89 / 99 / 18 / 19, `npm run test:esm` 10/10, 3/3 UMD browser e2e, `licchk` clean
- Node ESM: `FileWriter`, `ModelWriter.writeModelsToFileSystem` and `ModelLoader` all reach real `fs`; ESM and CJS export names identical to 4.2.0, member-for-member

`.github/workflows/build.yml` only triggers on PRs targeting `main`, so the unit-test and e2e jobs don't run here by design — the results above are from running them locally on this head. DCO is green.

### Related Issues

- Pull Request accordproject/concerto#1306
- Issue accordproject/concerto#1304

### Author Checklist

- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [x] Extend the documentation, if necessary
- [x] Merging to `main` from `fork:branchname`