### PR TITLE
fix(concerto-core): stop mangling regex samples that already satisfy length

### DIFF
--- a/packages/concerto-core/src/serializer/valuegenerator.ts
+++ b/packages/concerto-core/src/serializer/valuegenerator.ts
@@ -134,6 +134,25 @@ const getString = (minLength, maxLength) => {
 
 
 /**
+ * Determine whether the length of a value is within the given bounds. A null or
+ * undefined bound is not enforced.
+ * @param {string} value the value to test.
+ * @param {number} minLength the lower bound on the range, inclusive.
+ * @param {number} maxLength the upper bound on the range, inclusive.
+ * @return {boolean} true if the length of the value is within the bounds.
+ * @private
+ */
+const isLengthInRange = (value, minLength, maxLength) => {
+    if (minLength !== null && minLength !== undefined && value.length < minLength) {
+        return false;
+    }
+    if (maxLength !== null && maxLength !== undefined && value.length > maxLength) {
+        return false;
+    }
+    return true;
+};
+
+/**
  * Get a randomly generated sample regex String value with lower and upper bound.
  * @param {RegExp} regex A regular expression.
  * @param {number} minLength the lower bound on the range, inclusive.
@@ -147,7 +166,9 @@ const getRegexString = (regex, minLength, maxLength) => {
     }
     const randexp = new RandExp(regex.source, regex.flags);
     let stringValue = randexp.gen();
-    if (minLength || maxLength) {
+    // Padding or truncating the generated value to a random length in the range would
+    // stop it matching the regex, so only reshape it when it is outside the range.
+    if ((minLength || maxLength) && !isLengthInRange(stringValue, minLength, maxLength)) {
         stringValue = generateString(stringValue, minLength, maxLength, () => randexp.gen());
     }
     return stringValue;

--- a/packages/concerto-core/src/serializer/valuegenerator.ts
+++ b/packages/concerto-core/src/serializer/valuegenerator.ts
@@ -168,7 +168,9 @@ const getRegexString = (regex, minLength, maxLength) => {
     let stringValue = randexp.gen();
     // Padding or truncating the generated value to a random length in the range would
     // stop it matching the regex, so only reshape it when it is outside the range.
-    if ((minLength || maxLength) && !isLengthInRange(stringValue, minLength, maxLength)) {
+    // isLengthInRange treats a null or undefined bound as unenforced, so no
+    // separate truthiness gate: that would also skip a legitimate bound of 0.
+    if (!isLengthInRange(stringValue, minLength, maxLength)) {
         stringValue = generateString(stringValue, minLength, maxLength, () => randexp.gen());
     }
     return stringValue;

--- a/packages/concerto-core/test/serializer/instancegenerator.js
+++ b/packages/concerto-core/test/serializer/instancegenerator.js
@@ -532,6 +532,18 @@ describe('InstanceGenerator', () => {
             resource.code.should.match(/^[a-z]{3}$/);
         });
 
+        it('should enforce a length bound of zero on a regex Scalar field', function () {
+            let resource = test(`namespace org.acme.test@1.0.0
+
+            scalar Empty extends String regex=/^[a-z]*$/ length=[0,0]
+
+            asset MyAsset identified by id {
+                o String id
+                o Empty empty
+            }`);
+            resource.empty.should.equal('');
+        });
+
         it('should throw an error when id provided does not match regex on id field', function () {
             (() => test(`namespace org.acme.test@1.0.0
 

--- a/packages/concerto-core/test/serializer/instancegenerator.js
+++ b/packages/concerto-core/test/serializer/instancegenerator.js
@@ -520,6 +520,18 @@ describe('InstanceGenerator', () => {
             resource.scalarValueWithExactLength.should.have.lengthOf(100);
         });
 
+        it('should generate a value matching a fixed length regex for a Scalar field with a length', function () {
+            let resource = test(`namespace org.acme.test@1.0.0
+
+            scalar Code extends String regex=/^[a-z]{3}$/ length=[1,10]
+
+            asset MyAsset identified by id {
+                o String id
+                o Code code
+            }`);
+            resource.code.should.match(/^[a-z]{3}$/);
+        });
+
         it('should throw an error when id provided does not match regex on id field', function () {
             (() => test(`namespace org.acme.test@1.0.0
 

--- a/packages/concerto-core/test/serializer/valuegenerator.js
+++ b/packages/concerto-core/test/serializer/valuegenerator.js
@@ -209,6 +209,21 @@ describe('ValueGenerator', function() {
             });
         });
 
+        it('getRegex with string length should return a string that matches a fixed length regex', function() {
+            [
+                [1, 10],
+                [null, 10],
+                [1, null],
+                [3, 3],
+            ].forEach(([min, max]) => {
+                const regex = /^[a-z]{3}$/;
+                for (let i = 0; i < 10; i++) {
+                    const output = ValueGeneratorFactory.sample().getRegex(regex, min, max);
+                    expect(regex.test(output)).to.be.true;
+                }
+            });
+        });
+
         it('getString with length should return a string that matches the length constraint', function() {
             [
                 [1, 100],


### PR DESCRIPTION
### Changes

`getRegexString` in `valuegenerator.ts` only reshapes the RandExp output when the value actually violates the declared length bounds, via a new `isLengthInRange` helper. Previously it always padded or truncated to a random length inside the range, even when the generated value was already compliant.

### Motivation

A scalar combining both facets produces samples that fail its own model:

```text
scalar Code extends String regex=/^[a-z]{3}$/ length=[1,10]
```

Executed against main, 20 sampled instances: 19 of 20 values failed the regex (`"etuhkbm"`, `"tfhn"`, `"iqtwhqirwx"`, ...) and 20 of 20 failed `toJSON` validation of the very instance the factory had just generated. After the fix: 0 of 20 on both counts.

The contract comes from the feature itself: #178 introduced this code as "Generate valid values for Regex and Range meta properties". For facets that genuinely conflict (a regex that cannot produce any in-range length), the previous best-effort reshaping still applies, so no existing behavior is lost.

### Tests

Two additions: a repeated-sampling test asserting a fixed-length regex stays valid across four length-bound combinations, and an end-to-end factory sample test in `test/serializer/instancegenerator.js`. Reverting only the source while keeping the tests fails deterministically across repeated runs; restoring passes all 67 tests in the two touched suites.

`npm run lint` in `packages/concerto-core` is clean.

Changes are backwards compatible.