### PR TITLE
fix(concerto-core): use the nested id field's regex when generating samples

### DIFF
--- a/packages/concerto-core/src/serializer/instancegenerator.ts
+++ b/packages/concerto-core/src/serializer/instancegenerator.ts
@@ -172,7 +172,7 @@ class InstanceGenerator {
                     idField = idField.getScalarField();
                 }
                 if(idField?.validator?.regex){
-                    id = parameters.valueGenerator.getRegex(fieldOrScalarDeclaration.validator.regex);
+                    id = parameters.valueGenerator.getRegex(idField.validator.regex);
                 } else {
                     id = this.generateRandomId(declaration);
                 }

--- a/packages/concerto-core/src/serializer/instancegenerator.ts
+++ b/packages/concerto-core/src/serializer/instancegenerator.ts
@@ -172,7 +172,8 @@ class InstanceGenerator {
                     idField = idField.getScalarField();
                 }
                 if(idField?.validator?.regex){
-                    id = parameters.valueGenerator.getRegex(idField.validator.regex);
+                    id = parameters.valueGenerator.getRegex(idField.validator.regex,
+                        idField.validator.minLength, idField.validator.maxLength);
                 } else {
                     id = this.generateRandomId(declaration);
                 }

--- a/packages/concerto-core/test/serializer/instancegenerator.js
+++ b/packages/concerto-core/test/serializer/instancegenerator.js
@@ -530,6 +530,22 @@ describe('InstanceGenerator', () => {
                 o SSN ssn
             }`)).should.throw(/Provided id does not match regex/);
         });
+
+        it('should generate an id matching the regex on the id field of a nested type', function () {
+            let resource = test(`namespace org.acme.test@1.0.0
+
+            scalar SSN extends String regex=/^\\d{3}-\\d{2}-\\d{4}$/
+
+            participant MyParticipant identified by ssn {
+                o SSN ssn
+            }
+
+            asset MyAsset identified by assetId {
+                o String assetId
+                o MyParticipant owner
+            }`);
+            resource.owner.ssn.should.match(/^\d{3}-\d{2}-\d{4}$/);
+        });
     });
 
     describe('#findConcreteSubclass', () => {

--- a/packages/concerto-core/test/serializer/instancegenerator.js
+++ b/packages/concerto-core/test/serializer/instancegenerator.js
@@ -546,6 +546,31 @@ describe('InstanceGenerator', () => {
             }`);
             resource.owner.ssn.should.match(/^\d{3}-\d{2}-\d{4}$/);
         });
+
+        it('should respect length bounds alongside the regex on a nested id field', function () {
+            modelManager.addCTOModel(`namespace org.acme.test@1.0.0
+
+            scalar Tag extends String regex=/^[a-z]+$/ length=[2,4]
+
+            participant MyParticipant identified by tag {
+                o Tag tag
+            }
+
+            asset MyAsset identified by assetId {
+                o String assetId
+                o MyParticipant owner
+            }`);
+            // The generated value is random, so sample repeatedly to keep the
+            // bounds check meaningful.
+            for (let i = 0; i < 15; i++) {
+                let resource = factory.newResource('org.acme.test@1.0.0', 'MyAsset', 'asset1');
+                parameters.stack = new TypedStack(resource);
+                parameters.seen = [resource.getFullyQualifiedType()];
+                let generated = resource.getClassDeclaration().accept(visitor, parameters);
+                generated.owner.tag.should.match(/^[a-z]+$/);
+                generated.owner.tag.length.should.be.within(2, 4);
+            }
+        });
     });
 
     describe('#findConcreteSubclass', () => {


### PR DESCRIPTION
### Changes

One line in `InstanceGenerator.getFieldValue`: the identifier-regex branch now reads `idField.validator.regex`, the variable its own guard just checked, instead of `fieldOrScalarDeclaration.validator.regex`, which is the outer field being visited.

### Motivation

Generating a sample for a concept that contains an identified type whose id carries a regex crashes on main:

```text
concept Inner identified by ssn { o SSN ssn }
scalar SSN extends String regex=/^\d{3}-\d{2}-\d{4}$/
concept Outer { o Inner inner }
```

```
factory.newConcept(ns, 'Outer', 'id', { generate: 'sample' })
ERROR: TypeError - Cannot read properties of undefined (reading 'regex')
```

The guard checks `idField?.validator?.regex` but the call then dereferences the outer field's validator, which is null here. When the outer field does have its own regex validator, the id is silently generated from the wrong regex instead of crashing.

After the fix the same call produces `"580-41-7163"`, matching the id's regex.

### Tests

Regression test added in `test/serializer/instancegenerator.js`: generating a sample for a nested identified type with a regex-constrained id yields an id matching that regex. Reverting only the source while keeping the test reproduces the exact `TypeError` above; restoring passes all 41 instancegenerator tests.

`npm run lint` in `packages/concerto-core` is clean.

### Related issues

The code was introduced by #178 (issue #171); neither covers the nested case.

Changes are backwards compatible.