### PR TITLE
fix(concerto-core): reject non-array JSON for array fields instead of corrupting it

### DIFF
--- a/packages/concerto-core/src/serializer/jsonpopulator.ts
+++ b/packages/concerto-core/src/serializer/jsonpopulator.ts
@@ -290,6 +290,10 @@ class JSONPopulator {
         let result: any = null;
 
         if(field.isArray()) {
+            if(!Array.isArray(jsonObj)) {
+                const path = parameters.path?.stack.join('');
+                throw new ValidationException(`Expected value at path \`${path}\` to be an array of type \`${field.getType()}\``);
+            }
             result = [];
             const jsonArray = jsonObj as unknown[];
             for(let n=0; n < jsonArray.length; n++) {
@@ -451,6 +455,10 @@ class JSONPopulator {
         let defaultType = ModelUtil.getShortName(typeFQN);
 
         if(relationshipDeclaration.isArray()) {
+            if(!Array.isArray(jsonObj)) {
+                const path = parameters.path?.stack.join('');
+                throw new ValidationException(`Expected value at path \`${path}\` to be an array of type \`${relationshipDeclaration.getType()}\``);
+            }
             result = [];
             const jsonArray = jsonObj as { [key: string]: unknown, $class: string }[];
             for(let n=0; n < jsonArray.length; n++) {

--- a/packages/concerto-core/test/serializer/jsonpopulator.js
+++ b/packages/concerto-core/test/serializer/jsonpopulator.js
@@ -62,6 +62,10 @@ describe('JSONPopulator', () => {
                 o String assetId
                 o MyAsset1[] myAssets
             }
+            asset MyAsset3 identified by assetId {
+                o String assetId
+                o String[] values
+            }
             transaction MyTx1 {
                 --> MyAsset1 myAsset
             }
@@ -532,6 +536,53 @@ describe('JSONPopulator', () => {
             (() => {
                 jsonPopulator.visit(modelManager.getType('org.acme@1.0.0.MyContainerAsset2'), options);
             }).should.throw(/Expected value at path `\$.rootObj.myAssets\[0\].assetValue` to be of type `Integer`/);
+        });
+
+        it('should throw if the value for an array field is a string rather than an array', () => {
+            let options = {
+                jsonStack: new TypedStack({
+                    $class: 'org.acme@1.0.0.MyAsset3',
+                    assetId: 'asset3',
+                    values: 'hello' // this is invalid, should be an array
+                }),
+                resourceStack: new TypedStack({}),
+                factory: mockFactory,
+                modelManager: modelManager
+            };
+
+            (() => {
+                jsonPopulator.visit(modelManager.getType('org.acme@1.0.0.MyAsset3'), options);
+            }).should.throw(ValidationException, /Expected value at path `\$.values` to be an array of type `String`/);
+        });
+
+        it('should throw if the value for an array relationship is a string rather than an array', () => {
+            let options = {
+                jsonStack: new TypedStack('resource:org.acme@1.0.0.MyAsset1#asset1'),
+                resourceStack: new TypedStack({}),
+                factory: mockFactory,
+                modelManager: modelManager
+            };
+
+            (() => {
+                jsonPopulator.visit(relationshipDeclaration2, options);
+            }).should.throw(ValidationException, /Expected value at path `\$` to be an array of type `MyAsset1`/);
+        });
+
+        it('should throw if the value for an array field is not an array', () => {
+            let options = {
+                jsonStack: new TypedStack({
+                    $class: 'org.acme@1.0.0.MyAsset3',
+                    assetId: 'asset3',
+                    values: 42 // this is invalid, should be an array
+                }),
+                resourceStack: new TypedStack({}),
+                factory: mockFactory,
+                modelManager: modelManager
+            };
+
+            (() => {
+                jsonPopulator.visit(modelManager.getType('org.acme@1.0.0.MyAsset3'), options);
+            }).should.throw(ValidationException, /Expected value at path `\$.values` to be an array of type `String`/);
         });
 
         it('should be able to deserialise a map that uses abstract types as values', () => {


### PR DESCRIPTION
### Changes

- `JSONPopulator.visitField` and `visitRelationshipDeclaration` cast the popped JSON value for an array property straight to an array and iterate it by `length`. A string "iterates" as characters, so a `String[]` field fed `"hello"` deserializes as `["h","e","l","l","o"]`; a number or object has `length === undefined`, so the loop is skipped and the value silently becomes `[]`. Post-populate validation then passes because the corrupted resource is type-correct. Every scalar type mismatch on the same path throws `ValidationException` (`convertToObject` does for Integer, Long, Double, Boolean, String and DateTime); arrays alone corrupted silently.
- Both array paths now guard with `Array.isArray` and throw `ValidationException('Expected value at path \`...\` to be an array of type \`...\`')`, matching the existing message and path style.

Executed before the fix:

```
tags given "hello" (string) => ["h","e","l","l","o"]
nums given 42 (number)      => []
tags given {foo:"bar"}      => []
```

### Tests

Three cases added to `test/serializer/jsonpopulator.js`: a string for a `String[]` field, a number for a `String[]` field, and a string URI for a relationship array (plus a `MyAsset3` fixture in the test model). With only the source reverted and the tests kept, all three fail, one with `expected [Function] to throw 'ValidationException' but 'Error: Missing id' was thrown`, proving the character iteration reached `Relationship.fromURI` once per character. Restored, the file passes 65/65 and eslint is clean.

Related: #1277 covers null-handling and property-name validation on the same visitor but does not touch the array paths.