### PR TITLE
fix(concerto-util): normalize identifiers with a leading continuation char

### DIFF
--- a/packages/concerto-util/src/identifiers.ts
+++ b/packages/concerto-util/src/identifiers.ts
@@ -43,9 +43,11 @@ export function normalizeIdentifier(identifier: string | null | undefined, trunc
         throw new Error(`Unsupported identifier type, '${typeof result}'.`);
     }
 
-    // 1. If the identifier begins with a number, add a leading underscore
+    // 1. If the identifier begins with a character that is only valid as a
+    // continuation, a digit, a combining mark or a connector other than _,
+    // add a leading underscore
     result = result
-        .replace(/^\p{Nd}/u, '_$&')
+        .replace(/^(?:\p{Nd}|\p{Mn}|\p{Mc}|(?!_)\p{Pc})/u, '_$&')
 
     // 2. Substitute Whitespace, and joiners
         .replace(/[-‐−@#:;><|/\\\u200c\u200d]/g, '_')

--- a/packages/concerto-util/test/identifiers.js
+++ b/packages/concerto-util/test/identifiers.js
@@ -75,6 +75,10 @@ describe('Identifiers', function () {
             ['😄', '_1f604'],       // Surrogate pair, Emoji
             ['\u{1F604}', '_1f604'],  // Escaped surrogate pair, Emoji
             ['𐴓𐴠𐴑𐴤𐴝', '_d803_dd13_d803_dd20_d803_dd11'], // Surrogate pairs, Hanifi Rohingya RTL
+            ['‿foo', '_‿foo'], // leading connector punctuation, undertie
+            ['́foo', '_́foo'], // leading combining mark
+            ['ःfoo', '_ःfoo'], // leading spacing combining mark
+            ['́', '_́'], // combining mark alone
             [null, 'null'],
             [undefined, 'undefined'],
         ];


### PR DESCRIPTION
### What

`normalizeIdentifier` promises to turn arbitrary strings into valid Concerto identifiers, but it only guards a leading **digit**. Combining marks and connector punctuation are valid *continuation* characters (`ID_REGEX` allows `\p{Mn}`, `\p{Mc}`, `\p{Pc}` after the first char) while being invalid at the start, and a string that begins with one slips through every substitution untouched and dies on the function's own final check:

```js
normalizeIdentifier('́name');  // combining acute + "name"
// Error: Unexpected error. Not able to escape identifier '́name'.
normalizeIdentifier('‿foo');   // undertie (Pc) + "foo"
// Error: Unexpected error. Not able to escape identifier '‿foo'.
```

The message itself calls this path unexpected, and the existing test table shows the same characters are fully supported mid-string (`'foo‿bar'`, `'पः'` are no-op rows).

### The change

Step 1 now prefixes the underscore for any character that is a valid continuation but not a valid start: digits, combining marks, and connectors other than `_` itself, which must stay excluded so `'_class'` keeps round-tripping unchanged:

```diff
-        .replace(/^\p{Nd}/u, '_$&')
+        .replace(/^(?:\p{Nd}|\p{Mn}|\p{Mc}|(?!_)\p{Pc})/u, '_$&')
```

`$` is untouched (it is not `Pc`), leading ZWJ/ZWNJ already worked through step 2, and the empty-string throw asserted by the existing test is unchanged.

### Verification

Four rows added to the test table (leading undertie, leading combining mark, leading spacing combining mark, combining mark alone). Full `concerto-util` suite: 155 passing. Reverting only `src/identifiers.ts` fails exactly those 4 and leaves the other 151 passing, so the new rows isolate the change.