### PR TITLE
fix(concerto-core): reset lastIndex before testing a stateful validator regex

### DIFF
--- a/packages/concerto-core/src/factory.ts
+++ b/packages/concerto-core/src/factory.ts
@@ -127,7 +127,7 @@ class Factory {
                     idFullField = idFullField.getScalarField();
                 }
                 // if regex on identifier field & provided id does not match regex, throw error
-                if(idFullField?.validator?.regex && (idFullField.validator?.regex.test(id) === false)) {
+                if(idFullField?.validator?.regex && (idFullField.validator?.matchesRegex(id) === false)) {
                     throw new Error('Provided id does not match regex: ' + idFullField?.validator?.regex);
                 }
             }

--- a/packages/concerto-core/src/introspect/stringvalidator.ts
+++ b/packages/concerto-core/src/introspect/stringvalidator.ts
@@ -97,10 +97,27 @@ class StringValidator extends Validator{
                 this.reportError(identifier, `The string length of '${value}' should not exceed ${this.maxLength} characters.`);
             }
 
-            if (this.regex && !this.regex.test(value)) {
+            if (this.regex && !this.matchesRegex(value)) {
                 this.reportError(identifier, `Value '${value}' failed to match validation regex: ${this.regex}`);
             }
         }
+    }
+
+    /**
+     * Tests a value against the validation regex. Returns true when no regex is
+     * specified.
+     * @param {string} value the value to test
+     * @returns {boolean} true if the value matches the validation regex
+     */
+    matchesRegex(value) {
+        if (!this.regex) {
+            return true;
+        }
+        // `test` advances `lastIndex` when the regex has the global or sticky flag, so
+        // testing the same value twice would otherwise alternate between matching and
+        // not matching. Reset it to make every test independent of previous ones.
+        this.regex.lastIndex = 0;
+        return this.regex.test(value);
     }
 
     /**

--- a/packages/concerto-core/src/introspect/stringvalidator.ts
+++ b/packages/concerto-core/src/introspect/stringvalidator.ts
@@ -115,9 +115,14 @@ class StringValidator extends Validator{
         }
         // `test` advances `lastIndex` when the regex has the global or sticky flag, so
         // testing the same value twice would otherwise alternate between matching and
-        // not matching. Reset it to make every test independent of previous ones.
+        // not matching. Reset it before and after so that every test is independent of
+        // previous ones, and so that getRegex() never hands out a poisoned object.
         this.regex.lastIndex = 0;
-        return this.regex.test(value);
+        try {
+            return this.regex.test(value);
+        } finally {
+            this.regex.lastIndex = 0;
+        }
     }
 
     /**

--- a/packages/concerto-core/test/factory.js
+++ b/packages/concerto-core/test/factory.js
@@ -108,6 +108,19 @@ describe('Factory', function() {
             resource.assetId.should.equal('MY_ID_1');
         });
 
+        it('should repeatedly create a new instance with an ID matching a global regex', function() {
+            const regexModelManager = new ModelManager();
+            regexModelManager.addCTOModel(`
+            namespace org.acme.regex@1.0.0
+            asset RegexAsset identified by assetId {
+                o String assetId regex=/^[A-Z]{3}$/g
+            }`);
+            const regexFactory = new Factory(regexModelManager);
+            regexFactory.newResource('org.acme.regex@1.0.0', 'RegexAsset', 'ABC').assetId.should.equal('ABC');
+            regexFactory.newResource('org.acme.regex@1.0.0', 'RegexAsset', 'ABC').assetId.should.equal('ABC');
+            regexFactory.newResource('org.acme.regex@1.0.0', 'RegexAsset', 'ABC').assetId.should.equal('ABC');
+        });
+
         it('should create a new validating instance by default', function() {
             const resource = factory.newResource(namespace, assetName, 'MY_ID_1');
             should.not.equal(resource.validate, undefined);

--- a/packages/concerto-core/test/introspect/stringvalidator.js
+++ b/packages/concerto-core/test/introspect/stringvalidator.js
@@ -151,6 +151,13 @@ describe('StringValidator', () => {
             }).should.throw(/Validator error for field `id`. org.acme.myField/);
         });
 
+        it('should not leave lastIndex set on the regex it exposes', () => {
+            let v = new StringValidator(mockField, { pattern: '^[A-z][A-z][0-9]{7}', flags: 'g' });
+            v.getRegex().lastIndex.should.equal(0);
+            v.validate('id', 'AB1234567');
+            v.getRegex().lastIndex.should.equal(0);
+        });
+
         it('should repeatedly validate a matching string with a sticky regex', () => {
             let v = new StringValidator(mockField, { pattern: '^[A-z][A-z][0-9]{7}', flags: 'y' });
             v.validate('id', 'AB1234567');

--- a/packages/concerto-core/test/introspect/stringvalidator.js
+++ b/packages/concerto-core/test/introspect/stringvalidator.js
@@ -134,6 +134,29 @@ describe('StringValidator', () => {
             }).should.throw(/Validator error for field `id`. org.acme.myField/);
         });
 
+        it('should repeatedly validate a matching string with a global regex', () => {
+            let v = new StringValidator(mockField, { pattern: '^[A-z][A-z][0-9]{7}', flags: 'g' });
+            v.validate('id', 'AB1234567');
+            v.validate('id', 'AB1234567');
+            v.validate('id', 'AB1234567');
+        });
+
+        it('should repeatedly reject a mismatched string with a global regex', () => {
+            let v = new StringValidator(mockField, { pattern: '^[A-z][A-z][0-9]{7}', flags: 'g' });
+            (() => {
+                v.validate('id', 'xyz');
+            }).should.throw(/Validator error for field `id`. org.acme.myField/);
+            (() => {
+                v.validate('id', 'xyz');
+            }).should.throw(/Validator error for field `id`. org.acme.myField/);
+        });
+
+        it('should repeatedly validate a matching string with a sticky regex', () => {
+            let v = new StringValidator(mockField, { pattern: '^[A-z][A-z][0-9]{7}', flags: 'y' });
+            v.validate('id', 'AB1234567');
+            v.validate('id', 'AB1234567');
+        });
+
         it('should validate a string with escaped chacters', () => {
             let v = new StringValidator(mockField, { pattern: '^[\\\\]*\\n$' });
             v.validate('id', '\\\\\n');


### PR DESCRIPTION
### Changes

- `StringValidator` gains a `matchesRegex(value)` method that resets `lastIndex` to 0 before calling `test`, and `validate()` uses it.
- `Factory.newResource`'s identifier-regex check uses the same method instead of calling `test` on the raw regex.

### Motivation

A regex with the `g` or `y` flag is stateful: `test()` advances `lastIndex`, so the same value alternates between matching and failing on consecutive calls. The CTO grammar parses `RegularExpressionFlags` (parser.pegjs), so this is reachable from any model:

```text
o String code regex=/^[A-Z]{3}$/g
```

Executed against main, serializing the same valid instance repeatedly:

```
toJSON #0 (code=ABC) -> OK
toJSON #1 (code=ABC) -> ERROR: Value 'ABC' failed to match validation regex: /^[A-Z]{3}$/g
toJSON #2 (code=ABC) -> OK
toJSON #3 (code=ABC) -> ERROR ...
```

`Factory.newResource` with a `g`-flagged identifier regex shows the same alternation on the id check.

### Tests

Four regression tests: repeated validation and repeated rejection with a `g` flag, repeated validation with a `y` flag, and three consecutive `newResource` calls with a `g`-flagged id regex. Reverting only the source while keeping the tests fails them with the exact alternating symptom; restoring passes the full 83-test stringvalidator plus factory suites.

`npm run lint` in `packages/concerto-core` is clean.

### Related issues

Closest prior work is #302, which established that regex flags must be honored; nothing covers the statefulness of `g`/`y` under repeated validation.

Changes are backwards compatible: values accepted or rejected by a flagless regex are unaffected.