### PR TITLE
refactor(types)!: tighten introspect and model types, drop redeclared fields

### DIFF
--- a/packages/concerto-analysis/src/compare.ts
+++ b/packages/concerto-analysis/src/compare.ts
@@ -139,7 +139,9 @@ export class Compare {
 
     private compareModelFiles(comparers: Comparer[], a: ModelFile, b: ModelFile) {
         comparers.forEach(comparer => comparer.compareModelFiles?.(a, b));
-        this.compareClassDeclarations(comparers, a.getAllDeclarations(), b.getAllDeclarations());
+        // every declaration is put through the class declaration comparers; map and
+        // scalar declarations are additionally compared by the calls below
+        this.compareClassDeclarations(comparers, a.getAllDeclarations() as ClassDeclaration[], b.getAllDeclarations() as ClassDeclaration[]);
         this.compareMapDeclarations(comparers, a.getMapDeclarations(), b.getMapDeclarations());
         this.compareScalarDeclarations(comparers, a.getScalarDeclarations(), b.getScalarDeclarations());
     }

--- a/packages/concerto-analysis/src/comparers/properties.ts
+++ b/packages/concerto-analysis/src/comparers/properties.ts
@@ -224,8 +224,8 @@ const propertyValidatorChanged: ComparerFactory = (context) => ({
                 element: a
             });
             return;
-        } else if (!aValidator.compatibleWith(bValidator)) {
-            const aValidatorType = getValidatorType(aValidator);
+        } else if (!aValidator!.compatibleWith(bValidator)) {
+            const aValidatorType = getValidatorType(aValidator!);
             context.report({
                 key: 'property-validator-changed',
                 message: `A ${aValidatorType} validator for the field "${a.getName()}" in the ${classDeclarationType} "${a.getParent().getName()}" was changed and is no longer compatible`,
@@ -314,13 +314,13 @@ const propertySizeValidatorChanged: ComparerFactory = (context) => ({
                 message: `A collection size validator was removed from the ${getPropertyType(a)} "${a.getName()}" in the ${classDeclarationType} "${a.getParent().getName()}"`,
                 element: a
             });
-        } else if (!aValidator.compatibleWith(bValidator)) {
+        } else if (!aValidator!.compatibleWith(bValidator)) {
             context.report({
                 key: 'property-validator-changed',
                 message: `A collection size validator for the ${getPropertyType(a)} "${a.getName()}" in the ${classDeclarationType} "${a.getParent().getName()}" was changed and is no longer compatible`,
                 element: a
             });
-        } else if (aValidator.getMinSize() !== bValidator.getMinSize() || aValidator.getMaxSize() !== bValidator.getMaxSize()) {
+        } else if (aValidator!.getMinSize() !== bValidator!.getMinSize() || aValidator!.getMaxSize() !== bValidator!.getMaxSize()) {
             context.report({
                 key: 'property-validator-loosened',
                 message: `A collection size validator for the ${getPropertyType(a)} "${a.getName()}" in the ${classDeclarationType} "${a.getParent().getName()}" was loosened`,

--- a/packages/concerto-analysis/src/comparers/scalar-declarations.ts
+++ b/packages/concerto-analysis/src/comparers/scalar-declarations.ts
@@ -57,8 +57,8 @@ const scalarValidatorChanged: ComparerFactory = (context) => ({
                 element: a.getName()
             });
             return;
-        } else if (!aValidator.compatibleWith(bValidator)) {
-            const aValidatorType = getValidatorType(aValidator);
+        } else if (!aValidator!.compatibleWith(bValidator)) {
+            const aValidatorType = getValidatorType(aValidator!);
             context.report({
                 key: 'scalar-validator-changed',
                 message: `A ${aValidatorType} validator for the scalar "${a.getName()}" was changed and is no longer compatible`,

--- a/packages/concerto-analysis/test/unit/compare-utils.test.ts
+++ b/packages/concerto-analysis/test/unit/compare-utils.test.ts
@@ -4,6 +4,12 @@ import { getDeclarationType, getPropertyType, getValidatorType } from '../../src
 // This test suite should disappear once we port concerto-core to TypeScript because the error branches will be enforced by the transpiler.
 
 const modelManager = new ModelManager();
+
+// These stubs are deliberately incomplete ASTs - they carry no $class - because
+// the suite exists to reach error branches a well-formed model cannot.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const asAst = (ast: object): any => ast;
+
 const propertyAst = {
     name: 'myProp',
     type: 'Boolean'
@@ -13,12 +19,12 @@ const modelAst = {
     properties: []
 };
 
-const modelFile = new ModelFile(modelManager, modelAst, null, 'test.cto');
+const modelFile = new ModelFile(modelManager, asAst(modelAst), null, 'test.cto');
 
-const classDeclaration = new ClassDeclaration(modelFile, modelAst);
-const property = new Property(classDeclaration, propertyAst);
-const field = new Field(classDeclaration, propertyAst);
-const validator = new Validator(field, {});
+const classDeclaration = new ClassDeclaration(modelFile, asAst(modelAst));
+const property = new Property(classDeclaration, asAst(propertyAst));
+const field = new Field(classDeclaration, asAst(propertyAst));
+const validator = new Validator(field, asAst({}));
 
 test('should throw for unknown class declaration type', () => {
     // Note: The error message format might have slightly changed with TS class toString(), but let's try strict first

--- a/packages/concerto-core/src/astmodelmanager.ts
+++ b/packages/concerto-core/src/astmodelmanager.ts
@@ -13,13 +13,14 @@
  */
 
 import BaseModelManager from './basemodelmanager';
+import type { ModelFileSource, ModelManagerOptions } from './types';
 
 // How to create a modelfile from a cto file
-const astProcessFile = (name, data) => {
+const astProcessFile = (name: string | null, data: unknown): ModelFileSource => {
     return {
         ast: data,
         definitions: null,
-        fileName: name,
+        fileName: name ?? 'UNKNOWN',
     };
 };
 
@@ -42,7 +43,7 @@ class AstModelManager extends BaseModelManager {
      * @constructor
      * @param {object} [options] - Serializer options
      */
-    constructor(options?) {
+    constructor(options?: ModelManagerOptions) {
         super(options, astProcessFile);
     }
 }

--- a/packages/concerto-core/src/basemodelmanager.ts
+++ b/packages/concerto-core/src/basemodelmanager.ts
@@ -13,7 +13,9 @@
  */
 
 import { DefaultFileLoader, FileDownloader, ModelWriter } from '@accordproject/concerto-util';
+import type { WritableModelFile } from '@accordproject/concerto-util';
 import { MetaModelUtil, MetaModelNamespace } from '@accordproject/concerto-metamodel';
+import type { IModel, IModels } from '@accordproject/concerto-metamodel';
 
 import Factory from './factory';
 import Globalize from './globalize';
@@ -26,6 +28,7 @@ import MetamodelException from './metamodelexception';
 import rootModelModule from './rootmodelhelper';
 import decoratorModelModule from './decoratormodelhelper';
 import type { ModelFileSource, ModelManagerOptions } from './types';
+import type { AstNode } from './introspect/decorated';
 type ModelFileInstance = InstanceType<typeof ModelFile>;
 type ModelFileInput = string | ModelFileInstance;
 
@@ -52,11 +55,11 @@ import debugLib from 'debug';
 const debug = debugLib('concerto:BaseModelManager');
 
 // How to create a modelfile from the external content
-const defaultProcessFile = (name: string, data: unknown): ModelFileSource => {
+const defaultProcessFile = (name: string | null, data: unknown): ModelFileSource => {
     return {
         ast: data, // AST is input
         definitions: null, // No CTO file
-        fileName: name,
+        fileName: name ?? 'UNKNOWN',
     };
 };
 
@@ -86,14 +89,14 @@ const EXCLUDE_NS = ['concerto@1.0.0', 'concerto', 'concerto.decorator@1.0.0'];
  * @memberof module:concerto-core
  */
 class BaseModelManager {
-     modelFiles: any;
-     processFile: any;
-     factory: any;
-     serializer: any;
-     decoratorFactories: any[];
-     options: any;
-     decoratorValidation: any;
-     metamodelModelFile: any;
+     modelFiles: Record<string, ModelFileInstance>;
+     processFile: (fileName: string | null, modelInput: string | unknown) => ModelFileSource;
+     factory: Factory;
+     serializer: Serializer;
+     decoratorFactories: DecoratorFactory[];
+     options: ModelManagerOptions | undefined;
+     decoratorValidation: NonNullable<ModelManagerOptions['decoratorValidation']>;
+     metamodelModelFile: ModelFileInstance;
     /**
      * Create the ModelManager.
      * @constructor
@@ -119,7 +122,7 @@ class BaseModelManager {
         this.decoratorValidation = options?.decoratorValidation ? options?.decoratorValidation : DEFAULT_DECORATOR_VALIDATION;
 
         // Cache a copy of the Metamodel ModelFile for use when validating the structure of ModelFiles later.
-        this.metamodelModelFile = new ModelFile(this, MetaModelUtil.metaModelAst, undefined, MetaModelNamespace);
+        this.metamodelModelFile = new ModelFile(this, MetaModelUtil.metaModelAst as AstNode, undefined, MetaModelNamespace);
 
         if(options?.addMetamodel) {
             this.addModelFile(this.metamodelModelFile);
@@ -183,7 +186,7 @@ class BaseModelManager {
     validateModelFile(modelFile, fileName?) {
         if (typeof modelFile === 'string') {
             const { ast } = this.processFile(fileName, modelFile);
-            let m = new ModelFile(this, ast, modelFile, fileName);
+            let m = new ModelFile(this, ast as AstNode, modelFile, fileName);
             m.validate();
         } else {
             modelFile.validate();
@@ -319,7 +322,7 @@ class BaseModelManager {
 
         const { ast, definitions } = this.processFile(fileName, modelInput);
         const finalCto = cto || definitions;
-        const m = new ModelFile(this, ast, finalCto, fileName);
+        const m = new ModelFile(this, ast as AstNode, finalCto, fileName);
 
         this.addModelFile(m, finalCto, fileName, disableValidation);
 
@@ -342,7 +345,7 @@ class BaseModelManager {
         debug(NAME, 'updateModelFile', modelFile, fileName);
         if (typeof modelFile === 'string') {
             const { ast } = this.processFile(fileName, modelFile);
-            let m = new ModelFile(this, ast, modelFile, fileName);
+            let m = new ModelFile(this, ast as AstNode, modelFile, fileName);
             return this.updateModelFile(m,fileName,disableValidation);
         } else {
             let existing = this.modelFiles[modelFile.getNamespace()];
@@ -399,7 +402,7 @@ class BaseModelManager {
                 let m: ModelFileInstance;
                 if (typeof modelFile === 'string') {
                     const { ast } = this.processFile(fileName, modelFile);
-                    m = new ModelFile(this, ast, modelFile, fileName);
+                    m = new ModelFile(this, ast as AstNode, modelFile, fileName);
                 } else {
                     m = modelFile;
                 }
@@ -460,11 +463,11 @@ class BaseModelManager {
         Object.assign(originalModelFiles, this.modelFiles);
 
         try {
-            const externalModels = await downloader.downloadExternalDependencies(this.getModelFiles(), options);
+            const externalModels = await downloader.downloadExternalDependencies(this.getModelFiles() as unknown as (ModelFileInstance[] & ModelFileSource[]), options);
 
             const externalModelFiles: ModelFileInstance[] = [];
             externalModels.forEach((file) => {
-                const mf = new ModelFile(this, file.ast, file.definitions, file.fileName);
+                const mf = new ModelFile(this, file.ast as AstNode, file.definitions, file.fileName);
                 const existing = this.modelFiles[mf.getNamespace()];
 
                 if (existing) {
@@ -494,7 +497,7 @@ class BaseModelManager {
      *  If true, external models are written to the file system. Defaults to true
      */
     writeModelsToFileSystem(path, options = {}) {
-        ModelWriter.writeModelsToFileSystem(this.getModelFiles(), path, options);
+        ModelWriter.writeModelsToFileSystem(this.getModelFiles() as unknown as WritableModelFile[], path, options);
     }
 
     /**
@@ -535,7 +538,7 @@ class BaseModelManager {
      */
     getModels(options?: { includeExternalModels?: boolean }) {
         const modelFiles = this.getModelFiles();
-        let models: Array<{ name: string; content: string | null }> = [];
+        let models: Array<{ name: string; content: string | null | undefined }> = [];
         const opts = Object.assign({
             includeExternalModels: true,
         }, options);
@@ -665,70 +668,70 @@ class BaseModelManager {
      * Get the AssetDeclarations defined in this model manager
      * @return {AssetDeclaration[]} the AssetDeclarations defined in the model manager
      */
-    getAssetDeclarations() {
+    getAssetDeclarations(): AssetDeclaration[] {
         return this.getModelFiles().reduce((prev, cur) => {
             return prev.concat(cur.getAssetDeclarations());
-        }, [] as any[]);
+        }, [] as AssetDeclaration[]);
     }
 
     /**
      * Get the TransactionDeclarations defined in this model manager
      * @return {TransactionDeclaration[]} the TransactionDeclarations defined in the model manager
      */
-    getTransactionDeclarations() {
+    getTransactionDeclarations(): TransactionDeclaration[] {
         return this.getModelFiles().reduce((prev, cur) => {
             return prev.concat(cur.getTransactionDeclarations());
-        }, [] as any[]);
+        }, [] as TransactionDeclaration[]);
     }
 
     /**
      * Get the EventDeclarations defined in this model manager
      * @return {EventDeclaration[]} the EventDeclaration defined in the model manager
      */
-    getEventDeclarations() {
+    getEventDeclarations(): EventDeclaration[] {
         return this.getModelFiles().reduce((prev, cur) => {
             return prev.concat(cur.getEventDeclarations());
-        }, [] as any[]);
+        }, [] as EventDeclaration[]);
     }
 
     /**
      * Get the ParticipantDeclarations defined in this model manager
      * @return {ParticipantDeclaration[]} the ParticipantDeclaration defined in the model manager
      */
-    getParticipantDeclarations() {
+    getParticipantDeclarations(): ParticipantDeclaration[] {
         return this.getModelFiles().reduce((prev, cur) => {
             return prev.concat(cur.getParticipantDeclarations());
-        }, [] as any[]);
+        }, [] as ParticipantDeclaration[]);
     }
 
     /**
      * Get the MapDeclarations defined in this model manager
      * @return {MapDeclaration[]} the MapDeclaration defined in the model manager
      */
-    getMapDeclarations() {
+    getMapDeclarations(): MapDeclaration[] {
         return this.getModelFiles().reduce((prev, cur) => {
             return prev.concat(cur.getMapDeclarations());
-        }, [] as any[]);
+        }, [] as MapDeclaration[]);
     }
 
     /**
      * Get the EnumDeclarations defined in this model manager
      * @return {EnumDeclaration[]} the EnumDeclaration defined in the model manager
      */
-    getEnumDeclarations() {
+    getEnumDeclarations(): EnumDeclaration[] {
         return this.getModelFiles().reduce((prev, cur) => {
             return prev.concat(cur.getEnumDeclarations());
-        }, [] as any[]);
+        }, [] as EnumDeclaration[]);
     }
 
     /**
      * Get the Concepts defined in this model manager
      * @return {ConceptDeclaration[]} the ConceptDeclaration defined in the model manager
      */
-    getConceptDeclarations() {
+    getConceptDeclarations(): ConceptDeclaration[] {
         return this.getModelFiles().reduce((prev, cur) => {
             return prev.concat(cur.getConceptDeclarations());
-        }, [] as any[]);
+        }, [] as ConceptDeclaration[]);
     }
 
     /**
@@ -787,9 +790,9 @@ class BaseModelManager {
      * @param {object} metaModel - the MetaModel
      * @return {object} the resolved metamodel
      */
-    resolveMetaModel(metaModel) {
+    resolveMetaModel(metaModel: IModel): IModel {
         const priorModels = this.getAst(false, true);
-        return MetaModelUtil.resolveLocalNames(priorModels, metaModel);
+        return MetaModelUtil.resolveLocalNames(priorModels, metaModel) as IModel;
     }
 
     /**
@@ -798,9 +801,9 @@ class BaseModelManager {
      * @param {object} [options] - options for the from ast method
      * @param {object} [options.disableValidation] - option to disable metamodel validation and just fetch the models, to be used only if the metamodel is already validated
      */
-    fromAst(ast, options?) {
+    fromAst(ast: IModels, options?: { disableValidation?: boolean }) {
         this.clearModelFiles();
-        ast.models.forEach( model => {
+        ast.models.forEach( (model: IModel) => {
             if(!EXCLUDE_NS.includes(model.namespace)) { // excludes the internal namespaces, already added
                 const modelFile = new ModelFile( this, model );
                 this.addModelFile( modelFile, null, null, true );
@@ -817,10 +820,10 @@ class BaseModelManager {
      * @param {boolean} [includeConcertoNamespaces] - whether to include the concerto namespaces
      * @returns {*} the metamodel
      */
-    getAst(resolve?,includeConcertoNamespaces?) {
-        const result = {
+    getAst(resolve?, includeConcertoNamespaces?): IModels {
+        const result: IModels = {
             $class: `${MetaModelNamespace}.Models`,
-            models: [] as any[],
+            models: [] as IModel[],
         };
         const modelFiles = this.getModelFiles(includeConcertoNamespaces);
         modelFiles.forEach((thisModelFile) => {

--- a/packages/concerto-core/src/decoratorextractor.ts
+++ b/packages/concerto-core/src/decoratorextractor.ts
@@ -498,7 +498,7 @@ class DecoratorExtractor {
     */
     processModels(){
         const processedModels = this.sourceModelAst.models.map(model =>{
-            if (model?.decorators?.length) {
+            if ((model?.decorators?.length ?? 0) > 0) {
                 this.constructDCSDictionary(model.namespace, model.decorators, {});
                 model.decorators = this.filterOutDecorators(model.decorators);
             }

--- a/packages/concerto-core/src/decoratorextractor.ts
+++ b/packages/concerto-core/src/decoratorextractor.ts
@@ -17,6 +17,12 @@ import ModelUtil from './modelutil';
 import yaml from 'yaml';
 import { MetaModelNamespace } from '@accordproject/concerto-metamodel';
 
+// Types needed for TypeScript generation.
+/* eslint-disable no-unused-vars */
+import type { IModels } from '@accordproject/concerto-metamodel';
+import type { DecoratorCommandTarget } from './types';
+/* eslint-enable no-unused-vars */
+
 // $class value for decorator arguments that carry a string value
 const DECORATOR_STRING_TYPE = `${MetaModelNamespace}.DecoratorString`;
 
@@ -26,14 +32,25 @@ const DECORATOR_STRING_TYPE = `${MetaModelNamespace}.DecoratorString`;
  * @memberof module:concerto-core
  * @private
  */
+/**
+ * A decorator collected from a model, keyed in the extraction dictionary by
+ * the namespace it was found in.
+ */
+interface ExtractedDecorator {
+    declaration: string;
+    property: string;
+    mapElement: string;
+    dcs: string;
+}
+
 class DecoratorExtractor {
-    extractionDictionary: any;
-    removeDecoratorsFromModel: any;
-    locale: any;
-    dcs_version: any;
-    sourceModelAst: any;
-    updatedModelAst: any;
-    action: any;
+    extractionDictionary: Record<string, ExtractedDecorator[]>;
+    removeDecoratorsFromModel: boolean;
+    locale: string;
+    dcs_version: string;
+    sourceModelAst: IModels;
+    updatedModelAst: IModels;
+    action: number;
     /**
      * The action to be performed to extract all, only vocab or only non-vocab decorators
      */
@@ -53,7 +70,7 @@ class DecoratorExtractor {
      * @param {int} [action=DecoratorExtractor.Action.EXTRACT_ALL]  - the action to be performed
      * @param {object} [options] - decorator extractor options
      */
-    constructor(removeDecoratorsFromModel, locale, dcs_version, sourceModelAst, action = DecoratorExtractor.Action.EXTRACT_ALL, options?) {
+    constructor(removeDecoratorsFromModel: boolean, locale: string, dcs_version: string, sourceModelAst: IModels, action: number = DecoratorExtractor.Action.EXTRACT_ALL, options?: Record<string, unknown>) {
         this.extractionDictionary = {};
         this.removeDecoratorsFromModel = removeDecoratorsFromModel;
         this.locale = locale;
@@ -208,7 +225,7 @@ class DecoratorExtractor {
      * @private
      */
     constructTarget(namespace, obj){
-        const target: any = {
+        const target: DecoratorCommandTarget & { $class: string } = {
             '$class': `org.accordproject.decoratorcommands@${this.dcs_version}.CommandTarget`,
             'namespace':namespace
         };
@@ -481,7 +498,7 @@ class DecoratorExtractor {
     */
     processModels(){
         const processedModels = this.sourceModelAst.models.map(model =>{
-            if ((model?.decorators?.length > 0)){
+            if (model?.decorators?.length) {
                 this.constructDCSDictionary(model.namespace, model.decorators, {});
                 model.decorators = this.filterOutDecorators(model.decorators);
             }

--- a/packages/concerto-core/src/decoratormanager.ts
+++ b/packages/concerto-core/src/decoratormanager.ts
@@ -31,6 +31,7 @@ import { jsonToYaml, yamlToJson } from './dcsconverter';
 // Types needed for TypeScript generation.
 /* eslint-disable no-unused-vars */
 import type ModelFile from './introspect/modelfile';
+import type { DecoratorCommand } from './types';
 /* eslint-enable no-unused-vars */
 
 const DCS_VERSION = '0.4.0';
@@ -131,8 +132,8 @@ function isUnversionedNamespaceEqual(modelFile, unversionedNamespace) {
  * @private
  */
 class DcsIndexWrapper {
-    command: any;
-    index: any;
+    command: DecoratorCommand;
+    index: number;
 
     /**
      * Create the DcsIndexWrapper.
@@ -140,7 +141,7 @@ class DcsIndexWrapper {
      * @param {*} command - the decorator command
      * @param {number} index - the index of the command
      */
-    constructor(command, index) {
+    constructor(command: DecoratorCommand, index: number) {
         this.command = command;
         this.index = index;
     }
@@ -149,7 +150,7 @@ class DcsIndexWrapper {
      * Get the decorator command.
      * @returns {*} The decorator command.
      */
-    getCommand() {
+    getCommand(): DecoratorCommand {
         return this.command;
     }
 
@@ -157,7 +158,7 @@ class DcsIndexWrapper {
      * Get the index of the command.
      * @returns {number} The index of the command.
      */
-    getIndex() {
+    getIndex(): number {
         return this.index;
     }
 }
@@ -426,7 +427,7 @@ class DecoratorManager {
             model.imports = model.imports ? model.imports.concat(neededImports) : neededImports;
             const namespaceName = ModelUtil.parseNamespace(model.namespace).name;
             model.declarations.forEach((decl) => {
-                const declarationDecoratorCommandSets: any[] = [];
+                const declarationDecoratorCommandSets: DcsIndexWrapper[] = [];
                 const { name: declarationName, $class: $classForDeclaration } = decl;
                 this.pushMapValues(declarationDecoratorCommandSets, declarationCommandsMap, declarationName);
                 this.pushMapValues(declarationDecoratorCommandSets, namespaceCommandsMap, model.namespace);
@@ -439,7 +440,7 @@ class DecoratorManager {
                 });
 
                 if($classForDeclaration === `${MetaModelNamespace}.MapDeclaration`) {
-                    const mapDecoratorCommandSets: any = [];
+                    const mapDecoratorCommandSets: DcsIndexWrapper[] = [];
                     this.pushMapValues(mapDecoratorCommandSets, typeCommandsMap, decl.key.$class);
                     this.pushMapValues(mapDecoratorCommandSets, typeCommandsMap, decl.value.$class);
                     this.pushMapValues(mapDecoratorCommandSets, mapElementCommandsMap, 'KEY');
@@ -454,7 +455,7 @@ class DecoratorManager {
                 // scalars are declarations but do not have properties
                 if (decl.properties) {
                     decl.properties.forEach((property) => {
-                        const propertyDecoratorCommandSets: any[] = [];
+                        const propertyDecoratorCommandSets: DcsIndexWrapper[] = [];
                         const { name: propertyName, $class: $classForProperty } = property;
                         this.pushMapValues(propertyDecoratorCommandSets, propertyCommandsMap, propertyName);
                         this.pushMapValues(propertyDecoratorCommandSets, typeCommandsMap, $classForProperty);
@@ -560,7 +561,7 @@ class DecoratorManager {
                 command.target.type
             );
         }
-        let modelFile: any = null;
+        let modelFile: ModelFile | null = null;
         if (command.target.namespace) {
             modelFile = validationModelManager.getModelFile(
                 command.target.namespace
@@ -585,10 +586,11 @@ class DecoratorManager {
             );
         }
 
+        // the guard above throws unless modelFile was resolved for the namespace
         if (command.target.namespace && command.target.declaration) {
             validationModelManager.resolveType(
                 'DecoratorCommand.target.declaration',
-                `${modelFile.getNamespace()}.${command.target.declaration}`
+                `${modelFile!.getNamespace()}.${command.target.declaration}`
             );
         }
         if (command.target.properties && command.target.property) {
@@ -602,7 +604,7 @@ class DecoratorManager {
             command.target.property
         ) {
             const decl = validationModelManager.getType(
-                `${modelFile.getNamespace()}.${command.target.declaration}`
+                `${modelFile!.getNamespace()}.${command.target.declaration}`
             );
             const property = decl.getProperty(command.target.property);
             if (!property) {
@@ -617,7 +619,7 @@ class DecoratorManager {
             command.target.properties
         ) {
             const decl = validationModelManager.getType(
-                `${modelFile.getNamespace()}.${command.target.declaration}`
+                `${modelFile!.getNamespace()}.${command.target.declaration}`
             );
             command.target.properties.forEach((commandProperty) => {
                 const property = decl.getProperty(commandProperty);

--- a/packages/concerto-core/src/factory.ts
+++ b/packages/concerto-core/src/factory.ts
@@ -34,7 +34,11 @@ import dayjs from './dayjs-setup';
 
 // Types needed for TypeScript generation.
 /* eslint-disable no-unused-vars */
-import type ModelManager from './modelmanager';
+import type BaseModelManager from './basemodelmanager';
+import type ClassDeclaration from './introspect/classdeclaration';
+import type Typed from './model/typed';
+import type { Dayjs } from 'dayjs';
+import type { GenerateOptions, InstanceGeneratorParameters } from './types';
 /* eslint-enable no-unused-vars */
 
 /**
@@ -45,7 +49,7 @@ import type ModelManager from './modelmanager';
  * @memberof module:concerto-core
  */
 class Factory {
-    modelManager: any;
+    modelManager: BaseModelManager;
     /**
      * Create a new ID for an object.
      * @returns {string} a new ID
@@ -59,7 +63,7 @@ class Factory {
      *
      * @param {ModelManager} modelManager - The ModelManager to use for this registry
      */
-    constructor(modelManager) {
+    constructor(modelManager: BaseModelManager) {
         this.modelManager = modelManager;
     }
 
@@ -129,8 +133,8 @@ class Factory {
             throw new Error('Type is not identifiable ' + classDecl.getFullyQualifiedName());
         }
 
-        let newObj: any = null;
-        let timestamp: any = null;
+        let newObj: Resource;
+        let timestamp: Dayjs | null = null;
         if (classDecl.isTransaction() || classDecl.isEvent()) {
             timestamp = dayjs.utc();
         }
@@ -214,7 +218,7 @@ class Factory {
         } else if (!type) {
             throw new Error('type not specified');
         }
-        let transaction: any = this.newResource(ns, type, id, options);
+        const transaction = this.newResource(ns, type, id, options);
         const classDeclaration = transaction.getClassDeclaration();
 
         if (!classDeclaration.isTransaction()) {
@@ -244,7 +248,7 @@ class Factory {
         } else if (!type) {
             throw new Error('type not specified');
         }
-        let event: any = this.newResource(ns, type, id, options);
+        const event = this.newResource(ns, type, id, options);
         const classDeclaration = event.getClassDeclaration();
 
         if (!classDeclaration.isEvent()) {
@@ -263,8 +267,8 @@ class Factory {
      * @param {ClassDeclaration} classDeclaration - class declaration for the resource.
      * @param {Object} clientOptions - field generation options supplied by the caller.
      */
-    initializeNewObject(newObject, classDeclaration, clientOptions) {
-        const generateParams: any = this.parseGenerateOptions(clientOptions);
+    initializeNewObject(newObject: Typed, classDeclaration: ClassDeclaration, clientOptions: GenerateOptions) {
+        const generateParams = this.parseGenerateOptions(clientOptions);
         if (generateParams) {
             generateParams.stack = new TypedStack(newObject);
             generateParams.seen = [newObject.getFullyQualifiedType()];
@@ -282,23 +286,22 @@ class Factory {
      * @param {Object} clientOptions - field generation options supplied by the caller.
      * @return {Object} InstanceGenerator options.
      */
-    parseGenerateOptions(clientOptions) {
+    parseGenerateOptions(clientOptions: GenerateOptions): InstanceGeneratorParameters | null {
         if (!clientOptions.generate) {
             return null;
         }
 
-        const generateParams: any = { };
-        generateParams.modelManager = this.modelManager;
-        generateParams.factory = this;
-
-        if ((/^empty$/i).test(clientOptions.generate)) {
-            generateParams.valueGenerator = ValueGeneratorFactory.empty();
-        } else {
+        const valueGenerator = (/^empty$/i).test(clientOptions.generate)
+            ? ValueGeneratorFactory.empty()
             // Allow any other value for backwards compatibility with previous (truthy) behavior
-            generateParams.valueGenerator = ValueGeneratorFactory.sample();
-        }
+            : ValueGeneratorFactory.sample();
 
-        generateParams.includeOptionalFields = clientOptions.includeOptionalFields ? true : false;
+        const generateParams: InstanceGeneratorParameters = {
+            modelManager: this.modelManager,
+            factory: this,
+            valueGenerator,
+            includeOptionalFields: clientOptions.includeOptionalFields ? true : false,
+        };
 
         return generateParams;
     }

--- a/packages/concerto-core/src/introspect/classdeclaration.ts
+++ b/packages/concerto-core/src/introspect/classdeclaration.ts
@@ -26,6 +26,7 @@ import ModelUtil from '../modelutil';
 // Types needed for TypeScript generation.
 /* eslint-disable no-unused-vars */
 import type Property from './property';
+import type { AstNode } from './decorated';
 /* eslint-enable no-unused-vars */
 
 /**
@@ -40,20 +41,24 @@ import type Property from './property';
  * @memberof module:concerto-core
  */
 class ClassDeclaration extends Declaration {
-    modelFile: any;
-    properties: any;
-    superType: any;
-    superTypeDeclaration: any;
-    idField: any;
-    timestamped: any;
-    abstract: any;
-    type: any;
+    // These are populated by process(), which the Declaration constructor calls,
+    // so they carry definite assignment assertions rather than initialisers --
+    // an initialiser here would run after the base constructor and clobber it.
+    properties!: Property[];
+    superType!: string | null;
+    superTypeDeclaration!: ClassDeclaration | null;
+    idField!: string | null;
+    timestamped!: boolean;
+    abstract!: boolean;
+    type!: string;
+
     /**
      * Returns the kind of declaration
+     * @abstract
      * @return {string} the kind of declaration
      */
     declarationKind(): string {
-        return '';
+        throw new Error('not implemented');
     }
 
     /**
@@ -141,8 +146,7 @@ class ClassDeclaration extends Declaration {
      * @private
      */
     addTimestampField() {
-        const definition: any = {};
-        definition.$class = `${MetaModelNamespace}.DateTimeProperty`;
+        const definition: AstNode = { $class: `${MetaModelNamespace}.DateTimeProperty` };
         definition.name = '$timestamp';
         this.properties.push(new Field(this, definition));
     }
@@ -153,8 +157,7 @@ class ClassDeclaration extends Declaration {
      * @private
      */
     addIdentifierField() {
-        const definition: any = {};
-        definition.$class = `${MetaModelNamespace}.StringProperty`;
+        const definition: AstNode = { $class: `${MetaModelNamespace}.StringProperty` };
         definition.name = '$identifier';
         this.properties.push(new Field(this, definition));
     }
@@ -163,13 +166,13 @@ class ClassDeclaration extends Declaration {
      * Resolve the super type on this class and store it as an internal property.
      * @return {ClassDeclaration} The super type, or null if non specified.
      */
-    _resolveSuperType() {
+    _resolveSuperType(): ClassDeclaration | null {
         if (!this.superType) {
             return null;
         }
         // Clear out any old resolved super types.
         this.superTypeDeclaration = null;
-        let classDecl: any = null;
+        let classDecl: ClassDeclaration;
         if (this.getModelFile().isImportedType(this.superType)) {
             let fqnSuper = this.getModelFile().resolveImport(this.superType);
             classDecl = this.modelFile.getModelManager().getType(fqnSuper);
@@ -307,7 +310,7 @@ class ClassDeclaration extends Declaration {
      *
      * @return {boolean} true if the class is abstract
      */
-    isAbstract() {
+    isAbstract(): boolean {
         return this.abstract;
     }
 
@@ -316,7 +319,7 @@ class ClassDeclaration extends Declaration {
      * (system or explicit)
      * @returns {Boolean} true if the class declaration includes an identifier
      */
-    isIdentified() {
+    isIdentified(): boolean {
         return !!(this.getIdentifierFieldName());
     }
 
@@ -325,7 +328,7 @@ class ClassDeclaration extends Declaration {
      * $identifier
      * @returns {Boolean} true if the class declaration includes a system identifier
      */
-    isSystemIdentified() {
+    isSystemIdentified(): boolean {
         return this.getIdentifierFieldName() === '$identifier';
     }
 
@@ -333,7 +336,7 @@ class ClassDeclaration extends Declaration {
      * Returns true if this class declaration declares an explicit identifier
      * @returns {Boolean} true if the class declaration includes an explicit identifier
      */
-    isExplicitlyIdentified() {
+    isExplicitlyIdentified(): boolean {
         return (!!this.idField && this.idField !== '$identifier');
     }
 
@@ -343,20 +346,22 @@ class ClassDeclaration extends Declaration {
      *
      * @return {string} the name of the id field for this class or null if it does not exist
      */
-    getIdentifierFieldName() {
+    getIdentifierFieldName(): string | null {
         if (this.idField) {
             return this.idField;
         } else {
-            if (this.getSuperType()) {
+            const superType = this.getSuperType();
+            if (superType) {
                 // we first check our own modelfile, as we may be called from validate
                 // in which case our model file has not yet been added to the model modelManager
-                let classDecl = this.getModelFile().getLocalType(this.getSuperType());
+                let classDecl = this.getModelFile().getLocalType(superType);
 
-                // not a local type, so we try the model manager
+                // not a local type, so we try the model manager, which throws
+                // if the super type cannot be resolved
                 if (!classDecl) {
-                    classDecl = this.modelFile.getModelManager().getType(this.getSuperType());
+                    classDecl = this.modelFile.getModelManager().getType(superType);
                 }
-                return classDecl.getIdentifierFieldName();
+                return classDecl!.getIdentifierFieldName();
             } else {
                 return null;
             }
@@ -371,7 +376,7 @@ class ClassDeclaration extends Declaration {
      * @param {string} name the name of the field
      * @return {Property} the field definition or null if it does not exist
      */
-    getOwnProperty(name) {
+    getOwnProperty(name: string): Property | null {
         for (let n = 0; n < this.properties.length; n++) {
             const field = this.properties[n];
             if (field.getName() === name) {
@@ -387,7 +392,7 @@ class ClassDeclaration extends Declaration {
      *
      * @return {Property[]} the array of fields
      */
-    getOwnProperties() {
+    getOwnProperties(): Property[] {
         return this.properties;
     }
 
@@ -397,7 +402,7 @@ class ClassDeclaration extends Declaration {
      *
      * @return {string} the FQN name of the super type or null
      */
-    getSuperType() {
+    getSuperType(): string | null {
         const superTypeDeclaration = this.getSuperTypeDeclaration();
         if (superTypeDeclaration) {
             return superTypeDeclaration.getFullyQualifiedName();
@@ -410,7 +415,7 @@ class ClassDeclaration extends Declaration {
      * Get the super type class declaration for this class.
      * @return {ClassDeclaration} the super type declaration, or null if there is no super type.
      */
-    getSuperTypeDeclaration() {
+    getSuperTypeDeclaration(): ClassDeclaration | null {
         if (!this.superType) {
             // No super type.
             return null;
@@ -427,15 +432,15 @@ class ClassDeclaration extends Declaration {
      * Get the class declarations for all subclasses of this class, including this class.
      * @return {ClassDeclaration[]} subclass declarations.
      */
-    getAssignableClassDeclarations() {
-        const results = new Set<any>();
+    getAssignableClassDeclarations(): ClassDeclaration[] {
+        const results = new Set<ClassDeclaration>();
         const modelManager = this.getModelFile().getModelManager();
         const introspector = new Introspector(modelManager);
         const allClassDeclarations = introspector.getClassDeclarations();
         const subclassMap = new Map();
 
         // Build map of all direct subclasses relationships
-        allClassDeclarations.forEach((declaration: any) => {
+        allClassDeclarations.forEach((declaration) => {
             const superType = declaration.getSuperType();
             if (superType) {
                 const subclasses = subclassMap.get(superType) || new Set();
@@ -465,14 +470,14 @@ class ClassDeclaration extends Declaration {
      * Get the class declarations for just the direct subclasses of this class, excluding this class.
      * @return {ClassDeclaration[]} direct subclass declarations.
      */
-    getDirectSubclasses() {
+    getDirectSubclasses(): ClassDeclaration[] {
         const modelManager = this.getModelFile().getModelManager();
         const introspector = new Introspector(modelManager);
         const allClassDeclarations = introspector.getClassDeclarations();
         const subclassMap = new Map();
 
         // Build map of all direct subclasses relationships
-        allClassDeclarations.forEach((declaration: any) => {
+        allClassDeclarations.forEach((declaration) => {
             const superType = declaration.getSuperType();
             if (superType) {
                 const subclasses = subclassMap.get(superType) || new Set();
@@ -494,9 +499,9 @@ class ClassDeclaration extends Declaration {
      * Get all the super-type declarations for this type.
      * @return {ClassDeclaration[]} super-type declarations.
      */
-    getAllSuperTypeDeclarations() {
-        const results: any[] = [];
-        for (let type = this;
+    getAllSuperTypeDeclarations(): ClassDeclaration[] {
+        const results: ClassDeclaration[] = [];
+        for (let type: ClassDeclaration | null = this;
             (type = type.getSuperTypeDeclaration());) {
             results.push(type);
         }
@@ -511,9 +516,9 @@ class ClassDeclaration extends Declaration {
      * @param {string} name the name of the field
      * @return {Property} the field, or null if it does not exist
      */
-    getProperty(name) {
+    getProperty(name: string): Property | null {
         let result = this.getOwnProperty(name);
-        let classDecl: any = null;
+        let classDecl: ClassDeclaration;
 
         if (result === null && this.superType !== null) {
             if (this.getModelFile().isImportedType(this.superType)) {
@@ -533,9 +538,9 @@ class ClassDeclaration extends Declaration {
      *
      * @return {Property[]} the array of fields
      */
-    getProperties() {
+    getProperties(): Property[] {
         let result = this.getOwnProperties();
-        let classDecl: any = null;
+        let classDecl: ClassDeclaration;
         if (this.superType !== null) {
             if (this.getModelFile().isImportedType(this.superType)) {
                 let fqnSuper = this.getModelFile().resolveImport(this.superType);
@@ -564,22 +569,26 @@ class ClassDeclaration extends Declaration {
      * @returns {Property} the property
      * @throws {IllegalModelException} if the property path is invalid or the property does not exist
      */
-    getNestedProperty(propertyPath) {
+    getNestedProperty(propertyPath: string): Property {
 
         const propertyNames = propertyPath.split('.');
-        let classDeclaration = this;
-        let result: any = null;
+        let classDeclaration: ClassDeclaration = this;
+        // propertyPath.split() always yields at least one name, so the loop below
+        // either assigns result or throws
+        let result!: Property;
 
         for (let n = 0; n < propertyNames.length; n++) {
 
             // get the nth property
-            result = classDeclaration.getProperty(propertyNames[n]);
+            const property = classDeclaration.getProperty(propertyNames[n]);
 
-            if (result === null) {
+            if (property === null) {
                 throw new IllegalModelException('Property ' + propertyNames[n] + ' does not exist on ' + classDeclaration.getFullyQualifiedName(), this.modelFile, this.ast.location);
             }
+            result = property;
+
             // not the last element, get the class of the element
-            else if (n < propertyNames.length - 1) {
+            if (n < propertyNames.length - 1) {
                 if (result.isPrimitive() || result.isTypeEnum()) {
                     throw new Error('Property ' + propertyNames[n] + ' is a primitive or enum. Invalid property path: ' + propertyPath);
                 } else {
@@ -596,7 +605,7 @@ class ClassDeclaration extends Declaration {
      * Returns the string representation of this class
      * @return {String} the string representation of the class
      */
-    toString() {
+    toString(): string {
         let superType = '';
         if (this.superType) {
             superType = ' super=' + this.superType;
@@ -609,7 +618,7 @@ class ClassDeclaration extends Declaration {
      *
      * @return {boolean} true if the class is an asset
      */
-    isAsset() {
+    isAsset(): boolean {
         return this.type === `${MetaModelNamespace}.AssetDeclaration`;
     }
 
@@ -618,7 +627,7 @@ class ClassDeclaration extends Declaration {
      *
      * @return {boolean} true if the class is an asset
      */
-    isParticipant() {
+    isParticipant(): boolean {
         return this.type === `${MetaModelNamespace}.ParticipantDeclaration`;
     }
 
@@ -627,7 +636,7 @@ class ClassDeclaration extends Declaration {
      *
      * @return {boolean} true if the class is an asset
      */
-    isTransaction() {
+    isTransaction(): boolean {
         return this.type === `${MetaModelNamespace}.TransactionDeclaration`;
     }
 
@@ -636,7 +645,7 @@ class ClassDeclaration extends Declaration {
      *
      * @return {boolean} true if the class is an asset
      */
-    isEvent() {
+    isEvent(): boolean {
         return this.type === `${MetaModelNamespace}.EventDeclaration`;
     }
 
@@ -645,7 +654,7 @@ class ClassDeclaration extends Declaration {
      *
      * @return {boolean} true if the class is an asset
      */
-    isConcept() {
+    isConcept(): boolean {
         return this.type === `${MetaModelNamespace}.ConceptDeclaration`;
     }
 
@@ -654,7 +663,7 @@ class ClassDeclaration extends Declaration {
      *
      * @return {boolean} true if the class is an asset
      */
-    isEnum() {
+    isEnum(): boolean {
         return this.type === `${MetaModelNamespace}.EnumDeclaration`;
     }
 
@@ -663,7 +672,7 @@ class ClassDeclaration extends Declaration {
      *
      * @return {boolean} true if the class is an asset
      */
-    isMapDeclaration() {
+    isMapDeclaration(): boolean {
         return this.type === `${MetaModelNamespace}.MapDeclaration`;
     }
 
@@ -672,7 +681,7 @@ class ClassDeclaration extends Declaration {
      *
      * @return {boolean} true if the class is an asset
      */
-    isClassDeclaration() {
+    isClassDeclaration(): boolean {
         return true;
     }
 }

--- a/packages/concerto-core/src/introspect/collectionsizevalidator.ts
+++ b/packages/concerto-core/src/introspect/collectionsizevalidator.ts
@@ -15,6 +15,12 @@
 import { NullUtil } from '@accordproject/concerto-util';
 import Validator from './validator';
 
+// Types needed for TypeScript generation.
+/* eslint-disable no-unused-vars */
+import type { ValidatedElement } from './validator';
+import type { AstNode } from './decorated';
+/* eslint-enable no-unused-vars */
+
 const { isNull } = NullUtil;
 
 /**
@@ -24,8 +30,8 @@ const { isNull } = NullUtil;
  * @memberof module:concerto-core
  */
 class CollectionSizeValidator extends Validator {
-    minSize: any;
-    maxSize: any;
+    minSize: number | null;
+    maxSize: number | null;
 
     /**
      * Create a CollectionSizeValidator.
@@ -34,14 +40,14 @@ class CollectionSizeValidator extends Validator {
      *
      * @throws {IllegalModelException}
      */
-    constructor(field, validator) {
+    constructor(field: ValidatedElement, validator: AstNode) {
         super(field, validator);
         this.minSize = validator.minSize ?? null;
         this.maxSize = validator.maxSize ?? null;
 
         if (isNull(this.minSize) && isNull(this.maxSize)) {
             this.reportError(field.getName(), 'Invalid collection size, minSize and/or maxSize must be specified.');
-        } else if (this.minSize < 0 || this.maxSize < 0) {
+        } else if ((this.minSize ?? 0) < 0 || (this.maxSize ?? 0) < 0) {
             this.reportError(field.getName(), 'minSize and/or maxSize must be positive integers.');
         } else if (isNull(this.minSize) || isNull(this.maxSize)) {
             // this is fine and means that we don't need to check whether minSize > maxSize
@@ -57,7 +63,7 @@ class CollectionSizeValidator extends Validator {
      * @throws {IllegalModelException}
      * @private
      */
-    validate(identifier, value) {
+    validate(identifier: string | null, value: number): void {
         if(!isNull(this.minSize) && value < this.minSize) {
             this.reportError(identifier, `Collection must contain at least ${this.minSize} elements.`);
         }
@@ -70,7 +76,7 @@ class CollectionSizeValidator extends Validator {
      * Returns the minSize for this validator, or null if not specified
      * @returns {number} the min size or null
      */
-    getMinSize() {
+    getMinSize(): number | null {
         return this.minSize;
     }
 
@@ -78,7 +84,7 @@ class CollectionSizeValidator extends Validator {
      * Returns the maxSize for this validator, or null if not specified
      * @returns {number} the max size or null
      */
-    getMaxSize() {
+    getMaxSize(): number | null {
         return this.maxSize;
     }
 
@@ -90,7 +96,7 @@ class CollectionSizeValidator extends Validator {
      * @returns {boolean} True if this validator is compatible with the other
      * validator, false otherwise.
      */
-    compatibleWith(other) {
+    compatibleWith(other: Validator | null): boolean {
         if (!(other instanceof CollectionSizeValidator)) {
             return false;
         }

--- a/packages/concerto-core/src/introspect/collectionsizevalidator.ts
+++ b/packages/concerto-core/src/introspect/collectionsizevalidator.ts
@@ -18,7 +18,7 @@ import Validator from './validator';
 // Types needed for TypeScript generation.
 /* eslint-disable no-unused-vars */
 import type { ValidatedElement } from './validator';
-import type { AstNode } from './decorated';
+import type { ICollectionSizeValidator } from '@accordproject/concerto-metamodel';
 /* eslint-enable no-unused-vars */
 
 const { isNull } = NullUtil;
@@ -30,6 +30,7 @@ const { isNull } = NullUtil;
  * @memberof module:concerto-core
  */
 class CollectionSizeValidator extends Validator {
+    declare validator: ICollectionSizeValidator;
     minSize: number | null;
     maxSize: number | null;
 
@@ -40,7 +41,7 @@ class CollectionSizeValidator extends Validator {
      *
      * @throws {IllegalModelException}
      */
-    constructor(field: ValidatedElement, validator: AstNode) {
+    constructor(field: ValidatedElement, validator: ICollectionSizeValidator) {
         super(field, validator);
         this.minSize = validator.minSize ?? null;
         this.maxSize = validator.maxSize ?? null;

--- a/packages/concerto-core/src/introspect/declaration.ts
+++ b/packages/concerto-core/src/introspect/declaration.ts
@@ -13,6 +13,7 @@
  */
 
 import Decorated from './decorated';
+import type { AstNode } from './decorated';
 import ModelUtil from '../modelutil';
 import IllegalModelException from './illegalmodelexception';
 
@@ -33,9 +34,9 @@ import type ModelFile from './modelfile';
  * @memberof module:concerto-core
  */
 class Declaration extends Decorated {
-    modelFile: any;
-    name: any;
-    fqn: any;
+    modelFile: ModelFile;
+    name!: string;
+    fqn!: string;
     /**
      * Create a Declaration from an Abstract Syntax Tree. The AST is the
      * result of parsing.
@@ -44,7 +45,7 @@ class Declaration extends Decorated {
      * @param {Object} ast - the AST created by the parser
      * @throws {IllegalModelException}
      */
-    constructor(modelFile, ast) {
+    constructor(modelFile: ModelFile, ast: AstNode) {
         super(ast);
         this.modelFile = modelFile;
         this.process();
@@ -76,7 +77,7 @@ class Declaration extends Decorated {
      * @throws {IllegalModelException}
      * @protected
      */
-    validate(...args) {
+    validate(...args: any[]) {
         super.validate(...args);
         const modelFile = this.getModelFile();
 
@@ -98,7 +99,7 @@ class Declaration extends Decorated {
      * @param {string} typeName - local/imported type name
      * @returns {boolean} true if the resolved import is a reserved system type
      */
-    private isReservedSystemTypeImport(modelFile, typeName) {
+    private isReservedSystemTypeImport(modelFile: ModelFile, typeName: string): boolean {
         const importedType = modelFile.getType(typeName);
         if (!importedType || typeof importedType === 'string') {
             return false;
@@ -122,7 +123,7 @@ class Declaration extends Decorated {
      * @public
      * @return {ModelFile} the owning ModelFile
      */
-    getModelFile() {
+    getModelFile(): ModelFile {
         return this.modelFile;
     }
 
@@ -132,7 +133,7 @@ class Declaration extends Decorated {
      *
      * @return {string} the short name of this class
      */
-    getName() {
+    getName(): string {
         return this.name;
     }
 
@@ -140,7 +141,7 @@ class Declaration extends Decorated {
      * Return the namespace of this class.
      * @return {string} namespace - a namespace.
      */
-    getNamespace() {
+    getNamespace(): string {
         return this.modelFile.getNamespace();
     }
 
@@ -150,7 +151,7 @@ class Declaration extends Decorated {
      *
      * @return {string} the fully-qualified name of this class
      */
-    getFullyQualifiedName() {
+    getFullyQualifiedName(): string {
         return this.fqn;
     }
 
@@ -158,7 +159,7 @@ class Declaration extends Decorated {
      * Returns false as scalars are never identified.
      * @returns {Boolean} false as scalars are never identified
      */
-    isIdentified() {
+    isIdentified(): boolean {
         return false;
     }
 
@@ -166,7 +167,7 @@ class Declaration extends Decorated {
      * Returns false as scalars are never identified.
      * @returns {Boolean} false as scalars are never identified
      */
-    isSystemIdentified() {
+    isSystemIdentified(): boolean {
         return false;
     }
 
@@ -176,7 +177,7 @@ class Declaration extends Decorated {
      *
      * @return {string} the name of the id field for this class or null if it does not exist
      */
-    getIdentifierFieldName() {
+    getIdentifierFieldName(): string | null {
         return null;
     }
 
@@ -186,7 +187,7 @@ class Declaration extends Decorated {
      *
      * @return {string} the FQN name of the super type or null
      */
-    getType() {
+    getType(): string | null {
         return null;
     }
 
@@ -203,7 +204,7 @@ class Declaration extends Decorated {
      *
      * @return {boolean} true if the class is an enum
      */
-    isEnum() {
+    isEnum(): boolean {
         return false;
     }
 
@@ -212,7 +213,7 @@ class Declaration extends Decorated {
      *
      * @return {boolean} true if the class is a class
      */
-    isClassDeclaration() {
+    isClassDeclaration(): boolean {
         return false;
     }
 
@@ -221,7 +222,7 @@ class Declaration extends Decorated {
      *
      * @return {boolean} true if the class is a scalar
      */
-    isScalarDeclaration() {
+    isScalarDeclaration(): boolean {
         return false;
     }
 
@@ -230,7 +231,52 @@ class Declaration extends Decorated {
      *
      * @return {boolean} true if the class is a map-declaration
      */
-    isMapDeclaration() {
+    isMapDeclaration(): boolean {
+        return false;
+    }
+
+    /**
+     * Returns true if this class is the definition of an asset.
+     *
+     * @return {boolean} true if the class is an asset
+     */
+    isAsset(): boolean {
+        return false;
+    }
+
+    /**
+     * Returns true if this class is the definition of a participant.
+     *
+     * @return {boolean} true if the class is a participant
+     */
+    isParticipant(): boolean {
+        return false;
+    }
+
+    /**
+     * Returns true if this class is the definition of a transaction.
+     *
+     * @return {boolean} true if the class is a transaction
+     */
+    isTransaction(): boolean {
+        return false;
+    }
+
+    /**
+     * Returns true if this class is the definition of an event.
+     *
+     * @return {boolean} true if the class is an event
+     */
+    isEvent(): boolean {
+        return false;
+    }
+
+    /**
+     * Returns true if this class is the definition of a concept.
+     *
+     * @return {boolean} true if the class is a concept
+     */
+    isConcept(): boolean {
         return false;
     }
 }

--- a/packages/concerto-core/src/introspect/decorated.ts
+++ b/packages/concerto-core/src/introspect/decorated.ts
@@ -15,10 +15,29 @@
 import Decorator from './decorator';
 import IllegalModelException from './illegalmodelexception';
 
+import type { IDecorator, IRange } from '@accordproject/concerto-metamodel';
+
 // Types needed for TypeScript generation.
 /* eslint-disable no-unused-vars */
 import type ModelFile from './modelfile';
 /* eslint-enable no-unused-vars */
+
+/**
+ * The shape shared by every metamodel AST node that the introspect classes
+ * consume. The named members are the ones present on every node; the index
+ * signature is deliberate: these classes are duck-typed across node kinds
+ * (a ClassDeclaration is built from either a concept or an enum declaration,
+ * for example), so narrowing `ast` per subclass would mean a type guard at
+ * every access site. Callers wanting the precise node types should use the
+ * interfaces exported by `@accordproject/concerto-metamodel`.
+ */
+export interface AstNode {
+    $class: string;
+    name?: string;
+    location?: IRange;
+    decorators?: IDecorator[];
+    [key: string]: any;
+}
 
 /**
  * Decorated defines a model element that may have decorators attached.
@@ -29,8 +48,8 @@ import type ModelFile from './modelfile';
  * @memberof module:concerto-core
  */
 class Decorated {
-    ast: any;
-    decorators: any[] = [];
+    ast: AstNode;
+    decorators: Decorator[] = [];
     /**
      * Create a Decorated from an Abstract Syntax Tree. The AST is the
      * result of parsing.
@@ -38,7 +57,7 @@ class Decorated {
      * @param {string} ast - the AST created by the parser
      * @throws {IllegalModelException}
      */
-    constructor(ast) {
+    constructor(ast: AstNode) {
         if(!ast) {
             throw new Error('ast not specified');
         }
@@ -52,7 +71,7 @@ class Decorated {
      * @protected
      * @return {ModelFile} the owning ModelFile
      */
-    getModelFile() {
+    getModelFile(): ModelFile {
         throw new Error('not implemented');
     }
 
@@ -76,7 +95,7 @@ class Decorated {
         this.decorators = [];
 
         if(this.ast.decorators) {
-            const modelFile: any = this.getModelFile();
+            const modelFile = this.getModelFile();
             const factories = modelFile.getModelManager()?.getDecoratorFactories();
             const hasFactories = factories && factories.length > 0;
             for(let n=0; n < this.ast.decorators.length; n++ ) {
@@ -136,7 +155,7 @@ class Decorated {
      *
      * @return {Decorator[]} the decorators for the class
      */
-    getDecorators() {
+    getDecorators(): Decorator[] {
         return this.decorators;
     }
 
@@ -145,7 +164,7 @@ class Decorated {
      * @param {string} name  - the name of the decorator
      * @return {Decorator} the decorator attached to this class with the given name, or null if it does not exist.
      */
-    getDecorator(name) {
+    getDecorator(name: string): Decorator | null {
         for(let n=0; n < this.decorators.length; n++) {
             let decorator = this.decorators[n];
             if(decorator.getName() === name) {

--- a/packages/concerto-core/src/introspect/decorator.ts
+++ b/packages/concerto-core/src/introspect/decorator.ts
@@ -19,9 +19,25 @@ import IllegalModelException from './illegalmodelexception';
 
 // Types needed for TypeScript generation.
 /* eslint-disable no-unused-vars */
-import type ClassDeclaration from './classdeclaration';
-import type Property from './property';
+import type Decorated from './decorated';
+import type { AstNode } from './decorated';
+import type { IDecorator } from '@accordproject/concerto-metamodel';
 /* eslint-enable no-unused-vars */
+
+/**
+ * A decorator argument that references a type, produced from a
+ * `DecoratorTypeReference` node in the metamodel AST.
+ */
+export interface DecoratorTypeReferenceArgument {
+    type: 'Identifier';
+    name: string;
+    array: boolean;
+}
+
+/**
+ * The values a decorator can be given: a literal, or a reference to a type.
+ */
+export type DecoratorArgument = string | number | boolean | DecoratorTypeReferenceArgument;
 
 /**
  * Decorator encapsulates a decorator (annotation) on a class or property.
@@ -29,9 +45,9 @@ import type Property from './property';
  * @memberof module:concerto-core
  */
 class Decorator {
-    ast: any;
-    parent: any;
-    arguments: any[];
+    ast: AstNode;
+    parent: Decorated;
+    arguments: DecoratorArgument[];
     name!: string;
     /**
      * Create a Decorator.
@@ -39,7 +55,7 @@ class Decorator {
      * @param {Object} ast - The AST created by the parser
      * @throws {IllegalModelException}
      */
-    constructor(parent, ast) {
+    constructor(parent: Decorated, ast: AstNode) {
         this.ast = ast;
         this.parent = parent;
         this.arguments = [];
@@ -53,8 +69,8 @@ class Decorator {
     * @param {*} [fileLocation] the file location
     * @private
     */
-    handleError(level, err) {
-        Logger.dispatch(level, err);
+    handleError(level: string | undefined, err: unknown): void {
+        Logger.dispatch(level as string, err);
         if (level === 'error') {
             throw new IllegalModelException(err, this.getParent().getModelFile(), this.ast.location);
         }
@@ -74,7 +90,7 @@ class Decorator {
      * Returns the owner of this property
      * @return {ClassDeclaration|Property} the parent class or property declaration
      */
-    getParent() {
+    getParent(): Decorated {
         return this.parent;
     }
 
@@ -84,7 +100,9 @@ class Decorator {
      * @private
      */
     process() {
-        this.name = this.ast.name;
+        // a Decorator is always built from a metamodel Decorator node, which
+        // always carries a name
+        this.name = (this.ast as IDecorator).name;
         this.arguments = [];
 
         if (this.ast.arguments) {
@@ -112,7 +130,9 @@ class Decorator {
      */
     validate() {
         const mf = this.getParent().getModelFile();
-        const decoratedName = this.getParent().getFullyQualifiedName?.();
+        // ModelFile decorators have no fully qualified name, hence the optional call
+        const parent = this.getParent() as Decorated & { getFullyQualifiedName?(): string };
+        const decoratedName = parent.getFullyQualifiedName?.();
         const mm = mf.getModelManager();
         const validationOptions = mm.getDecoratorValidation();
 
@@ -160,18 +180,22 @@ class Decorator {
                             }
                             break;
                         default: {
-                            if (argType !== 'object' || arg?.type !== 'Identifier') {
+                            if (typeof arg !== 'object' || arg?.type !== 'Identifier') {
                                 const err = `Decorator ${this.getName()} has invalid decorator argument. Expected object. Found ${argType}, with value ${JSON.stringify(arg)}`;
                                 this.handleError(validationOptions.invalidDecorator, err);
                             }
-                            const typeDecl = mf.getType(arg.name);
+                            // handleError above only throws when the decorator
+                            // validation option is set to 'error', so arg may still
+                            // be something other than a type reference here
+                            const typeReference = arg as DecoratorTypeReferenceArgument;
+                            const typeDecl = mf.getType(typeReference.name);
                             if (!typeDecl) {
-                                const err = `Decorator ${this.getName()} references a type ${arg.name} which has not been defined/imported.`;
+                                const err = `Decorator ${this.getName()} references a type ${typeReference.name} which has not been defined/imported.`;
                                 this.handleError(validationOptions.invalidDecorator, err);
                             }
                             else {
                                 if (!ModelUtil.isAssignableTo(typeDecl.getModelFile(), typeDecl.getFullyQualifiedName(), property)) {
-                                    const err = `Decorator ${this.getName()} references a type ${arg.name} which cannot be assigned to the declared type ${property.getFullyQualifiedTypeName()}`;
+                                    const err = `Decorator ${this.getName()} references a type ${typeReference.name} which cannot be assigned to the declared type ${property.getFullyQualifiedTypeName()}`;
                                     this.handleError(validationOptions.invalidDecorator, err);
                                 }
                             }
@@ -191,7 +215,7 @@ class Decorator {
      * Returns the name of a decorator
      * @return {string} the name of this decorator
      */
-    getName() {
+    getName(): string {
         return this.name;
     }
 
@@ -199,7 +223,7 @@ class Decorator {
      * Returns the arguments for this decorator
      * @return {object[]} the arguments for this decorator
      */
-    getArguments() {
+    getArguments(): DecoratorArgument[] {
         return this.arguments;
     }
 
@@ -208,7 +232,7 @@ class Decorator {
      *
      * @return {boolean} true if the class is a decorator
      */
-    isDecorator() {
+    isDecorator(): boolean {
         return true;
     }
 }

--- a/packages/concerto-core/src/introspect/decorator.ts
+++ b/packages/concerto-core/src/introspect/decorator.ts
@@ -65,11 +65,10 @@ class Decorator {
     /**
     * Handles a validation error, logging and throwing as required
     * @param {string} level the log level
-    * @param {*} err the error to log
-    * @param {*} [fileLocation] the file location
+    * @param {string | Error} err the message to log, or the error that was caught
     * @private
     */
-    handleError(level: string | undefined, err: unknown): void {
+    handleError(level: string | undefined, err: string | Error): void {
         Logger.dispatch(level as string, err);
         if (level === 'error') {
             throw new IllegalModelException(err, this.getParent().getModelFile(), this.ast.location);
@@ -206,7 +205,7 @@ class Decorator {
                 }
             }
             catch (err) {
-                this.handleError(validationOptions.missingDecorator, err);
+                this.handleError(validationOptions.missingDecorator, err as Error);
             }
         }
     }

--- a/packages/concerto-core/src/introspect/decoratorfactory.ts
+++ b/packages/concerto-core/src/introspect/decoratorfactory.ts
@@ -14,9 +14,9 @@
 
 // Types needed for TypeScript generation.
 /* eslint-disable no-unused-vars */
-import type ClassDeclaration from './classdeclaration';
+import type Decorated from './decorated';
+import type { AstNode } from './decorated';
 import type Decorator from './decorator';
-import type Property from './property';
 /* eslint-enable no-unused-vars */
 
 /**
@@ -34,7 +34,7 @@ class DecoratorFactory {
      * @param {Object} ast - The AST created by the parser
      * @return {Decorator} The decorator.
      */
-    newDecorator(parent, ast) {
+    newDecorator(parent: Decorated, ast: AstNode): Decorator | null {
         throw new Error('abstract function called');
     }
 

--- a/packages/concerto-core/src/introspect/field.ts
+++ b/packages/concerto-core/src/introspect/field.ts
@@ -23,6 +23,7 @@ import { NullUtil as Util } from '@accordproject/concerto-util';
 /* eslint-disable no-unused-vars */
 import type ClassDeclaration from './classdeclaration';
 import type Validator from './validator';
+import type { AstNode } from './decorated';
 /* eslint-enable no-unused-vars */
 
 /**
@@ -36,16 +37,18 @@ import type Validator from './validator';
  * @memberof module:concerto-core
  */
 class Field extends Property {
-    validator: any;
-    defaultValue: any;
-    scalarField: any;
+    // Populated by process(), which the Property constructor calls, so these
+    // carry definite assignment assertions rather than initialisers.
+    validator!: Validator | null;
+    defaultValue!: string | number | boolean | null;
+    scalarField: Field | null;
     /**
      * Create a Field.
      * @param {ClassDeclaration} parent - The owner of this property
      * @param {Object} ast - The AST created by the parser
      * @throws {IllegalModelException}
      */
-    constructor(parent, ast) {
+    constructor(parent: ClassDeclaration, ast: AstNode) {
         super(parent, ast);
         this.scalarField = null; // cache scalar field
     }
@@ -93,7 +96,7 @@ class Field extends Property {
      * Returns the validator string for this field
      * @return {Validator} the validator for the field or null
      */
-    getValidator() {
+    getValidator(): Validator | null {
         return this.validator;
     }
 
@@ -101,7 +104,7 @@ class Field extends Property {
      * Returns the default value for the field or null if there is no default value
      * @return {string | number} the default value for the field or null
      */
-    getDefaultValue() {
+    getDefaultValue(): string | number | boolean | null {
         return this.defaultValue;
     }
 
@@ -109,7 +112,7 @@ class Field extends Property {
      * Returns a string representation of this property§
      * @return {String} the string version of the property.
      */
-    toString() {
+    toString(): string {
         return (
             'Field {name=' +
             this.name +
@@ -128,7 +131,7 @@ class Field extends Property {
      *
      * @return {boolean} true if the class is a field
      */
-    isField() {
+    isField(): boolean {
         return true;
     }
 
@@ -136,7 +139,7 @@ class Field extends Property {
      * Returns true if the field's type is a scalar
      * @returns {boolean} true if the field is a scalar type
      */
-    isTypeScalar() {
+    isTypeScalar(): boolean {
         if (this.isPrimitive()) {
             return false;
         } else {
@@ -155,7 +158,7 @@ class Field extends Property {
      * @throws {Error} throws an error if this field is not a scalar type.
      * @returns {Field} the primitive field for this scalar
      */
-    getScalarField() {
+    getScalarField(): Field {
         if(this.scalarField) {
             return this.scalarField;
         }

--- a/packages/concerto-core/src/introspect/introspector.ts
+++ b/packages/concerto-core/src/introspect/introspector.ts
@@ -15,7 +15,8 @@
 // Types needed for TypeScript generation.
 /* eslint-disable no-unused-vars */
 import type ClassDeclaration from './classdeclaration';
-import type ModelManager from '../modelmanager';
+import type Declaration from './declaration';
+import type BaseModelManager from '../basemodelmanager';
 /* eslint-enable no-unused-vars */
 
 /**
@@ -26,12 +27,12 @@ import type ModelManager from '../modelmanager';
  * @memberof module:concerto-core
  */
 class Introspector {
-    modelManager: any;
+    modelManager: BaseModelManager;
     /**
      * Create the Introspector.
      * @param {ModelManager} modelManager - the ModelManager that backs this Introspector
      */
-    constructor(modelManager) {
+    constructor(modelManager: BaseModelManager) {
         this.modelManager = modelManager;
     }
 
@@ -49,14 +50,14 @@ class Introspector {
      * Returns all the class declarations for the business network.
      * @return {ClassDeclaration[]} the array of class declarations
      */
-    getClassDeclarations() {
-        let result = [];
+    getClassDeclarations(): ClassDeclaration[] {
+        let result: ClassDeclaration[] = [];
         const modelFiles = this.modelManager.getModelFiles();
         for(let n=0; n < modelFiles.length; n++) {
             const modelFile = modelFiles[n];
 
             const filteredDeclarations = modelFile.getAllDeclarations()
-                .filter(declaration =>  !declaration.isMapDeclaration?.() && !declaration.isScalarDeclaration?.());
+                .filter((declaration: Declaration) => !declaration.isMapDeclaration?.() && !declaration.isScalarDeclaration?.()) as ClassDeclaration[];
 
             result = result.concat(filteredDeclarations);
         }
@@ -70,7 +71,7 @@ class Introspector {
      * @return {ClassDeclaration} the class declaration
      * @throws {Error} if the class declaration does not exist
      */
-    getClassDeclaration(fullyQualifiedTypeName) {
+    getClassDeclaration(fullyQualifiedTypeName: string): ClassDeclaration {
         return this.modelManager.getType(fullyQualifiedTypeName);
     }
 
@@ -79,7 +80,7 @@ class Introspector {
      * @return {ModelManager} the backing ModelManager
      * @private
      */
-    getModelManager() {
+    getModelManager(): BaseModelManager {
         return this.modelManager;
     }
 }

--- a/packages/concerto-core/src/introspect/mapdeclaration.ts
+++ b/packages/concerto-core/src/introspect/mapdeclaration.ts
@@ -71,7 +71,7 @@ class MapDeclaration extends Declaration {
             throw new IllegalModelException(`MapDeclaration must contain valid MapValueType, for MapDeclaration ${this.ast.name}` , this.modelFile, this.ast.location);
         }
 
-        // name and fqn are already set by Declaration.process() above
+        // super.process() has already set name and fqn from this.ast.name
         this.key = new MapKeyType(this, this.ast.key);
         this.value = new MapValueType(this, this.ast.value);
     }

--- a/packages/concerto-core/src/introspect/mapdeclaration.ts
+++ b/packages/concerto-core/src/introspect/mapdeclaration.ts
@@ -21,6 +21,7 @@ import ModelUtil from '../modelutil';
 // Types needed for TypeScript generation.
 /* eslint-disable no-unused-vars */
 import type ModelFile from './modelfile';
+import type { AstNode } from './decorated';
 /* eslint-enable no-unused-vars */
 
 /**
@@ -33,18 +34,17 @@ import type ModelFile from './modelfile';
  * @memberof module:concerto-core
  */
 class MapDeclaration extends Declaration {
-    modelFile: any;
-    name: any;
-    key: any;
-    value: any;
-    fqn: any;
+    // Populated by process(), which the Declaration constructor calls, so these
+    // carry definite assignment assertions rather than initialisers.
+    key!: MapKeyType;
+    value!: MapValueType;
     /**
      * Create an MapDeclaration.
      * @param {ModelFile} modelFile - the ModelFile for this class
      * @param {Object} ast - The AST created by the parser
      * @throws {IllegalModelException}
      */
-    constructor(modelFile, ast) {
+    constructor(modelFile: ModelFile, ast: AstNode) {
         super(modelFile, ast);
         this.modelFile = modelFile;
         this.process();
@@ -71,10 +71,9 @@ class MapDeclaration extends Declaration {
             throw new IllegalModelException(`MapDeclaration must contain valid MapValueType, for MapDeclaration ${this.ast.name}` , this.modelFile, this.ast.location);
         }
 
-        this.name = this.ast.name;
+        // name and fqn are already set by Declaration.process() above
         this.key = new MapKeyType(this, this.ast.key);
         this.value = new MapValueType(this, this.ast.value);
-        this.fqn = ModelUtil.getFullyQualifiedName(this.modelFile.getNamespace(), this.ast.name);
     }
 
     /**
@@ -90,41 +89,11 @@ class MapDeclaration extends Declaration {
     }
 
     /**
-     * Returns the fully qualified name of this class.
-     * The name will include the namespace if present.
-     *
-     * @return {string} the fully-qualified name of this class
-     */
-    getFullyQualifiedName() {
-        return this.fqn;
-    }
-
-    /**
-     * Returns the ModelFile that defines this class.
-     *
-     * @public
-     * @return {ModelFile} the owning ModelFile
-     */
-    getModelFile() {
-        return this.modelFile;
-    }
-
-    /**
-     * Returns the short name of a class. This name does not include the
-     * namespace from the owning ModelFile.
-     *
-     * @return {string} the short name of this class
-     */
-    getName() {
-        return this.name;
-    }
-
-    /**
      * Returns the type of the Map key property.
      *
      * @return {MapKeyType} the Map key property
      */
-    getKey() {
+    getKey(): MapKeyType {
         return this.key;
     }
 
@@ -133,7 +102,7 @@ class MapDeclaration extends Declaration {
      *
      * @return {MapValueType} the Map Value property
      */
-    getValue() {
+    getValue(): MapValueType {
         return this.value;
     }
 
@@ -141,7 +110,7 @@ class MapDeclaration extends Declaration {
      * Returns the string representation of this class
      * @return {String} the string representation of the class
      */
-    toString() {
+    toString(): string {
         return 'MapDeclaration {id=' + this.getFullyQualifiedName() + '}';
     }
 
@@ -150,7 +119,7 @@ class MapDeclaration extends Declaration {
      *
      * @return {string} what kind of declaration this is
      */
-    declarationKind() {
+    declarationKind(): string {
         return 'MapDeclaration';
     }
 
@@ -159,7 +128,7 @@ class MapDeclaration extends Declaration {
      *
      * @return {boolean} true if the class is a class
      */
-    isMapDeclaration() {
+    isMapDeclaration(): boolean {
         return true;
     }
 }

--- a/packages/concerto-core/src/introspect/mapkeytype.ts
+++ b/packages/concerto-core/src/introspect/mapkeytype.ts
@@ -22,6 +22,7 @@ import IllegalModelException from './illegalmodelexception';
 /* eslint-disable no-unused-vars */
 import type ModelFile from './modelfile';
 import type MapDeclaration from './mapdeclaration';
+import type { AstNode } from './decorated';
 /* eslint-enable no-unused-vars */
 
 /**
@@ -33,9 +34,10 @@ import type MapDeclaration from './mapdeclaration';
  * @memberof module:concerto-core
  */
 class MapKeyType extends Decorated {
-    parent: any;
-    modelFile: any;
-    type: any;
+    parent: MapDeclaration;
+    modelFile: ModelFile;
+    // Populated by process(), which this class's constructor calls.
+    type!: string;
     /**
      * Create an MapKeyType.
      * @param {MapDeclaration} parent - The owner of this property
@@ -43,7 +45,7 @@ class MapKeyType extends Decorated {
      * @param {ModelFile} modelFile - the ModelFile for the Map class
      * @throws {IllegalModelException}
      */
-    constructor(parent, ast) {
+    constructor(parent: MapDeclaration, ast: AstNode) {
         super(ast);
         this.parent = parent;
         this.modelFile = parent.getModelFile();
@@ -85,7 +87,7 @@ class MapKeyType extends Decorated {
      * @param {Object} ast - The AST created by the parser
      * @private
      */
-    processType(ast) {
+    processType(ast: AstNode) {
         switch(ast.$class) {
         case `${MetaModelNamespace}.DateTimeMapKeyType`:
             this.type = 'DateTime';
@@ -105,7 +107,7 @@ class MapKeyType extends Decorated {
      * @public
      * @return {ModelFile} the owning ModelFile
      */
-    getModelFile() {
+    getModelFile(): ModelFile {
         return this.parent.getModelFile();
     }
 
@@ -114,7 +116,7 @@ class MapKeyType extends Decorated {
      * @public
      * @return {MapDeclaration} the parent map declaration
      */
-    getParent() {
+    getParent(): MapDeclaration {
         return this.parent;
     }
 
@@ -124,7 +126,7 @@ class MapKeyType extends Decorated {
      *
      * @return {string} the short name of this class
      */
-    getType() {
+    getType(): string {
         return this.type;
     }
 
@@ -132,7 +134,7 @@ class MapKeyType extends Decorated {
      * Returns the string representation of this class
      * @return {String} the string representation of the class
      */
-    toString() {
+    toString(): string {
         return 'MapKeyType {id=' + this.getType() + '}';
     }
 
@@ -141,7 +143,7 @@ class MapKeyType extends Decorated {
      *
      * @return {boolean} true if the class is a Map Key
      */
-    isKey() {
+    isKey(): boolean {
         return true;
     }
 
@@ -150,7 +152,7 @@ class MapKeyType extends Decorated {
      *
      * @return {boolean} true if the class is a Map Value
      */
-    isValue() {
+    isValue(): boolean {
         return false;
     }
 
@@ -158,7 +160,7 @@ class MapKeyType extends Decorated {
      * Return the namespace of this map key.
      * @return {string} namespace - a namespace.
      */
-    getNamespace() {
+    getNamespace(): string {
         return this.modelFile.getNamespace();
     }
 }

--- a/packages/concerto-core/src/introspect/mapvaluetype.ts
+++ b/packages/concerto-core/src/introspect/mapvaluetype.ts
@@ -21,6 +21,7 @@ import ModelUtil from '../modelutil';
 /* eslint-disable no-unused-vars */
 import type ModelFile from './modelfile';
 import type MapDeclaration from './mapdeclaration';
+import type { AstNode } from './decorated';
 /* eslint-enable no-unused-vars */
 
 /**
@@ -32,16 +33,17 @@ import type MapDeclaration from './mapdeclaration';
  * @memberof module:concerto-core
  */
 class MapValueType extends Decorated {
-    parent: any;
-    modelFile: any;
-    type: any;
+    parent: MapDeclaration;
+    modelFile: ModelFile;
+    // Populated by process(), which this class's constructor calls.
+    type!: string;
     /**
      * Create an MapValueType.
      * @param {MapDeclaration} parent - The owner of this property
      * @param {Object} ast - The AST created by the parser
      * @throws {IllegalModelException}
      */
-    constructor(parent, ast) {
+    constructor(parent: MapDeclaration, ast: AstNode) {
         super(ast);
         this.parent = parent;
         this.modelFile = parent.getModelFile();
@@ -85,7 +87,7 @@ class MapValueType extends Decorated {
      * @param {Object} ast - The AST created by the parser
      * @private
      */
-    processType(ast) {
+    processType(ast: AstNode) {
         let decl;
         switch(this.ast.$class) {
         case `${MetaModelNamespace}.ObjectMapValueType`:
@@ -136,7 +138,7 @@ class MapValueType extends Decorated {
      * @public
      * @return {ModelFile} the owning ModelFile
      */
-    getModelFile() {
+    getModelFile(): ModelFile {
         return this.parent.getModelFile();
     }
 
@@ -145,7 +147,7 @@ class MapValueType extends Decorated {
      * @public
      * @return {MapDeclaration} the parent map declaration
      */
-    getParent() {
+    getParent(): MapDeclaration {
         return this.parent;
     }
 
@@ -155,7 +157,7 @@ class MapValueType extends Decorated {
      *
      * @return {string} the short name of this class
      */
-    getType() {
+    getType(): string {
         return this.type;
     }
 
@@ -163,7 +165,7 @@ class MapValueType extends Decorated {
      * Returns the string representation of this class
      * @return {String} the string representation of the class
      */
-    toString() {
+    toString(): string {
         return 'MapValueType {id=' + this.getType() + '}';
     }
 
@@ -172,7 +174,7 @@ class MapValueType extends Decorated {
      *
      * @return {boolean} true if the class is a Map Key
      */
-    isKey() {
+    isKey(): boolean {
         return false;
     }
 
@@ -181,7 +183,7 @@ class MapValueType extends Decorated {
      *
      * @return {boolean} true if the class is a Map Value
      */
-    isValue() {
+    isValue(): boolean {
         return true;
     }
 
@@ -189,7 +191,7 @@ class MapValueType extends Decorated {
      * Return the namespace of this map value.
      * @return {string} namespace - a namespace.
      */
-    getNamespace() {
+    getNamespace(): string {
         return this.modelFile.getNamespace();
     }
 }

--- a/packages/concerto-core/src/introspect/metamodel.ts
+++ b/packages/concerto-core/src/introspect/metamodel.ts
@@ -19,6 +19,11 @@ import Factory from '../factory';
 import Serializer from '../serializer';
 import ModelFile from '../introspect/modelfile';
 
+// Types needed for TypeScript generation.
+/* eslint-disable no-unused-vars */
+import type { AstNode } from './decorated';
+/* eslint-enable no-unused-vars */
+
 /**
  * Create a metamodel manager (for validation against the metamodel)
  * @return {ModelManager} the metamodel manager
@@ -27,7 +32,7 @@ function newMetaModelManager() {
     const metaModelManager = new ModelManager();
     const mf = new ModelFile(
         metaModelManager,
-        MetaModelUtil.metaModelAst,
+        MetaModelUtil.metaModelAst as AstNode,
         MetaModelUtil.metaModelCto,
         'concerto.metamodel'
     );

--- a/packages/concerto-core/src/introspect/modelfile.ts
+++ b/packages/concerto-core/src/introspect/modelfile.ts
@@ -32,9 +32,16 @@ import packageJson from '../../package.json';
 
 // Types needed for TypeScript generation.
 /* eslint-disable no-unused-vars */
-import type ModelManager from '../modelmanager';
+import type BaseModelManager from '../basemodelmanager';
 import type Declaration from './declaration';
+import type { AstNode } from './decorated';
+import type { IImportType, IModel } from '@accordproject/concerto-metamodel';
 /* eslint-enable no-unused-vars */
+
+/**
+ * A predicate over a Declaration, used by ModelFile#filter.
+ */
+export type FilterFunction = (declaration: Declaration) => boolean;
 
 /**
  * Class representing a Model File. A Model File contains a single namespace
@@ -44,21 +51,20 @@ import type Declaration from './declaration';
  * @memberof module:concerto-core
  */
 class ModelFile extends Decorated {
-    modelManager: any;
-    ast: any;
-    definitions: any;
-    fileName: any;
+    modelManager: BaseModelManager;
+    definitions: string | null | undefined;
+    fileName: string | null | undefined;
     external: boolean;
-    declarations: any[];
-    localTypes: any;
-    imports: any[];
-    importShortNames: Map<string, any>;
-    importWildcardNamespaces: any[];
-    importUriMap: Record<string, any>;
-    concertoVersion: any;
-    version: any;
-    namespace: any;
-    modelFile: any;
+    declarations: Declaration[];
+    localTypes: Map<string, Declaration> | null;
+    imports: AstNode[];
+    importShortNames: Map<string, string>;
+    importWildcardNamespaces: string[];
+    importUriMap: Record<string, string>;
+    concertoVersion: string | null;
+    version: string | null | undefined;
+    // Set by fromAst(), which the constructor calls
+    namespace!: string;
     /**
      * Create a ModelFile. This should only be called by framework code.
      * Use the ModelManager to manage ModelFiles.
@@ -69,7 +75,7 @@ class ModelFile extends Decorated {
      * @param {string} [fileName] - The optional filename for this modelfile
      * @throws {IllegalModelException}
      */
-    constructor(modelManager, ast, definitions?, fileName?) {
+    constructor(modelManager: BaseModelManager, ast: AstNode, definitions?: string | null, fileName?: string | null) {
         super(ast);
         this.modelManager = modelManager;
         this.external = false;
@@ -126,7 +132,7 @@ class ModelFile extends Decorated {
      * @protected
      * @return {ModelFile} the owning ModelFile
      */
-    getModelFile() {
+    getModelFile(): ModelFile {
         return this;
     }
 
@@ -134,7 +140,7 @@ class ModelFile extends Decorated {
      * Returns true
      * @returns {boolean} true
      */
-    isModelFile() {
+    isModelFile(): boolean {
         return true;
     }
 
@@ -143,7 +149,7 @@ class ModelFile extends Decorated {
      * @returns {string} the semantic version or null if the namespace for the model file is
      * unversioned
      */
-    getVersion() {
+    getVersion(): string | null | undefined {
         return this.version;
     }
 
@@ -159,7 +165,7 @@ class ModelFile extends Decorated {
      * Returns true if this ModelFile was downloaded from an external URI.
      * @return {boolean} true iff this ModelFile was downloaded from an external URI
      */
-    isExternal() {
+    isExternal(): boolean {
         return this.external;
     }
 
@@ -169,7 +175,7 @@ class ModelFile extends Decorated {
      * @return {string} the URI or null if the namespace was not associated with a URI.
      * @private
      */
-    getImportURI(namespace) {
+    getImportURI(namespace: string): string | null {
         const result = this.importUriMap[namespace];
         if(result) {
             return result;
@@ -184,7 +190,7 @@ class ModelFile extends Decorated {
      * @return {Object} keys are import declarations, values are URIs
      * @private
      */
-    getExternalImports() {
+    getExternalImports(): Record<string, string> {
         return this.importUriMap;
     }
 
@@ -203,7 +209,7 @@ class ModelFile extends Decorated {
      *
      * @return {ModelManager} The ModelManager for this ModelFile
      */
-    getModelManager() {
+    getModelManager(): BaseModelManager {
         return this.modelManager;
     }
 
@@ -213,7 +219,7 @@ class ModelFile extends Decorated {
      * @return {string[]} The array of fully-qualified names for types imported by
      * this ModelFile
      */
-    getImports() {
+    getImports(): string[] {
         let result: string[] = [];
         this.imports.forEach( imp => {
             result = result.concat(ModelUtil.importFullyQualifiedNames(imp));
@@ -359,9 +365,9 @@ class ModelFile extends Decorated {
      * @throws {Error} - if the type is not imported
      * @private
      */
-    resolveImport(type) {
+    resolveImport(type: string): string {
         if (this.importShortNames.has(type)) {
-            return this.importShortNames.get(type);
+            return this.importShortNames.get(type)!;
         }
 
         let formatter = Globalize('en').messageFormatter('modelfile-resolveimport-failfindimp');
@@ -378,9 +384,9 @@ class ModelFile extends Decorated {
      * @param {string} type - the short name of the type
      * @returns {string} - the actual imported name. If not aliased then returns the same string
      */
-    getImportedType(type) {
-        let fqn = this.resolveImport(type);
-        return fqn.split('.').pop();
+    getImportedType(type: string): string {
+        const fqn = this.resolveImport(type);
+        return fqn.split('.').pop()!;
     }
 
     /**
@@ -446,7 +452,7 @@ class ModelFile extends Decorated {
                     return null;
                 }
                 else {
-                    return this.getLocalType(type).getFullyQualifiedName();
+                    return this.getLocalType(type)!.getFullyQualifiedName();
                 }
             }
             else {
@@ -464,7 +470,7 @@ class ModelFile extends Decorated {
      * @param {string} type the short OR FQN name of the type
      * @return {ClassDeclaration} the ClassDeclaration, or null if the type does not exist
      */
-    getLocalType(type) {
+    getLocalType(type: string): Declaration | null {
         if(!this.localTypes) {
             throw new Error('Internal error: local types are not yet initialized. Do not try to resolve types inside `process`.');
         }
@@ -474,7 +480,7 @@ class ModelFile extends Decorated {
         }
 
         if (this.localTypes.has(type)) {
-            return this.localTypes.get(type);
+            return this.localTypes.get(type)!;
         } else {
             return null;
         }
@@ -541,7 +547,7 @@ class ModelFile extends Decorated {
      * Get the Namespace for this model file.
      * @return {string} The Namespace for this model file
      */
-    getNamespace() {
+    getNamespace(): string {
         return this.namespace;
     }
 
@@ -549,7 +555,7 @@ class ModelFile extends Decorated {
      * Get the filename for this model file. Note that this may be null.
      * @return {string} The filename for this model file
      */
-    getName() {
+    getName(): string | null | undefined {
         return this.fileName;
     }
 
@@ -630,8 +636,8 @@ class ModelFile extends Decorated {
      * @param {Function} type - the type of the declaration
      * @return {Object[]} the ClassDeclaration defined in the model file
      */
-    getDeclarations(type) {
-        let result: any[] = [];
+    getDeclarations<T extends Declaration>(type: new (...args: any[]) => T): T[] {
+        const result: T[] = [];
         for(let n=0; n < this.declarations.length; n++) {
             let declaration = this.declarations[n];
             if(declaration instanceof type) {
@@ -646,7 +652,7 @@ class ModelFile extends Decorated {
      * Get all declarations in this ModelFile
      * @return {ClassDeclaration[]} the ClassDeclarations defined in the model file
      */
-    getAllDeclarations() {
+    getAllDeclarations(): Declaration[] {
         return this.declarations;
     }
 
@@ -654,7 +660,7 @@ class ModelFile extends Decorated {
      * Get the definitions for this model.
      * @return {string} The definitions for this model.
      */
-    getDefinitions() {
+    getDefinitions(): string | null | undefined {
         return this.definitions;
     }
 
@@ -662,15 +668,16 @@ class ModelFile extends Decorated {
      * Get the ast for this model.
      * @return {object} The definitions for this model.
      */
-    getAst() {
-        return this.ast;
+    getAst(): IModel {
+        // a ModelFile is always constructed from a metamodel Model node
+        return this.ast as IModel;
     }
 
     /**
      * Get the expected concerto version
      * @return {string} The semver range for compatible concerto versions
      */
-    getConcertoVersion() {
+    getConcertoVersion(): string | null {
         return this.concertoVersion;
     }
 
@@ -711,13 +718,13 @@ class ModelFile extends Decorated {
      * @param {object} ast - the AST obtained from the parser
      * @private
      */
-    fromAst(ast) {
+    fromAst(ast: AstNode) {
         const nsInfo = ModelUtil.parseNamespace(ast.namespace);
 
         const namespaceParts = nsInfo.name.split('.');
         namespaceParts.forEach(part => {
             if (!ModelUtil.isValidIdentifier(part)){
-                throw new IllegalModelException(`Invalid namespace part '${part}'`, this.modelFile, this.ast.location);
+                throw new IllegalModelException(`Invalid namespace part '${part}'`, this, this.ast.location);
             }
         });
 
@@ -771,7 +778,7 @@ class ModelFile extends Decorated {
                 break;
             }
             default:
-                this.importShortNames.set(imp.name, ModelUtil.importFullyQualifiedNames(imp)[0]);
+                this.importShortNames.set((imp as IImportType).name, ModelUtil.importFullyQualifiedNames(imp)[0]);
             }
             if(imp.uri) {
                 this.importUriMap[ModelUtil.importFullyQualifiedNames(imp)[0]] = imp.uri;
@@ -881,8 +888,8 @@ class ModelFile extends Decorated {
      * @returns {ModelFile?} - the filtered ModelFile
      * @private
      */
-    filter(predicate, modelManager){
-        const declarations: any[] = [];
+    filter(predicate: FilterFunction, modelManager: BaseModelManager): ModelFile | null {
+        const declarations: AstNode[] = [];
         for (const declaration of this.declarations) {
             if (predicate(declaration)) {
                 declarations.push(declaration.ast);

--- a/packages/concerto-core/src/introspect/numbervalidator.ts
+++ b/packages/concerto-core/src/introspect/numbervalidator.ts
@@ -18,8 +18,7 @@ import Validator from './validator';
 
 // Types needed for TypeScript generation.
 /* eslint-disable no-unused-vars */
-import type { ValidatedElement } from './validator';
-import type { AstNode } from './decorated';
+import type { ValidatedElement, NumberDomainValidatorAst } from './validator';
 /* eslint-enable no-unused-vars */
 
 // Types needed for TypeScript generation.
@@ -35,6 +34,7 @@ import type ScalarDeclaration from './scalardeclaration';
  * @memberof module:concerto-core
  */
 class NumberValidator extends Validator{
+    declare validator: NumberDomainValidatorAst;
     lowerBound: number | null;
     upperBound: number | null;
 
@@ -45,18 +45,19 @@ class NumberValidator extends Validator{
      *
      * @throws {IllegalModelException}
      */
-    constructor(field: ValidatedElement, ast: AstNode) {
+    constructor(field: ValidatedElement, ast: NumberDomainValidatorAst) {
         super(field, ast);
 
         this.lowerBound = null;
         this.upperBound = null;
 
+        // the hasOwnProperty guards establish that the bound is present
         if(Object.prototype.hasOwnProperty.call(ast, 'lower')) {
-            this.lowerBound = ast.lower;
+            this.lowerBound = ast.lower as number;
         }
 
         if(Object.prototype.hasOwnProperty.call(ast, 'upper')) {
-            this.upperBound = ast.upper;
+            this.upperBound = ast.upper as number;
         }
 
         if(this.lowerBound === null && this.upperBound === null) {

--- a/packages/concerto-core/src/introspect/numbervalidator.ts
+++ b/packages/concerto-core/src/introspect/numbervalidator.ts
@@ -18,6 +18,12 @@ import Validator from './validator';
 
 // Types needed for TypeScript generation.
 /* eslint-disable no-unused-vars */
+import type { ValidatedElement } from './validator';
+import type { AstNode } from './decorated';
+/* eslint-enable no-unused-vars */
+
+// Types needed for TypeScript generation.
+/* eslint-disable no-unused-vars */
 import type Field from './field';
 import type ScalarDeclaration from './scalardeclaration';
 /* eslint-enable no-unused-vars */
@@ -29,8 +35,8 @@ import type ScalarDeclaration from './scalardeclaration';
  * @memberof module:concerto-core
  */
 class NumberValidator extends Validator{
-    lowerBound: any;
-    upperBound: any;
+    lowerBound: number | null;
+    upperBound: number | null;
 
     /**
      * Create a NumberValidator.
@@ -39,7 +45,7 @@ class NumberValidator extends Validator{
      *
      * @throws {IllegalModelException}
      */
-    constructor(field, ast) {
+    constructor(field: ValidatedElement, ast: AstNode) {
         super(field, ast);
 
         this.lowerBound = null;
@@ -80,14 +86,14 @@ class NumberValidator extends Validator{
      * Returns the lower bound for this validator, or null if not specified
      * @returns {number} the lower bound or null
      */
-    getLowerBound() {
+    getLowerBound(): number | null {
         return this.lowerBound;
     }
     /**
      * Returns the upper bound for this validator, or null if not specified
      * @returns {number} the upper bound or null
      */
-    getUpperBound() {
+    getUpperBound(): number | null {
         return this.upperBound;
     }
 
@@ -98,7 +104,7 @@ class NumberValidator extends Validator{
      * @throws {IllegalModelException}
      * @private
      */
-    validate(identifier, value) {
+    validate(identifier: string | null, value: number): void {
         if(value !== null) {
             if(this.lowerBound !== null && value < this.lowerBound) {
                 this.reportError(identifier, `Value ${value} is outside lower bound ${this.lowerBound}`);
@@ -115,7 +121,7 @@ class NumberValidator extends Validator{
      * @return {string} the string representation
      * @private
      */
-    toString() {
+    toString(): string {
         return 'NumberValidator lower: ' + this.lowerBound + ' upper: ' + this.upperBound;
     }
 
@@ -127,7 +133,7 @@ class NumberValidator extends Validator{
      * @returns {boolean} True if this validator is compatible with the other
      * validator, false otherwise.
      */
-    compatibleWith(other) {
+    compatibleWith(other: Validator | null): boolean {
         if (!(other instanceof NumberValidator)) {
             return false;
         }

--- a/packages/concerto-core/src/introspect/property.ts
+++ b/packages/concerto-core/src/introspect/property.ts
@@ -23,6 +23,8 @@ import CollectionSizeValidator from './collectionsizevalidator';
 /* eslint-disable no-unused-vars */
 import type ClassDeclaration from './classdeclaration';
 import type ModelFile from './modelfile';
+import type Decorator from './decorator';
+import type { AstNode } from './decorated';
 /* eslint-enable no-unused-vars */
 
 
@@ -34,21 +36,26 @@ import type ModelFile from './modelfile';
  * @memberof module:concerto-core
  */
 class Property extends Decorated {
-    parent: any;
-    modelFile: any;
-    name: any;
-    decorator: any;
-    type: any;
-    array: any;
-    sizeValidator: any;
-    optional: any;
+    parent: ClassDeclaration;
+    // Populated by process(), which this class's constructor calls, so these
+    // carry definite assignment assertions rather than initialisers -- an
+    // initialiser here would run before process() and be overwritten anyway.
+    name!: string;
+    /**
+     * Vestigial: only ever set to null, never read. Retained for compatibility.
+     */
+    decorator!: Decorator | null;
+    type!: string | null;
+    array!: boolean;
+    sizeValidator!: CollectionSizeValidator | null;
+    optional!: boolean;
     /**
      * Create a Property.
      * @param {ClassDeclaration} parent - the owner of this property
      * @param {Object} ast - The AST created by the parser
      * @throws {IllegalModelException}
      */
-    constructor(parent, ast) {
+    constructor(parent: ClassDeclaration, ast: AstNode) {
         super(ast);
         this.parent = parent;
         this.process();
@@ -60,7 +67,7 @@ class Property extends Decorated {
      * @public
      * @return {ModelFile} the owning ModelFile
      */
-    getModelFile() {
+    getModelFile(): ModelFile {
         return this.parent.getModelFile();
     }
 
@@ -68,7 +75,7 @@ class Property extends Decorated {
      * Returns the owner of this property
      * @return {ClassDeclaration} the parent class declaration
      */
-    getParent() {
+    getParent(): ClassDeclaration {
         return this.parent;
     }
 
@@ -81,7 +88,7 @@ class Property extends Decorated {
         super.process();
 
         if (!ModelUtil.isValidIdentifier(this.ast.name)){
-            throw new IllegalModelException(`Invalid property name '${this.ast.name}'`, this.modelFile, this.ast.location);
+            throw new IllegalModelException(`Invalid property name '${this.ast.name}'`, this.getModelFile(), this.ast.location);
         }
 
         this.name = this.ast.name;
@@ -143,7 +150,7 @@ class Property extends Decorated {
      * @throws {IllegalModelException}
      * @protected
      */
-    validate(classDecl) {
+    validate(classDecl: ClassDeclaration) {
         super.validate();
 
         if(this.type) {
@@ -174,7 +181,7 @@ class Property extends Decorated {
      * Returns the name of a property
      * @return {string} the name of this field
      */
-    getName() {
+    getName(): string {
         return this.name;
     }
 
@@ -182,7 +189,7 @@ class Property extends Decorated {
      * Returns the type of a property
      * @return {string} the type of this field
      */
-    getType() {
+    getType(): string | null {
         return this.type;
     }
 
@@ -190,7 +197,7 @@ class Property extends Decorated {
      * Returns true if the field is optional
      * @return {boolean} true if the field is optional
      */
-    isOptional() {
+    isOptional(): boolean {
         return this.optional;
     }
 
@@ -198,9 +205,10 @@ class Property extends Decorated {
      * Returns the fully qualified type name of a property
      * @return {string} the fully qualified type of this property
      */
-    getFullyQualifiedTypeName() {
+    getFullyQualifiedTypeName(): string {
         if(this.isPrimitive()) {
-            return this.type;
+            // isPrimitive() is only true when this.type is a primitive type name
+            return this.type as string;
         }
 
         const parent = this.getParent();
@@ -223,7 +231,7 @@ class Property extends Decorated {
      * Returns the fully name of a property (ns + class name + property name)
      * @return {string} the fully qualified name of this property
      */
-    getFullyQualifiedName() {
+    getFullyQualifiedName(): string {
         return this.getParent().getFullyQualifiedName() + '.' + this.getName();
     }
 
@@ -231,7 +239,7 @@ class Property extends Decorated {
      * Returns the namespace of the parent of this property
      * @return {string} the namespace of the parent of this property
      */
-    getNamespace() {
+    getNamespace(): string {
         return this.getParent().getNamespace();
     }
 
@@ -239,7 +247,7 @@ class Property extends Decorated {
      * Returns true if the field is declared as an array type
      * @return {boolean} true if the property is an array type
      */
-    isArray() {
+    isArray(): boolean {
         return this.array;
     }
 
@@ -247,7 +255,7 @@ class Property extends Decorated {
      * Returns the collection size validator for this property, if one exists.
      * @return {CollectionSizeValidator|null} the validator or null
      */
-    getSizeValidator() {
+    getSizeValidator(): CollectionSizeValidator | null {
         return this.sizeValidator;
     }
 
@@ -256,7 +264,7 @@ class Property extends Decorated {
      * Returns true if the field is declared as an enumerated value
      * @return {boolean} true if the property is an enumerated value
      */
-    isTypeEnum() {
+    isTypeEnum(): boolean {
         if(this.isPrimitive()) {
             return false;
         }
@@ -270,7 +278,7 @@ class Property extends Decorated {
      * Returns true if this property is a primitive type.
      * @return {boolean} true if the property is a primitive type.
      */
-    isPrimitive() {
+    isPrimitive(): boolean {
         return ModelUtil.isPrimitiveType(this.getType());
     }
 }

--- a/packages/concerto-core/src/introspect/property.ts
+++ b/packages/concerto-core/src/introspect/property.ts
@@ -23,7 +23,6 @@ import CollectionSizeValidator from './collectionsizevalidator';
 /* eslint-disable no-unused-vars */
 import type ClassDeclaration from './classdeclaration';
 import type ModelFile from './modelfile';
-import type Decorator from './decorator';
 import type { AstNode } from './decorated';
 /* eslint-enable no-unused-vars */
 
@@ -41,10 +40,6 @@ class Property extends Decorated {
     // carry definite assignment assertions rather than initialisers -- an
     // initialiser here would run before process() and be overwritten anyway.
     name!: string;
-    /**
-     * Vestigial: only ever set to null, never read. Retained for compatibility.
-     */
-    decorator!: Decorator | null;
     type!: string | null;
     array!: boolean;
     sizeValidator!: CollectionSizeValidator | null;
@@ -92,7 +87,6 @@ class Property extends Decorated {
         }
 
         this.name = this.ast.name;
-        this.decorator = null;
 
         if(!this.name) {
             throw new Error('No name for type ' + JSON.stringify(this.ast));

--- a/packages/concerto-core/src/introspect/relationshipdeclaration.ts
+++ b/packages/concerto-core/src/introspect/relationshipdeclaration.ts
@@ -18,6 +18,7 @@ import ModelUtil from '../modelutil';
 
 // Types needed for TypeScript generation.
 /* eslint-disable no-unused-vars */
+import type { AstNode } from './decorated';
 import type ClassDeclaration from './classdeclaration';
 /* eslint-enable no-unused-vars */
 
@@ -36,7 +37,7 @@ class RelationshipDeclaration extends Property {
      * @param {Object} ast - The AST created by the parser
      * @throws {IllegalModelException}
      */
-    constructor(parent, ast) {
+    constructor(parent: ClassDeclaration, ast: AstNode) {
         super(parent, ast);
     }
 
@@ -46,14 +47,14 @@ class RelationshipDeclaration extends Property {
      * @throws {IllegalModelException}
      * @protected
      */
-    validate(classDecl) {
+    validate(classDecl: ClassDeclaration): void {
         super.validate(classDecl);
         // relationship cannot point to primitive types
         if(!this.getType()) {
             throw new IllegalModelException('Relationship must have a type', classDecl.getModelFile(), this.ast.location);
         }
 
-        let classDeclaration: any = null;
+        let classDeclaration: ClassDeclaration | null = null;
 
         // you can't have a relationship with a primitive...
         if(ModelUtil.isPrimitiveType(this.getType())) {
@@ -91,7 +92,7 @@ class RelationshipDeclaration extends Property {
      * Returns a string representation of this property
      * @return {String} the string version of the property.
      */
-    toString() {
+    toString(): string {
         return 'RelationshipDeclaration {name=' + this.name + ', type=' + this.getFullyQualifiedTypeName() + ', array=' + this.array + ', optional=' + this.optional +'}';
     }
 
@@ -100,7 +101,7 @@ class RelationshipDeclaration extends Property {
      *
      * @return {boolean} true if the class is a relationship
      */
-    isRelationship() {
+    isRelationship(): boolean {
         return true;
     }
 }

--- a/packages/concerto-core/src/introspect/scalardeclaration.ts
+++ b/packages/concerto-core/src/introspect/scalardeclaration.ts
@@ -39,14 +39,19 @@ import type ClassDeclaration from './classdeclaration';
  * @memberof module:concerto-core
  */
 class ScalarDeclaration extends Declaration {
-    superType: any;
-    superTypeDeclaration: any;
-    idField: any;
-    timestamped: any;
-    abstract: any;
-    validator: any;
-    type: any;
-    defaultValue: any;
+    // Populated by process(), which the Declaration constructor calls, so these
+    // carry definite assignment assertions rather than initialisers.
+    // superType, superTypeDeclaration, idField, timestamped and abstract exist
+    // only to mirror ClassDeclaration's shape; the accessors below are
+    // deprecated and answer with constants.
+    superType!: string | null;
+    superTypeDeclaration!: ClassDeclaration | null;
+    idField!: string | null;
+    timestamped!: boolean;
+    abstract!: boolean;
+    validator!: Validator | null;
+    type!: string | null;
+    defaultValue!: string | number | boolean | null;
     /**
      * Process the AST and build the model
      *
@@ -60,7 +65,8 @@ class ScalarDeclaration extends Declaration {
         if (ModelUtil.isPrimitiveType(scalarName)) {
             throw new IllegalModelException(
                 `Invalid scalar name '${scalarName}'. Name conflicts with primitive type.`,
-                this.ast.name.location // Directly use the AST node's location
+                this.modelFile,
+                this.ast.location
             );
         }
         this.superType = null;
@@ -140,7 +146,7 @@ class ScalarDeclaration extends Declaration {
      * @returns {Boolean} false as scalars are never identified
      * @deprecated
      */
-    isIdentified() {
+    isIdentified(): boolean {
         return false;
     }
 
@@ -149,7 +155,7 @@ class ScalarDeclaration extends Declaration {
      * @returns {Boolean} false as scalars are never identified
      * @deprecated
      */
-    isSystemIdentified() {
+    isSystemIdentified(): boolean {
         return false;
     }
 
@@ -158,7 +164,7 @@ class ScalarDeclaration extends Declaration {
      * @return {string} as scalars are never identified
      * @deprecated
      */
-    getIdentifierFieldName() {
+    getIdentifierFieldName(): string | null {
         return null;
     }
 
@@ -168,7 +174,7 @@ class ScalarDeclaration extends Declaration {
      *
      * @return {string} the FQN name of the super type or null
      */
-    getType() {
+    getType(): string | null {
         return this.type;
     }
 
@@ -179,7 +185,7 @@ class ScalarDeclaration extends Declaration {
      * @return {string} the FQN name of the super type or null
      * @deprecated
      */
-    getSuperType() {
+    getSuperType(): string | null {
         return null;
     }
 
@@ -188,7 +194,7 @@ class ScalarDeclaration extends Declaration {
      * @return {ClassDeclaration} the super type declaration, or null if there is no super type.
      * @deprecated
      */
-    getSuperTypeDeclaration() {
+    getSuperTypeDeclaration(): ClassDeclaration | null {
         return null;
     }
 
@@ -196,7 +202,7 @@ class ScalarDeclaration extends Declaration {
      * Returns the validator string for this scalar definition
      * @return {Validator} the validator for the field or null
      */
-    getValidator() {
+    getValidator(): Validator | null {
         return this.validator;
     }
 
@@ -204,7 +210,7 @@ class ScalarDeclaration extends Declaration {
      * Returns the default value for the field or null
      * @return {string | number | null} the default value for the field or null
      */
-    getDefaultValue() {
+    getDefaultValue(): string | number | boolean | null {
         return this.defaultValue;
     }
 
@@ -212,7 +218,7 @@ class ScalarDeclaration extends Declaration {
      * Returns the string representation of this class
      * @return {String} the string representation of the class
      */
-    toString() {
+    toString(): string {
         return 'ScalarDeclaration {id=' + this.getFullyQualifiedName() + '}';
     }
 
@@ -222,7 +228,7 @@ class ScalarDeclaration extends Declaration {
      * @return {boolean} true if the class is abstract
      * @deprecated
      */
-    isAbstract() {
+    isAbstract(): boolean {
         return true;
     }
 
@@ -231,7 +237,7 @@ class ScalarDeclaration extends Declaration {
      *
      * @return {boolean} true if the class is a scalar
      */
-    isScalarDeclaration() {
+    isScalarDeclaration(): boolean {
         return true;
     }
 
@@ -241,7 +247,7 @@ class ScalarDeclaration extends Declaration {
      * @return {boolean} true if the class is an asset
      * @deprecated
      */
-    isAsset() {
+    isAsset(): boolean {
         return false;
     }
 
@@ -251,7 +257,7 @@ class ScalarDeclaration extends Declaration {
      * @return {boolean} true if the class is a participant
      * @deprecated
      */
-    isParticipant() {
+    isParticipant(): boolean {
         return false;
     }
 
@@ -261,7 +267,7 @@ class ScalarDeclaration extends Declaration {
      * @return {boolean} true if the class is a transaction
      * @deprecated
      */
-    isTransaction() {
+    isTransaction(): boolean {
         return false;
     }
 
@@ -271,7 +277,7 @@ class ScalarDeclaration extends Declaration {
      * @return {boolean} true if the class is an event
      * @deprecated
      */
-    isEvent() {
+    isEvent(): boolean {
         return false;
     }
 
@@ -281,7 +287,7 @@ class ScalarDeclaration extends Declaration {
      * @return {boolean} true if the class is a concept
      * @deprecated
      */
-    isConcept() {
+    isConcept(): boolean {
         return false;
     }
 

--- a/packages/concerto-core/src/introspect/stringvalidator.ts
+++ b/packages/concerto-core/src/introspect/stringvalidator.ts
@@ -19,7 +19,7 @@ import Validator from './validator';
 // Types needed for TypeScript generation.
 /* eslint-disable no-unused-vars */
 import type { ValidatedElement } from './validator';
-import type { AstNode } from './decorated';
+import type { IStringLengthValidator, IStringRegexValidator } from '@accordproject/concerto-metamodel';
 /* eslint-enable no-unused-vars */
 
 // Types needed for TypeScript generation.
@@ -35,6 +35,7 @@ import type ScalarDeclaration from './scalardeclaration';
  * @memberof module:concerto-core
  */
 class StringValidator extends Validator{
+    declare validator: IStringRegexValidator | undefined;
     // The metamodel makes both bounds optional, so an AST can leave either
     // absent as well as explicitly null.
     minLength: number | null | undefined;
@@ -49,7 +50,7 @@ class StringValidator extends Validator{
      *
      * @throws {IllegalModelException}
      */
-    constructor(field: ValidatedElement, validator: AstNode, lengthValidator?: AstNode) {
+    constructor(field: ValidatedElement, validator?: IStringRegexValidator, lengthValidator?: IStringLengthValidator) {
         super(field, validator);
         this.minLength = null;
         this.maxLength = null;

--- a/packages/concerto-core/src/introspect/stringvalidator.ts
+++ b/packages/concerto-core/src/introspect/stringvalidator.ts
@@ -18,6 +18,12 @@ import Validator from './validator';
 
 // Types needed for TypeScript generation.
 /* eslint-disable no-unused-vars */
+import type { ValidatedElement } from './validator';
+import type { AstNode } from './decorated';
+/* eslint-enable no-unused-vars */
+
+// Types needed for TypeScript generation.
+/* eslint-disable no-unused-vars */
 import type Field from './field';
 import type ScalarDeclaration from './scalardeclaration';
 /* eslint-enable no-unused-vars */
@@ -29,9 +35,11 @@ import type ScalarDeclaration from './scalardeclaration';
  * @memberof module:concerto-core
  */
 class StringValidator extends Validator{
-    minLength: any;
-    maxLength: any;
-    regex: any;
+    // The metamodel makes both bounds optional, so an AST can leave either
+    // absent as well as explicitly null.
+    minLength: number | null | undefined;
+    maxLength: number | null | undefined;
+    regex: RegExp | null;
 
     /**
      * Create a StringValidator.
@@ -41,7 +49,7 @@ class StringValidator extends Validator{
      *
      * @throws {IllegalModelException}
      */
-    constructor(field, validator, lengthValidator) {
+    constructor(field: ValidatedElement, validator: AstNode, lengthValidator?: AstNode) {
         super(field, validator);
         this.minLength = null;
         this.maxLength = null;
@@ -54,22 +62,25 @@ class StringValidator extends Validator{
             if(this.minLength === null && this.maxLength === null) {
                 // can't specify no upper and lower value
                 this.reportError(field.getName(), 'Invalid string length, minLength and-or maxLength must be specified.');
-            } else if (this.minLength < 0 || this.maxLength < 0) {
+            } else if ((this.minLength ?? 0) < 0 || (this.maxLength ?? 0) < 0) {
                 this.reportError(field.getName(), 'minLength and-or maxLength must be positive integers.');
             } else if (this.minLength === null || this.maxLength === null) {
                 // this is fine and means that we don't need to check whether minLength > maxLength
-            } else if(this.minLength > this.maxLength) {
+            } else if(this.minLength !== undefined && this.maxLength !== undefined && this.minLength > this.maxLength) {
                 this.reportError(field.getName(), 'minLength must be less than or equal to maxLength.');
             }
         }
 
         if (validator) {
             try {
-                const CustomRegExp = field?.parent?.getModelFile()?.getModelManager()?.options?.regExp || RegExp;
+                // ScalarDeclarations have no parent, so the custom RegExp option
+                // is only picked up for properties
+                const parent = 'getParent' in field ? field.getParent() : undefined;
+                const CustomRegExp = (parent?.getModelFile()?.getModelManager()?.options?.regExp || RegExp) as typeof RegExp;
                 this.regex = new CustomRegExp(validator.pattern, validator.flags);
             }
-            catch (exception: any) {
-                this.reportError(field.getName(), exception.message, ErrorCodes.REGEX_VALIDATOR_EXCEPTION);
+            catch (exception) {
+                this.reportError(field.getName(), (exception as Error).message, ErrorCodes.REGEX_VALIDATOR_EXCEPTION);
             }
         }
 
@@ -85,13 +96,13 @@ class StringValidator extends Validator{
      * @throws {IllegalModelException}
      * @private
      */
-    validate(identifier, value) {
+    validate(identifier: string | null, value: string): void {
         if(value !== null) {
             //Enforce string length rule first
-            if(this.minLength !== null && value.length < this.minLength) {
+            if(this.minLength !== null && this.minLength !== undefined && value.length < this.minLength) {
                 this.reportError(identifier, `The string length of '${value}' should be at least ${this.minLength} characters.`);
             }
-            if(this.maxLength !== null && value.length > this.maxLength) {
+            if(this.maxLength !== null && this.maxLength !== undefined && value.length > this.maxLength) {
                 this.reportError(identifier, `The string length of '${value}' should not exceed ${this.maxLength} characters.`);
             }
 
@@ -105,14 +116,14 @@ class StringValidator extends Validator{
      * Returns the minLength for this validator, or null if not specified
      * @returns {number} the min length or null
      */
-    getMinLength() {
+    getMinLength(): number | null | undefined {
         return this.minLength;
     }
     /**
      * Returns the maxLength for this validator, or null if not specified
      * @returns {number} the max length or null
      */
-    getMaxLength() {
+    getMaxLength(): number | null | undefined {
         return this.maxLength;
     }
 
@@ -120,7 +131,7 @@ class StringValidator extends Validator{
      * Returns the RegExp object associated with the string validator, or null if not specified
      * @returns {RegExp} the RegExp object
      */
-    getRegex() {
+    getRegex(): RegExp | null {
         return this.regex;
     }
 
@@ -132,7 +143,7 @@ class StringValidator extends Validator{
      * @returns {boolean} True if this validator is compatible with the other
      * validator, false otherwise.
      */
-    compatibleWith(other) {
+    compatibleWith(other: Validator | null): boolean {
         if (!(other instanceof StringValidator)) {
             return false;
         }

--- a/packages/concerto-core/src/introspect/validator.ts
+++ b/packages/concerto-core/src/introspect/validator.ts
@@ -16,9 +16,16 @@ import { BaseException, ErrorCodes } from '@accordproject/concerto-util';
 
 // Types needed for TypeScript generation.
 /* eslint-disable no-unused-vars */
-import type Field from './field';
+import type Property from './property';
 import type ScalarDeclaration from './scalardeclaration';
+import type { AstNode } from './decorated';
 /* eslint-enable no-unused-vars */
+
+/**
+ * The model elements a Validator can be attached to: a Property (in practice a
+ * Field) or a ScalarDeclaration.
+ */
+export type ValidatedElement = Property | ScalarDeclaration;
 
 /**
  * An Abstract field validator. Extend this class and override the
@@ -29,15 +36,15 @@ import type ScalarDeclaration from './scalardeclaration';
  * @memberof module:concerto-core
  */
 class Validator {
-    validator: any;
-    field: any;
+    validator: AstNode;
+    field: ValidatedElement;
     /**
      * Create a Property.
      * @param {Object} field - the field or scalar declaration this validator is attached to
      * @param {Object} validator - The validation string
      * @throws {IllegalModelException}
      */
-    constructor(field, validator) {
+    constructor(field: ValidatedElement, validator: AstNode) {
         this.validator = validator;
         this.field = field;
     }
@@ -48,7 +55,7 @@ class Validator {
      * @param {string} errorType the type of error
      * @throws {Error} throws an error to report the message
      */
-    reportError(id, msg, errorType=ErrorCodes.DEFAULT_VALIDATOR_EXCEPTION) {
+    reportError(id: string | null, msg: string, errorType: string = ErrorCodes.DEFAULT_VALIDATOR_EXCEPTION): never {
         throw new BaseException('Validator error for field `' + id + '`. ' + this.getFieldOrScalarDeclaration().getFullyQualifiedName() + ': ' + msg, undefined, errorType);
     }
 
@@ -66,7 +73,7 @@ class Validator {
      * Returns the field or scalar declaration that this validator applies to
      * @return {Object} the field
      */
-    getFieldOrScalarDeclaration() {
+    getFieldOrScalarDeclaration(): ValidatedElement {
         return this.field;
     }
 
@@ -77,7 +84,7 @@ class Validator {
      * @throws {IllegalModelException}
      * @private
      */
-    validate(identifier, value) {
+    validate(identifier: string | null, value: any): void {
     }
 
     /**
@@ -88,7 +95,7 @@ class Validator {
      * @returns {boolean} True if this validator is compatible with the other
      * validator, false otherwise.
      */
-    compatibleWith(other) {
+    compatibleWith(other: Validator | null): boolean {
         return false;
     }
 }

--- a/packages/concerto-core/src/introspect/validator.ts
+++ b/packages/concerto-core/src/introspect/validator.ts
@@ -18,8 +18,31 @@ import { BaseException, ErrorCodes } from '@accordproject/concerto-util';
 /* eslint-disable no-unused-vars */
 import type Property from './property';
 import type ScalarDeclaration from './scalardeclaration';
-import type { AstNode } from './decorated';
+import type {
+    ICollectionSizeValidator,
+    IDoubleDomainValidator,
+    IIntegerDomainValidator,
+    ILongDomainValidator,
+    IStringLengthValidator,
+    IStringRegexValidator,
+} from '@accordproject/concerto-metamodel';
 /* eslint-enable no-unused-vars */
+
+/**
+ * The numeric range validators, which share a shape across the three numeric
+ * primitive types.
+ */
+export type NumberDomainValidatorAst = IIntegerDomainValidator | ILongDomainValidator | IDoubleDomainValidator;
+
+/**
+ * The metamodel nodes a Validator is built from. Subclasses narrow this to the
+ * single node kind they handle.
+ */
+export type ValidatorAst =
+    | ICollectionSizeValidator
+    | IStringRegexValidator
+    | IStringLengthValidator
+    | NumberDomainValidatorAst;
 
 /**
  * The model elements a Validator can be attached to: a Property (in practice a
@@ -36,7 +59,7 @@ export type ValidatedElement = Property | ScalarDeclaration;
  * @memberof module:concerto-core
  */
 class Validator {
-    validator: AstNode;
+    validator: ValidatorAst | undefined;
     field: ValidatedElement;
     /**
      * Create a Property.
@@ -44,7 +67,7 @@ class Validator {
      * @param {Object} validator - The validation string
      * @throws {IllegalModelException}
      */
-    constructor(field: ValidatedElement, validator: AstNode) {
+    constructor(field: ValidatedElement, validator: ValidatorAst | undefined) {
         this.validator = validator;
         this.field = field;
     }

--- a/packages/concerto-core/src/model/identifiable.ts
+++ b/packages/concerto-core/src/model/identifiable.ts
@@ -15,6 +15,13 @@
 import ResourceId from './resourceid';
 import Typed from './typed';
 
+// Types needed for TypeScript generation.
+/* eslint-disable no-unused-vars */
+import type BaseModelManager from '../basemodelmanager';
+import type ClassDeclaration from '../introspect/classdeclaration';
+/* eslint-enable no-unused-vars */
+
+
 /**
  * Identifiable is an entity with a namespace, type and an identifier.
  * Applications should retrieve instances from {@link Factory}
@@ -25,8 +32,14 @@ import Typed from './typed';
  * @memberof module:concerto-core
  */
 class Identifiable extends Typed {
-    $identifierFieldName: any;
-    $identifier: any;
+    $identifierFieldName: string;
+    // Set via setIdentifier(), called from this constructor rather than
+    // assigned directly, so TS can't see the assignment for definite-assignment
+    // analysis; the field is genuinely absent for non-identified instances.
+    $identifier!: string | undefined;
+    // Genuinely polymorphic at runtime: JSDoc'd as a string, but
+    // Factory#newResource stores a Dayjs instance (or null) here for
+    // Transaction/Event timestamps.
     $timestamp: any;
     /**
      * Create an instance.
@@ -43,7 +56,7 @@ class Identifiable extends Typed {
      * @param {string} timestamp - The timestamp of this instance
      * @protected
      */
-    constructor(modelManager, classDeclaration, ns, type, id, timestamp) {
+    constructor(modelManager: BaseModelManager, classDeclaration: ClassDeclaration, ns: string, type: string, id?: string, timestamp?: unknown) {
         super(modelManager, classDeclaration, ns, type);
 
         // Cache the identifier field name

--- a/packages/concerto-core/src/model/identifiable.ts
+++ b/packages/concerto-core/src/model/identifiable.ts
@@ -19,6 +19,7 @@ import Typed from './typed';
 /* eslint-disable no-unused-vars */
 import type BaseModelManager from '../basemodelmanager';
 import type ClassDeclaration from '../introspect/classdeclaration';
+import type { Dayjs } from 'dayjs';
 /* eslint-enable no-unused-vars */
 
 
@@ -37,10 +38,10 @@ class Identifiable extends Typed {
     // assigned directly, so TS can't see the assignment for definite-assignment
     // analysis; the field is genuinely absent for non-identified instances.
     $identifier!: string | undefined;
-    // Genuinely polymorphic at runtime: JSDoc'd as a string, but
-    // Factory#newResource stores a Dayjs instance (or null) here for
-    // Transaction/Event timestamps.
-    $timestamp: any;
+    // Every DateTime value in the object model is held as a Dayjs, not a
+    // string; JSONGenerator formats it on the way out and JSONPopulator
+    // rebuilds one on the way in.
+    $timestamp?: Dayjs | null;
     /**
      * Create an instance.
      * <p>
@@ -53,10 +54,10 @@ class Identifiable extends Typed {
      * @param {string} ns - The namespace this instance.
      * @param {string} type - The type this instance.
      * @param {string} id - The identifier of this instance.
-     * @param {string} timestamp - The timestamp of this instance
+     * @param {Dayjs} [timestamp] - The timestamp of this instance
      * @protected
      */
-    constructor(modelManager: BaseModelManager, classDeclaration: ClassDeclaration, ns: string, type: string, id?: string, timestamp?: unknown) {
+    constructor(modelManager: BaseModelManager, classDeclaration: ClassDeclaration, ns: string, type: string, id?: string, timestamp?: Dayjs | null) {
         super(modelManager, classDeclaration, ns, type);
 
         // Cache the identifier field name
@@ -70,9 +71,9 @@ class Identifiable extends Typed {
 
     /**
      * Get the timestamp of this instance
-     * @return {string} The timestamp for this object
+     * @return {Dayjs} The timestamp for this object
      */
-    getTimestamp() {
+    getTimestamp(): Dayjs | null | undefined {
         return this.$timestamp;
     }
 

--- a/packages/concerto-core/src/model/relationship.ts
+++ b/packages/concerto-core/src/model/relationship.ts
@@ -15,7 +15,7 @@
 import Identifiable from './identifiable';
 import ModelUtil from '../modelutil';
 import ResourceId from './resourceid';
-import type ModelManager from '../modelmanager';
+import type BaseModelManager from '../basemodelmanager';
 import type ClassDeclaration from '../introspect/classdeclaration';
 
 /**
@@ -32,7 +32,7 @@ import type ClassDeclaration from '../introspect/classdeclaration';
  * @memberof module:concerto-core
  */
 class Relationship extends Identifiable {
-    $class: any;
+    $class: 'Relationship';
     /**
      * Create an asset. Use the Factory to create instances.
      * <p>
@@ -48,7 +48,7 @@ class Relationship extends Identifiable {
      * @param {string} timestamp - The timestamp of this instance
      * @private
      */
-    constructor(modelManager: ModelManager, classDeclaration: ClassDeclaration, ns: string, type: string, id: string, timestamp?: string) {
+    constructor(modelManager: BaseModelManager, classDeclaration: ClassDeclaration, ns: string, type: string, id: string, timestamp?: string) {
         super(modelManager, classDeclaration, ns, type, id, timestamp);
         // we use this metatag to identify the instance as a relationship
         this.$class = 'Relationship';

--- a/packages/concerto-core/src/model/relationship.ts
+++ b/packages/concerto-core/src/model/relationship.ts
@@ -17,6 +17,7 @@ import ModelUtil from '../modelutil';
 import ResourceId from './resourceid';
 import type BaseModelManager from '../basemodelmanager';
 import type ClassDeclaration from '../introspect/classdeclaration';
+import type { Dayjs } from 'dayjs';
 
 /**
  * A Relationship is a typed pointer to an instance. I.e the relationship
@@ -45,10 +46,10 @@ class Relationship extends Identifiable {
      * @param {string} ns - The namespace this instance.
      * @param {string} type - The type this instance.
      * @param {string} id - The identifier of this instance.
-     * @param {string} timestamp - The timestamp of this instance
+     * @param {Dayjs} [timestamp] - The timestamp of this instance
      * @private
      */
-    constructor(modelManager: BaseModelManager, classDeclaration: ClassDeclaration, ns: string, type: string, id: string, timestamp?: string) {
+    constructor(modelManager: BaseModelManager, classDeclaration: ClassDeclaration, ns: string, type: string, id: string, timestamp?: Dayjs | null) {
         super(modelManager, classDeclaration, ns, type, id, timestamp);
         // we use this metatag to identify the instance as a relationship
         this.$class = 'Relationship';

--- a/packages/concerto-core/src/model/resource.ts
+++ b/packages/concerto-core/src/model/resource.ts
@@ -18,6 +18,7 @@ import Identifiable from './identifiable';
 /* eslint-disable no-unused-vars */
 import type BaseModelManager from '../basemodelmanager';
 import type ClassDeclaration from '../introspect/classdeclaration';
+import type { Dayjs } from 'dayjs';
 /* eslint-enable no-unused-vars */
 
 
@@ -53,10 +54,10 @@ class Resource extends Identifiable {
      * @param {string} ns - The namespace this instance.
      * @param {string} type - The type this instance.
      * @param {string} id - The identifier of this instance.
-     * @param {string} timestamp - The timestamp of this instance
+     * @param {Dayjs} [timestamp] - The timestamp of this instance
      * @private
      */
-    constructor(modelManager: BaseModelManager, classDeclaration: ClassDeclaration, ns: string, type: string, id?: string, timestamp?: unknown) {
+    constructor(modelManager: BaseModelManager, classDeclaration: ClassDeclaration, ns: string, type: string, id?: string, timestamp?: Dayjs | null) {
         super(modelManager, classDeclaration, ns, type, id, timestamp);
     }
 

--- a/packages/concerto-core/src/model/resource.ts
+++ b/packages/concerto-core/src/model/resource.ts
@@ -14,6 +14,13 @@
 
 import Identifiable from './identifiable';
 
+// Types needed for TypeScript generation.
+/* eslint-disable no-unused-vars */
+import type BaseModelManager from '../basemodelmanager';
+import type ClassDeclaration from '../introspect/classdeclaration';
+/* eslint-enable no-unused-vars */
+
+
 /**
  *
  * Resource is an instance that has a type. The type of the resource
@@ -49,7 +56,7 @@ class Resource extends Identifiable {
      * @param {string} timestamp - The timestamp of this instance
      * @private
      */
-    constructor(modelManager, classDeclaration, ns, type, id, timestamp) {
+    constructor(modelManager: BaseModelManager, classDeclaration: ClassDeclaration, ns: string, type: string, id?: string, timestamp?: unknown) {
         super(modelManager, classDeclaration, ns, type, id, timestamp);
     }
 

--- a/packages/concerto-core/src/model/resourceid.ts
+++ b/packages/concerto-core/src/model/resourceid.ts
@@ -28,9 +28,9 @@ const RESOURCE_SCHEME = 'resource';
  * @property {String} id
  */
 class ResourceId {
-    namespace: any;
-    type: any;
-    id: any;
+    namespace: string;
+    type: string;
+    id: string;
     /**
      * <strong>Note: only for use by internal framework code.</strong>
      * @param {String} namespace - Namespace containing the type.

--- a/packages/concerto-core/src/model/typed.ts
+++ b/packages/concerto-core/src/model/typed.ts
@@ -18,7 +18,8 @@ import { NullUtil as Util } from '@accordproject/concerto-util';
 // Types needed for TypeScript generation.
 /* eslint-disable no-unused-vars */
 import type ClassDeclaration from '../introspect/classdeclaration';
-import type ModelManager from '../modelmanager';
+import type BaseModelManager from '../basemodelmanager';
+import type Field from '../introspect/field';
 /* eslint-enable no-unused-vars */
 
 /**
@@ -30,10 +31,10 @@ import type ModelManager from '../modelmanager';
  * @memberof module:concerto-core
  */
 class Typed {
-    $modelManager: any;
-    $classDeclaration: any;
-    $namespace: any;
-    $type: any;
+    $modelManager: BaseModelManager;
+    $classDeclaration: ClassDeclaration;
+    $namespace: string;
+    $type: string;
     /**
      * Create an instance.
      * <p>
@@ -47,7 +48,7 @@ class Typed {
      * @param {string} type - The type this instance.
      * @protected
      */
-    constructor(modelManager, classDeclaration, ns, type) {
+    constructor(modelManager: BaseModelManager, classDeclaration: ClassDeclaration, ns: string, type: string) {
         this.$modelManager = modelManager;
         this.$classDeclaration = classDeclaration;
         this.$namespace = ns;
@@ -70,7 +71,7 @@ class Typed {
      * @return {ModelManager} The ModelManager for this object
      * @private
      */
-    getModelManager() {
+    getModelManager(): BaseModelManager {
         return this.$modelManager;
     }
 
@@ -78,7 +79,7 @@ class Typed {
      * Get the type of the instance (a short name, not including namespace).
      * @return {string} The type of this object
      */
-    getType() {
+    getType(): string {
         return this.$type;
     }
 
@@ -86,7 +87,7 @@ class Typed {
      * Get the fully-qualified type name of the instance (including namespace).
      * @return {string} The fully-qualified type name of this object
      */
-    getFullyQualifiedType() {
+    getFullyQualifiedType(): string {
         return this.$classDeclaration.getFullyQualifiedName();
     }
 
@@ -94,7 +95,7 @@ class Typed {
      * Get the namespace of the instance.
      * @return {string} The namespace of this object
      */
-    getNamespace() {
+    getNamespace(): string {
         return this.$namespace;
     }
 
@@ -104,7 +105,7 @@ class Typed {
      * @return {ClassDeclaration} - the class declaration for this instance
      * @private
      */
-    getClassDeclaration() {
+    getClassDeclaration(): ClassDeclaration {
         return this.$classDeclaration;
     }
 
@@ -135,12 +136,15 @@ class Typed {
      * Sets the fields to their default values, based on the model
      * @private
      */
-    assignFieldDefaults() {
+    assignFieldDefaults(): void {
         let classDeclaration = this.getClassDeclaration();
         let fields = classDeclaration.getProperties();
 
         for (let n = 0; n < fields.length; n++) {
-            let field = fields[n];
+            // isTypeScalar/isField/getDefaultValue/getScalarField are Field-only
+            // members, absent on other Property subtypes (e.g. relationships) -
+            // the optional chaining below guards those cases at runtime.
+            let field = fields[n] as Field;
             if(field.isTypeScalar?.()) {
                 field = field.getScalarField();
             }
@@ -179,7 +183,7 @@ class Typed {
      * @returns {boolean} True if this instance is an instance of the specified fully
      * qualified type name, false otherwise.
      */
-    instanceOf(fqt) {
+    instanceOf(fqt: string): boolean {
         // Check to see if this is an exact instance of the specified type.
         const classDeclaration = this.getClassDeclaration();
         if (classDeclaration.getFullyQualifiedName() === fqt) {

--- a/packages/concerto-core/src/model/validatedresource.ts
+++ b/packages/concerto-core/src/model/validatedresource.ts
@@ -15,6 +15,11 @@
 import { TypedStack } from '@accordproject/concerto-util';
 import Resource from './resource';
 
+// Types needed for TypeScript generation.
+/* eslint-disable no-unused-vars */
+import type ResourceValidator from '../serializer/resourcevalidator';
+/* eslint-enable no-unused-vars */
+
 /**
  * ValidatedResource is a Resource that can validate that property
  * changes (or the whole instance) do not violate the structure of
@@ -25,7 +30,7 @@ import Resource from './resource';
  * @memberof module:concerto-core
  */
 class ValidatedResource extends Resource {
-    $validator: any;
+    $validator: ResourceValidator;
     /**
      * This constructor should not be called directly.
      * Use the Factory class to create instances.
@@ -97,15 +102,16 @@ class ValidatedResource extends Resource {
                 propName + ' which is not declared as an array in the model.');
         }
 
-        const parameters:any = {};
-        let newArray: any[] = [];
+        let newArray: unknown[] = [];
         if(this[propName]) {
             newArray = this[propName].slice(0);
         }
         newArray.push(value);
-        parameters.stack = new TypedStack(newArray);
-        parameters.modelManager = this.getModelManager();
-        parameters.rootResourceIdentifier = this.getFullyQualifiedIdentifier();
+        const parameters = {
+            stack: new TypedStack(newArray),
+            modelManager: this.getModelManager(),
+            rootResourceIdentifier: this.getFullyQualifiedIdentifier(),
+        };
         field.accept(this.$validator, parameters);
         super.addArrayValue(propName, value);
     }

--- a/packages/concerto-core/src/modelloader.ts
+++ b/packages/concerto-core/src/modelloader.ts
@@ -103,8 +103,7 @@ class ModelLoader {
      */
     static async loadModelManagerFromModelFiles(modelFiles: Array<string | ModelFile>, fileNames?: string[], options: ModelLoaderOptions = { offline: false }) {
         const opts = options || { offline: false };
-        
-        // FIX: Cast to 'any' to bypass strict constructor signature check
+
         let modelManager = new ModelManager(opts);
 
         // Load system model

--- a/packages/concerto-core/src/modelutil.ts
+++ b/packages/concerto-core/src/modelutil.ts
@@ -15,6 +15,11 @@
 import { MetaModelNamespace } from '@accordproject/concerto-metamodel';
 import { MetaModelUtil } from '@accordproject/concerto-metamodel';
 import semver from 'semver';
+
+// Types needed for TypeScript generation.
+/* eslint-disable no-unused-vars */
+import type { SemVer } from 'semver';
+/* eslint-enable no-unused-vars */
 import Globalize from './globalize';
 
 // Types needed for TypeScript generation.
@@ -120,7 +125,7 @@ class ModelUtil {
         }
 
         const parts = ns.split('@');
-        let version: any = parts[1];
+        let version: string | SemVer | null = parts[1];
         if(parts.length > 2) {
             throw new Error(`Invalid namespace ${ns}`);
         }
@@ -246,8 +251,8 @@ class ModelUtil {
      * @param {string} name - the name of the identifier to test.
      * @returns {boolean} true if the identifier is valid.
      */
-    static isValidIdentifier(name) {
-        return ID_REGEX.test(name);
+    static isValidIdentifier(name: string | undefined): name is string {
+        return ID_REGEX.test(name as string);
     }
 
     /**

--- a/packages/concerto-core/src/serializer.ts
+++ b/packages/concerto-core/src/serializer.ts
@@ -29,7 +29,9 @@ const baseDefaultOptions = {
 // Types needed for TypeScript generation.
 /* eslint-disable no-unused-vars */
 import type Factory from './factory';
-import type ModelManager from './modelmanager';
+import type BaseModelManager from './basemodelmanager';
+import type { SerializerOptions } from './types';
+import type { JsonPopulatorParameters } from './serializer/jsonpopulator';
 import type Resource from './model/resource';
 /* eslint-enable no-unused-vars */
 
@@ -41,16 +43,16 @@ import type Resource from './model/resource';
  * @memberof module:concerto-core
  */
 class Serializer {
-    factory: any;
-    modelManager: any;
-    defaultOptions: any;
+    factory: Factory;
+    modelManager: BaseModelManager;
+    defaultOptions: SerializerOptions;
     /**
      * Create a Serializer.
      * @param {Factory} factory - The Factory to use to create instances
      * @param {ModelManager} modelManager - The ModelManager to use for validation etc.
      * @param {object} [options] - Serializer options
      */
-    constructor(factory, modelManager, options?) {
+    constructor(factory: Factory, modelManager: BaseModelManager, options?: SerializerOptions) {
         if(!factory) {
             throw new Error(Globalize.formatMessage('serializer-constructor-factorynull'));
         } else if(!modelManager) {
@@ -66,7 +68,7 @@ class Serializer {
      * Set the default options for the serializer.
      * @param {Object} newDefaultOptions The new default options for the serializer.
      */
-    setDefaultOptions(newDefaultOptions) {
+    setDefaultOptions(newDefaultOptions: SerializerOptions) {
         // Combine the specified default options with the base default
         this.defaultOptions = Object.assign({}, baseDefaultOptions, newDefaultOptions);
     }
@@ -100,11 +102,12 @@ class Serializer {
             throw new Error(Globalize.formatMessage('serializer-tojson-notcobject'));
         }
 
-        const parameters: any = {};
-        parameters.stack = new TypedStack(resource);
-        parameters.modelManager = this.modelManager;
-        parameters.seenResources = new Set();
-        parameters.dedupeResources = new Set();
+        const parameters = {
+            stack: new TypedStack(resource),
+            modelManager: this.modelManager,
+            seenResources: new Set(),
+            dedupeResources: new Set(),
+        };
         const classDeclaration = this.modelManager.getType( resource.getFullyQualifiedType() );
 
         // validate the resource against the model
@@ -184,11 +187,12 @@ class Serializer {
 
         // populate the resource based on the jsonObject
         // by walking the classDeclaration
-        const parameters: any = {};
-        parameters.jsonStack = new TypedStack(jsonObject);
-        parameters.resourceStack = new TypedStack(resource);
-        parameters.modelManager = this.modelManager;
-        parameters.factory = this.factory;
+        const parameters: JsonPopulatorParameters = {
+            jsonStack: new TypedStack(jsonObject),
+            resourceStack: new TypedStack(resource),
+            modelManager: this.modelManager,
+            factory: this.factory,
+        };
         const populator = new JSONPopulator(options.acceptResourcesForRelationships === true, false, options.utcOffset, options.strictQualifiedDateTimes === true);
         classDeclaration.accept(populator, parameters);
 

--- a/packages/concerto-core/src/serializer/jsongenerator.ts
+++ b/packages/concerto-core/src/serializer/jsongenerator.ts
@@ -28,11 +28,11 @@ import { NullUtil as Util } from '@accordproject/concerto-util';
  * @memberof module:concerto-core
  */
 class JSONGenerator {
-    convertResourcesToRelationships: any;
-    permitResourcesForRelationships: any;
-    deduplicateResources: any;
-    convertResourcesToId: any;
-    utcOffset: any;
+    convertResourcesToRelationships: boolean | undefined;
+    permitResourcesForRelationships: boolean | undefined;
+    deduplicateResources: boolean | undefined;
+    convertResourcesToId: boolean | undefined;
+    utcOffset: number;
 
     /**
      * Constructor.
@@ -48,7 +48,7 @@ class JSONGenerator {
      * are specified for relationship fields into their id, false by default.
      * @param {number} [utcOffset] UTC Offset for DateTime values.
      */
-    constructor(convertResourcesToRelationships?, permitResourcesForRelationships?, deduplicateResources?, convertResourcesToId?, ergo?, utcOffset?) {
+    constructor(convertResourcesToRelationships?: boolean, permitResourcesForRelationships?: boolean, deduplicateResources?: boolean, convertResourcesToId?: boolean, ergo?: boolean, utcOffset?: number) {
         this.convertResourcesToRelationships = convertResourcesToRelationships;
         this.permitResourcesForRelationships = permitResourcesForRelationships;
         this.deduplicateResources = deduplicateResources;
@@ -142,8 +142,8 @@ class JSONGenerator {
             throw new Error('Expected a Resource, but found ' + obj);
         }
 
-        let result: any = {};
-        let id: any = null;
+        let result: Record<string, unknown> = {};
+        let id: string | null = null;
 
         if (obj.isIdentifiable() && this.deduplicateResources) {
             id = obj.toURI();
@@ -185,7 +185,7 @@ class JSONGenerator {
         const obj = parameters.stack.pop();
         let result;
         if (field.isArray()) {
-            let array: any[] = [];
+            let array: unknown[] = [];
             // Walk the object
             for (let index in obj) {
                 const item = obj[index];
@@ -256,7 +256,7 @@ class JSONGenerator {
         let result;
 
         if (relationshipDeclaration.isArray()) {
-            let array: any[] = [];
+            let array: unknown[] = [];
             // walk the object
             for (let index in obj) {
                 const item = obj[index];

--- a/packages/concerto-core/src/serializer/jsonpopulator.ts
+++ b/packages/concerto-core/src/serializer/jsonpopulator.ts
@@ -19,7 +19,7 @@ import ModelUtil from '../modelutil';
 import ValidationException from './validationexception';
 import dayjs from '../dayjs-setup';
 import type Factory from '../factory';
-import type ModelManager from '../modelmanager';
+import type BaseModelManager from '../basemodelmanager';
 import type Declaration from '../introspect/declaration';
 import type ClassDeclaration from '../introspect/classdeclaration';
 import type RelationshipDeclaration from '../introspect/relationshipdeclaration';
@@ -37,12 +37,12 @@ type Stack<T> = {
     stack: T[];
 };
 
-type JsonPopulatorParameters = {
+export type JsonPopulatorParameters = {
     jsonStack: Stack<String | { [key: string]: unknown; $class: string } | { [key: string]: unknown; $class: string }[]>;
     resourceStack: Stack<Resource>;
     path?: TypedStack<string>;
     factory: Factory;
-    modelManager: ModelManager;
+    modelManager: BaseModelManager;
     acceptResourcesForRelationships?: boolean;
     utcOffset?: number;
     strictQualifiedDateTimes?: boolean;
@@ -178,7 +178,9 @@ class JSONPopulator {
             if (value !== null) {
                 parameters.path?.push(`.${property}`);
                 parameters.jsonStack.push(value);
-                const classProperty = classDeclaration.getProperty(property);
+                // validateProperties() above has already established that every
+                // name in `properties` resolves to a property on the declaration
+                const classProperty = classDeclaration.getProperty(property)!;
                 resourceObj[property] = classProperty.accept(this,parameters);
                 parameters.path?.pop();
             }

--- a/packages/concerto-core/src/serializer/resourcevalidator.ts
+++ b/packages/concerto-core/src/serializer/resourcevalidator.ts
@@ -21,6 +21,11 @@ import ValidationException from './validationexception';
 import Globalize from '../globalize';
 import dayjs from '../dayjs-setup';
 
+// Types needed for TypeScript generation.
+/* eslint-disable no-unused-vars */
+import type { SerializerOptions } from '../types';
+/* eslint-enable no-unused-vars */
+
 /**
  * <p>
  * Validates a Resource or Field against the models defined in the ModelManager.
@@ -40,7 +45,7 @@ import dayjs from '../dayjs-setup';
  * @memberof module:concerto-core
  */
 class ResourceValidator {
-    options: any;
+    options: SerializerOptions;
 
     /**
      * ResourceValidator constructor
@@ -51,7 +56,7 @@ class ResourceValidator {
      * are specified for relationship fields into relationships, false by default.
      * @param {boolean} options.permitResourcesForRelationships - Permit resources in the
      */
-    constructor(options?) {
+    constructor(options?: SerializerOptions) {
         this.options = options || {};
     }
     /**
@@ -514,7 +519,7 @@ class ResourceValidator {
      */
     static reportFieldTypeViolation(id, propName, value, field) {
         let isArray = field.isArray() ? '[]' : '';
-        let typeOfValue = typeof value;
+        let typeOfValue: string = typeof value;
 
         if(value instanceof Identifiable) {
             typeOfValue = value.getFullyQualifiedType();

--- a/packages/concerto-core/src/serializer/valuegenerator.ts
+++ b/packages/concerto-core/src/serializer/valuegenerator.ts
@@ -16,6 +16,11 @@ import { loremIpsum } from 'lorem-ipsum';
 import RandExp from 'randexp';
 import dayjs from '../dayjs-setup';
 
+// Types needed for TypeScript generation.
+/* eslint-disable no-unused-vars */
+import type { Dayjs } from 'dayjs';
+/* eslint-enable no-unused-vars */
+
 /**
  * Generate a random number within a given range with
  * a prescribed precision and inside a global range
@@ -156,7 +161,7 @@ const getRegexString = (regex, minLength, maxLength) => {
  * @private
  */
 class EmptyValueGenerator {
-    currentDate: any;
+    currentDate: Dayjs;
     /**
      * This constructor should not be called directly.
      * @private
@@ -396,5 +401,5 @@ class ValueGeneratorFactory {
     }
 }
 
-export { ValueGeneratorFactory };
+export { ValueGeneratorFactory, EmptyValueGenerator, SampleValueGenerator };
 export default ValueGeneratorFactory;

--- a/packages/concerto-core/src/typenotfoundexception.ts
+++ b/packages/concerto-core/src/typenotfoundexception.ts
@@ -23,7 +23,7 @@ import Globalize from './globalize';
  * @memberof module:concerto-core
  */
 class TypeNotFoundException extends BaseException {
-    typeName: any;
+    typeName: string;
     /**
      * Constructor. If the optional 'message' argument is not supplied, it will be set to a default value that
      * includes the type name.
@@ -32,12 +32,12 @@ class TypeNotFoundException extends BaseException {
      * @param {string} component - the optional component which throws this error
      * @param {string} errorType - the error code related to the error
      */
-    constructor(typeName, message?, component?, errorType = ErrorCodes.TYPE_NOT_FOUND_EXCEPTION) {
+    constructor(typeName: string, message?: string, component?: string, errorType = ErrorCodes.TYPE_NOT_FOUND_EXCEPTION) {
         if (!message) {
             const formatter = Globalize.messageFormatter('typenotfounderror-defaultmessage');
             message = formatter({
                 typeName: typeName
-            });
+            }) as string;
         }
 
         // FIX: Explicitly default to '@accordproject/concerto-core' if component is not provided.
@@ -50,7 +50,7 @@ class TypeNotFoundException extends BaseException {
      * Get the name of the type that was not found.
      * @returns {string} fully qualified type name.
      */
-    getTypeName() {
+    getTypeName(): string {
         return this.typeName;
     }
 

--- a/packages/concerto-core/src/types.ts
+++ b/packages/concerto-core/src/types.ts
@@ -14,6 +14,16 @@
 
 'use strict';
 
+// Types needed for TypeScript generation.
+/* eslint-disable no-unused-vars */
+import type { IDecorator } from '@accordproject/concerto-metamodel';
+import type { TypedStack } from '@accordproject/concerto-util';
+import type BaseModelManager from './basemodelmanager';
+import type Factory from './factory';
+import type Typed from './model/typed';
+import type { EmptyValueGenerator } from './serializer/valuegenerator';
+/* eslint-enable no-unused-vars */
+
 export interface ModelManagerOptions {
     regExp?: RegExp;
     metamodelValidation?: boolean;
@@ -34,4 +44,97 @@ export interface ModelFileSource {
     ast: unknown;
     definitions: string | null;
     fileName: string;
+}
+
+/**
+ * Options accepted by Serializer#toJSON, Serializer#fromJSON and the
+ * visitors they drive.
+ */
+export interface SerializerOptions {
+    /** validate the structure of the Resource against its model. Defaults to true. */
+    validate?: boolean;
+    /** convert resources supplied for relationship fields into relationships. */
+    convertResourcesToRelationships?: boolean;
+    /** permit resources in the place of relationships, serializing them as resources. */
+    permitResourcesForRelationships?: boolean;
+    /** accept JSON objects in the place of relationships when deserializing. */
+    acceptResourcesForRelationships?: boolean;
+    /** serialize repeated resources once, writing only $id for later instances. */
+    deduplicateResources?: boolean;
+    /** convert resources supplied for relationship fields into their id. */
+    convertResourcesToId?: boolean;
+    /** UTC offset, in minutes, for DateTime values. */
+    utcOffset?: number;
+    /** only allow fully-qualified date-times with offsets. */
+    strictQualifiedDateTimes?: boolean;
+}
+
+/** Whether to upsert or append the decorator. */
+export type DecoratorCommandType = 'UPSERT' | 'APPEND';
+
+/** Map declaration elements that can be targeted by a decorator command. */
+export type DecoratorCommandMapElement = 'KEY' | 'VALUE' | 'KEY_VALUE';
+
+/**
+ * Which model elements to add the decorator to. Any absent element is a
+ * wildcard. Mirrors `CommandTarget` in the decorator command set model.
+ */
+export interface DecoratorCommandTarget {
+    $class?: string;
+    namespace?: string;
+    declaration?: string;
+    property?: string;
+    /** mutually exclusive with `property` */
+    properties?: string[];
+    type?: string;
+    mapElement?: DecoratorCommandMapElement;
+}
+
+/**
+ * Applies a decorator to a given target. Mirrors `Command` in the decorator
+ * command set model.
+ */
+export interface DecoratorCommand {
+    $class?: string;
+    target: DecoratorCommandTarget;
+    decorator: IDecorator;
+    type: DecoratorCommandType;
+    decoratorNamespace?: string;
+}
+
+/**
+ * A named and versioned set of decorator commands. Mirrors
+ * `DecoratorCommandSet` in the decorator command set model.
+ */
+export interface DecoratorCommandSet {
+    $class?: string;
+    name: string;
+    version: string;
+    includes?: Array<{ name: string; version: string }>;
+    commands: DecoratorCommand[];
+}
+
+/**
+ * Field generation options accepted by Factory#newResource and friends.
+ */
+export interface GenerateOptions {
+    /** skip validation of the created instance. */
+    disableValidation?: boolean;
+    /** 'sample' for realistic values, 'empty' for empty ones. */
+    generate?: string;
+    /** also generate values for optional fields. */
+    includeOptionalFields?: boolean;
+}
+
+/**
+ * The parameters an InstanceGenerator walks a declaration with, assembled by
+ * Factory#parseGenerateOptions.
+ */
+export interface InstanceGeneratorParameters {
+    modelManager: BaseModelManager;
+    factory: Factory;
+    valueGenerator: EmptyValueGenerator;
+    includeOptionalFields: boolean;
+    stack?: TypedStack<Typed>;
+    seen?: string[];
 }

--- a/packages/concerto-core/test/introspect/classdeclaration.js
+++ b/packages/concerto-core/test/introspect/classdeclaration.js
@@ -411,6 +411,19 @@ describe('ClassDeclaration', () => {
         });
     });
 
+    describe('#declarationKind', () => {
+        it('should throw on the abstract base class', () => {
+            const classDecl = new ClassDeclaration(modelFile, {
+                $class: `${MetaModelNamespace}.ConceptDeclaration`,
+                name: 'suchName',
+                properties: []
+            });
+            (() => {
+                classDecl.declarationKind();
+            }).should.throw(/not implemented/);
+        });
+    });
+
     describe('#getDirectSubclasses', function() {
         it('should return an array with Sub and Sub2 given they extend Super', function() {
             const modelFileNames = [

--- a/packages/concerto-core/test/introspect/declaration.js
+++ b/packages/concerto-core/test/introspect/declaration.js
@@ -76,4 +76,17 @@ describe('Declaration', () => {
             should.equal(declaration.toString(), null);
         });
     });
+
+    describe('declaration kind predicates', () => {
+        it('should all be false on the base class', () => {
+            declaration.isAsset().should.equal(false);
+            declaration.isParticipant().should.equal(false);
+            declaration.isTransaction().should.equal(false);
+            declaration.isEvent().should.equal(false);
+            declaration.isConcept().should.equal(false);
+            declaration.isEnum().should.equal(false);
+            declaration.isClassDeclaration().should.equal(false);
+            declaration.isScalarDeclaration().should.equal(false);
+        });
+    });
 });

--- a/packages/concerto-cto/src/external.ts
+++ b/packages/concerto-cto/src/external.ts
@@ -50,6 +50,12 @@ function updateModels(models: IModels, newModel: IModel): IModels {
 }
 
 /**
+ * Options passed through to the underlying FileDownloader (and, in turn, to the
+ * FileLoader's `fetch` call) when resolving external model dependencies.
+ */
+export type ResolveExternalOptions = RequestInit;
+
+/**
  * Downloads all ModelFiles that are external dependencies and adds or
  * updates them in this ModelManager.
  * @param {*} models - the AST for all the known models
@@ -58,7 +64,7 @@ function updateModels(models: IModels, newModel: IModel): IModels {
  * @throws {IllegalModelException} if the models fail validation
  * @return {Promise} a promise when the download and update operation is completed.
  */
-export async function resolveExternal(models: IModels, options?: any, fileDownloader?: any): Promise<IModels> {
+export async function resolveExternal(models: IModels, options?: ResolveExternalOptions, fileDownloader?: FileDownloader<IModel>): Promise<IModels> {
     const NAME = 'updateExternalModels';
     debugLog(NAME, 'updateExternalModels', options);
 
@@ -79,9 +85,9 @@ export async function resolveExternal(models: IModels, options?: any, fileDownlo
  * Creates a default file downloader
  * @return {FileDownloader} a default file downloader instance
  */
-export function createDefaultFileDownloader(): any {
+export function createDefaultFileDownloader(): FileDownloader<IModel> {
     // How to create a modelfile from the external content
-    const processFile = (name: string, data: any): any => {
+    const processFile = (name: string, data: string): IModel => {
         // Note: JSON URLs seem to be already parsed in 'data'
         // return { ast: data, data, name };
         if (pathBrowserify.extname(name) === '.cto') {

--- a/packages/concerto-cto/src/parserMain.ts
+++ b/packages/concerto-cto/src/parserMain.ts
@@ -12,13 +12,23 @@
  * limitations under the License.
  */
 
-import { MetaModelNamespace, IModels } from '@accordproject/concerto-metamodel';
+import { MetaModelNamespace, IModel, IModels } from '@accordproject/concerto-metamodel';
 
 import * as Parser from './parser';
 import ParseException from './parseexception';
 
 interface ParseOptions {
     skipLocationNodes?: boolean;
+}
+
+// The shape of the error thrown by the generated peg.js parser (parser.js's
+// `peg$SyntaxError`), which is not itself a typed module.
+interface CtoSyntaxError {
+    message: string;
+    location?: {
+        start: { line: number; column: number; offset: number };
+        end?: { line: number; column: number; offset: number };
+    };
 }
 
 /**
@@ -29,16 +39,17 @@ interface ParseOptions {
  * @param {boolean} [options.skipLocationNodes] - default true, when true location nodes will be skipped in the metamodel AST
  * @return {object} the metamodel instance for the cto argument
  */
-export function parse(cto: string, fileName?: string, options?: ParseOptions): any {
+export function parse(cto: string, fileName?: string, options?: ParseOptions): IModel {
     try {
         // Set default for skipLocationNodes to true if not specified
         if (!options || options?.skipLocationNodes === undefined) {
             options = { ...options, skipLocationNodes: true };
         }
         return Parser.parse(cto, options);
-    } catch(err: any) {
-        if(err.location && err.location.start) {
-            throw new ParseException(err.message, err.location, fileName);
+    } catch(err: unknown) {
+        const parseErr = err as CtoSyntaxError;
+        if(parseErr.location && parseErr.location.start) {
+            throw new ParseException(parseErr.message, parseErr.location, fileName);
         }
         else {
             throw err;
@@ -59,7 +70,7 @@ export function parseModels(files: string[], options?: ParseOptions): IModels {
         models: [],
     };
     files.forEach((modelFile) => {
-        let metaModel = Parser.parse(modelFile, options);
+        const metaModel: IModel = Parser.parse(modelFile, options);
         result.models.push(metaModel);
     });
     return result;

--- a/packages/concerto-util/src/filedownloader.ts
+++ b/packages/concerto-util/src/filedownloader.ts
@@ -26,19 +26,28 @@ type DownloadJob<TFile> = {
     options: RequestInit;
 };
 
-const flatten = <T>(arr: T[][]): T[] => ([] as T[]).concat(...arr);
+function flatten<T>(arr: T[][]): T[];
+function flatten<T>(arr: Array<T[] | undefined>): Array<T | undefined>;
+function flatten<T>(arr: Array<T[] | undefined>): Array<T | undefined> {
+    return ([] as Array<T | undefined>).concat(...arr);
+}
 const filterUndefined = <T>(arr: Array<T | undefined | null>): T[] => arr.filter((value): value is T => Boolean(value));
 
-const handleJobError = async (error: unknown, job: DownloadJob<unknown>) => {
+// Used as the PromisePool error handler for both the outer pool (whose items are
+// DownloadJob objects) and the inner recursive pool (whose items are plain URI
+// strings), hence the union.
+const handleJobError = async (error: unknown, job: DownloadJob<unknown> | string): Promise<never> => {
     const errLike = error as { response?: { status?: number }; code?: string };
     const badHttpResponse = errLike.response && errLike.response.status && errLike.response.status !== 200;
     const dnsFailure = errLike.code && errLike.code === 'ENOTFOUND';
+    // undefined for the inner pool's string jobs, as it has always been
+    const jobUrl = (job as DownloadJob<unknown>).url;
     if(badHttpResponse || dnsFailure){
-        const err = new Error(`Unable to download external model dependency '${job.url}'`);
+        const err = new Error(`Unable to download external model dependency '${jobUrl}'`);
         (err as { code?: string }).code = 'MISSING_DEPENDENCY';
         throw err;
     }
-    throw new Error('Failed to load model file. Job: ' + job.url + ' Details: ' + error);
+    throw new Error('Failed to load model file. Job: ' + jobUrl + ' Details: ' + error);
 };
 
 /**
@@ -86,9 +95,9 @@ class FileDownloader<TFile = unknown> {
         return PromisePool
             .withConcurrency(this.concurrency)
             .for(jobs)
-            .handleError(handleJobError as any)
+            .handleError(handleJobError)
             .process((x: DownloadJob<TFile>) => this.runJob(x, this.fileLoader))
-            .then(({ results }: any) => filterUndefined(flatten(results as Array<TFile[]>)));
+            .then(({ results }) => filterUndefined(flatten(results)));
     }
 
     /**
@@ -123,7 +132,7 @@ class FileDownloader<TFile = unknown> {
                 const externalImportsFiles = await PromisePool
                     .withConcurrency(this.concurrency)
                     .for(importedUris)
-                    .handleError(handleJobError as any)
+                    .handleError(handleJobError)
                     .process((uri: string) => {
                         if (!downloadedUris.has(uri)) {
                             // recurse and add a new job for the referenced URI
@@ -133,8 +142,9 @@ class FileDownloader<TFile = unknown> {
                                 downloadedUris: downloadedUris
                             }, fileLoader);
                         }
+                        return undefined;
                     })
-                    .then(({ results }: any) => filterUndefined(flatten(results as Array<TFile[]>)));
+                    .then(({ results }) => filterUndefined(flatten(results)));
 
                 return externalImportsFiles.concat([file]);
             });

--- a/packages/concerto-util/src/index.ts
+++ b/packages/concerto-util/src/index.ts
@@ -37,6 +37,7 @@ export type { FileLoader } from './loaders/fileloader';
 import Writer from './writer';
 import FileWriter from './filewriter';
 import * as ModelWriter from './modelwriter';
+export type { WritableModelFile, WriteModelsOptions } from './modelwriter';
 import InMemoryWriter from './inmemorywriter';
 
 // Logger

--- a/packages/concerto-util/src/null.ts
+++ b/packages/concerto-util/src/null.ts
@@ -25,7 +25,7 @@ class NullUtil {
      * @param obj - the object to be tested
      * @returns true if the object is null or undefined
      */
-    static isNull(obj: unknown): boolean {
+    static isNull(obj: unknown): obj is null | undefined {
         return(typeof(obj) === 'undefined' || obj === null);
     }
 }

--- a/packages/concerto-vocabulary/src/vocabulary.ts
+++ b/packages/concerto-vocabulary/src/vocabulary.ts
@@ -186,7 +186,8 @@ class Vocabulary {
         };
 
         const checkPropertyExists = (k: any, p: any) => {
-            const declaration = modelFile.getLocalType(Object.keys(k)[0]);
+            // only reached for keys that getLocalType has already resolved
+            const declaration = modelFile.getLocalType(Object.keys(k)[0]) as ClassDeclaration;
             const property = Object.keys(p)[0];
             if(declaration.isMapDeclaration()) {
                 if (property === 'KEY') {
@@ -202,7 +203,7 @@ class Vocabulary {
         };
 
         const result = {
-            missingTerms: modelFile.getAllDeclarations().flatMap( (d: ClassDeclaration) => this.getTerm(d.getName())
+            missingTerms: (modelFile.getAllDeclarations() as ClassDeclaration[]).flatMap( (d: ClassDeclaration) => this.getTerm(d.getName())
                 ? getOwnProperties(d).flatMap( (p: Property) => this.getTerm(d.getName(), getPropertyName(p)) ? null : `${d.getName()}.${getPropertyName(p)}`)
                 : d.getName() ).filter( (i: any) => i !== null),
             additionalTerms: this.content.declarations.flatMap( (k: any) => modelFile.getLocalType(Object.keys(k)[0])


### PR DESCRIPTION
# Closes #<CORRESPONDING ISSUE NUMBER>

Stacked on `esm/integration` (#1306). That PR replaced `require()` with `import`, which restored real base-class types across `concerto-core` and so switched property checking back on. It papered over the resulting errors by declaring every instance field as `: any` — including fields the base class already declared. Since 5.0.0 is a deliberate breaking release, this replaces those with real types while the `.d.ts` surface is already changing.

`: any` in the files touched here: **182 → 29**, and 17 of the 29 are pre-existing in `concerto-vocabulary`, which is outside this PR's scope.

### Changes

**Declared once, in the owning class**
- `ClassDeclaration` no longer redeclares `modelFile` — `Declaration` owns it.
- `MapDeclaration` no longer redeclares `modelFile`, `name` or `fqn`, and drops its `getModelFile` / `getName` / `getFullyQualifiedName` overrides, which were byte-identical to `Declaration`'s. Its `process()` no longer recomputes the `name` / `fqn` that `super.process()` has already set.
- `Property` dropped `modelFile`, which was declared but never assigned.
- `ModelFile` dropped `modelFile` and `ast`, likewise never assigned and already owned by `Decorated`.

Fields carry definite assignment assertions (`foo!: T`) rather than initialisers throughout. These classes are populated by a `process()` method that a *base* constructor invokes, and with `useDefineForClassFields` off a subclass initialiser is emitted after that constructor has run — it would clobber the value. A type-only declaration erases to nothing and is safe.

**Real types**
- `Decorated.ast` is an exported `AstNode` interface; `decorators` is `Decorator[]`; `getModelFile()` declares `ModelFile`, which removes the casts its callers needed.
- `Declaration`, `ClassDeclaration`, `ScalarDeclaration`, `MapDeclaration`, `MapKeyType`, `MapValueType`, `Property`, `Field`, `RelationshipDeclaration`, `Decorator`, `ModelFile`, `Introspector` and the four `Validator`s carry concrete field and return types. Nullable fields are `T | null`.
- `ModelFile.getDeclarations()` is generic, so `getAssetDeclarations()` and friends return their own declaration type.
- `NullUtil.isNull` and `ModelUtil.isValidIdentifier` are type predicates, so they narrow at their call sites instead of forcing casts.
- `BaseModelManager`, `Factory`, `Serializer`, the serializer visitors, the model classes, `DecoratorManager` and `DecoratorExtractor` take concrete field types. New shared interfaces in `types.ts`: `SerializerOptions`, `GenerateOptions`, `InstanceGeneratorParameters`, and the decorator command shapes mirroring the DCS model.
- `concerto-util` exports `WritableModelFile` / `WriteModelsOptions`; `concerto-cto` types `parse()` as `IModel`, gives `resolveExternal` a named options type, and the `as any` casts are gone from `FileDownloader`.

**Bugs the tightening surfaced**
- `Property` and `ModelFile` passed an always-`undefined` `this.modelFile` to `IllegalModelException`. They now pass the real `ModelFile`, so those two errors gain the file name and location they were meant to carry.
- `ScalarDeclaration` passed `this.ast.name.location` as the *modelFile* argument to `IllegalModelException` — `this.ast.name` is a string, so that was always `undefined`. It now passes `this.modelFile` and `this.ast.location`.
- `ClassDeclaration.declarationKind()` gained a `return ''` stub during the ESM migration, silently answering with an empty string for any subclass that forgot to override it — and `_resolveSuperType()` compares declaration kinds to decide whether an extends clause is legal. It throws now, matching `Decorated.getModelFile()`.

### Flags

- **No CI runs on this PR, by design.** `build.yml`, CodeQL and the conformance tests are all gated on `pull_request: branches: [main, v4.0.0]`, and this targets `esm/integration` to keep the diff to just the type work. Verified locally instead — see the footnote. It needs rebasing onto `main` once #1306 merges, and CI covers it from then on.
- **Runtime behaviour is unchanged apart from the three exception arguments above.** Everything else is types-only: no reordering, no renames, no removed fields.
- **`AstNode` keeps an index signature.** The introspect classes are deliberately duck-typed across node kinds — a `ClassDeclaration` is built from either a concept or an enum declaration — so narrowing `ast` to a precise metamodel interface per subclass would mean a type guard at every access site. That is a worthwhile follow-up, not something to fold into a types-only change.
- **`Property.decorator` is vestigial** — only ever assigned `null`, never read anywhere in `src` or `test`. It is typed and documented rather than removed, since removing a public field is beyond this PR. Worth deleting in 5.0.0 if you agree.
- **Downstream fallout was small**: `concerto-analysis` and `concerto-vocabulary` needed null guards and narrowing casts where core methods now admit `null`, and one `concerto-analysis` test builds deliberately incomplete ASTs (its own comment says the suite exists to reach branches a well-formed model cannot) which now go through an explicit cast.

### Screenshots or Video

n/a

### Related Issues
- Pull Request #1306

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [x] Extend the documentation, if necessary
- [x] Merging to `main` from `fork:branchname`

<sub>Verified locally: `npm run build` green across all packages including the 10 ESM smoke checks; `npm test` green in every workspace (concerto-core 1278 passing, coverage back above its 99% threshold; concerto-util 151; concerto-cto 163; concerto-analysis 99; vocabulary/concertino/linter all passing); `eslint` and `lint:deps` clean.</sub>