### PR TITLE
fix(concerto-cto): reject duplicate validators instead of silently keeping the last

### DIFF
--- a/packages/concerto-cto/src/parser.js
+++ b/packages/concerto-cto/src/parser.js
@@ -996,49 +996,39 @@ function peg$parse(input, options) {
   };
   var peg$f88 = function(v) { return v; };
   var peg$f89 = function(items) {
-      const result = {};
-      for (const v of items) {
-        if (v.$class === `${metamodelNamespace}.StringRegexValidator`) { result.regex = v; }
-        else if (v.$class === `${metamodelNamespace}.StringLengthValidator`) { result.length = v; }
-      }
-      return result;
+      return bucketValidators(items, {
+        [`${metamodelNamespace}.StringRegexValidator`]: 'regex',
+        [`${metamodelNamespace}.StringLengthValidator`]: 'length',
+      });
    };
   var peg$f90 = function(v) { return v; };
   var peg$f91 = function(items) {
-      const result = {};
-      for (const v of items) {
-        if (v.$class === `${metamodelNamespace}.StringRegexValidator`) { result.regex = v; }
-        else if (v.$class === `${metamodelNamespace}.StringLengthValidator`) { result.length = v; }
-        else if (v.$class === `${metamodelNamespace}.CollectionSizeValidator`) { result.size = v; }
-      }
-      return result;
+      return bucketValidators(items, {
+        [`${metamodelNamespace}.StringRegexValidator`]: 'regex',
+        [`${metamodelNamespace}.StringLengthValidator`]: 'length',
+        [`${metamodelNamespace}.CollectionSizeValidator`]: 'size',
+      });
    };
   var peg$f92 = function(v) { return v; };
   var peg$f93 = function(items) {
-      const result = {};
-      for (const v of items) {
-        if (v.$class === `${metamodelNamespace}.DoubleDomainValidator`) { result.range = v; }
-        else if (v.$class === `${metamodelNamespace}.CollectionSizeValidator`) { result.size = v; }
-      }
-      return result;
+      return bucketValidators(items, {
+        [`${metamodelNamespace}.DoubleDomainValidator`]: 'range',
+        [`${metamodelNamespace}.CollectionSizeValidator`]: 'size',
+      });
    };
   var peg$f94 = function(v) { return v; };
   var peg$f95 = function(items) {
-      const result = {};
-      for (const v of items) {
-        if (v.$class === `${metamodelNamespace}.IntegerDomainValidator`) { result.range = v; }
-        else if (v.$class === `${metamodelNamespace}.CollectionSizeValidator`) { result.size = v; }
-      }
-      return result;
+      return bucketValidators(items, {
+        [`${metamodelNamespace}.IntegerDomainValidator`]: 'range',
+        [`${metamodelNamespace}.CollectionSizeValidator`]: 'size',
+      });
    };
   var peg$f96 = function(v) { return v; };
   var peg$f97 = function(items) {
-      const result = {};
-      for (const v of items) {
-        if (v.$class === `${metamodelNamespace}.LongDomainValidator`) { result.range = v; }
-        else if (v.$class === `${metamodelNamespace}.CollectionSizeValidator`) { result.size = v; }
-      }
-      return result;
+      return bucketValidators(items, {
+        [`${metamodelNamespace}.LongDomainValidator`]: 'range',
+        [`${metamodelNamespace}.CollectionSizeValidator`]: 'size',
+      });
    };
   var peg$f98 = function(decorators, propertyType, array, id, d, validators, optional) {
     	const result = {
@@ -11917,6 +11907,17 @@ function peg$parse(input, options) {
   function isPrimitiveType(typeName) {
     const primitiveTypes = ['Boolean', 'String', 'DateTime', 'Double', 'Integer', 'Long'];
     return (primitiveTypes.indexOf(typeName) >= 0);
+  }
+  function bucketValidators(items, kindByClass) {
+    const result = {};
+    for (const v of items) {
+      const kind = kindByClass[v.$class];
+      if (result[kind]) {
+        error(`Duplicate ${kind} validator`);
+      }
+      result[kind] = v;
+    }
+    return result;
   }
 
   peg$result = peg$startRuleFunction();

--- a/packages/concerto-cto/src/parser.pegjs
+++ b/packages/concerto-cto/src/parser.pegjs
@@ -101,6 +101,17 @@
     const primitiveTypes = ['Boolean', 'String', 'DateTime', 'Double', 'Integer', 'Long'];
     return (primitiveTypes.indexOf(typeName) >= 0);
   }
+  function bucketValidators(items, kindByClass) {
+    const result = {};
+    for (const v of items) {
+      const kind = kindByClass[v.$class];
+      if (result[kind]) {
+        error(`Duplicate ${kind} validator`);
+      }
+      result[kind] = v;
+    }
+    return result;
+  }
 }
 
 Start
@@ -1435,53 +1446,43 @@ LongDomainValidator
 
 StringScalarValidators
    = items:(__ v:(StringRegexValidator / StringLengthValidator) { return v; })* {
-      const result = {};
-      for (const v of items) {
-        if (v.$class === `${metamodelNamespace}.StringRegexValidator`) { result.regex = v; }
-        else if (v.$class === `${metamodelNamespace}.StringLengthValidator`) { result.length = v; }
-      }
-      return result;
+      return bucketValidators(items, {
+        [`${metamodelNamespace}.StringRegexValidator`]: 'regex',
+        [`${metamodelNamespace}.StringLengthValidator`]: 'length',
+      });
    }
 
 StringFieldValidators
    = items:(__ v:(StringRegexValidator / StringLengthValidator / CollectionSizeValidator) { return v; })* {
-      const result = {};
-      for (const v of items) {
-        if (v.$class === `${metamodelNamespace}.StringRegexValidator`) { result.regex = v; }
-        else if (v.$class === `${metamodelNamespace}.StringLengthValidator`) { result.length = v; }
-        else if (v.$class === `${metamodelNamespace}.CollectionSizeValidator`) { result.size = v; }
-      }
-      return result;
+      return bucketValidators(items, {
+        [`${metamodelNamespace}.StringRegexValidator`]: 'regex',
+        [`${metamodelNamespace}.StringLengthValidator`]: 'length',
+        [`${metamodelNamespace}.CollectionSizeValidator`]: 'size',
+      });
    }
 
 RealFieldValidators
    = items:(__ v:(RealDomainValidator / CollectionSizeValidator) { return v; })* {
-      const result = {};
-      for (const v of items) {
-        if (v.$class === `${metamodelNamespace}.DoubleDomainValidator`) { result.range = v; }
-        else if (v.$class === `${metamodelNamespace}.CollectionSizeValidator`) { result.size = v; }
-      }
-      return result;
+      return bucketValidators(items, {
+        [`${metamodelNamespace}.DoubleDomainValidator`]: 'range',
+        [`${metamodelNamespace}.CollectionSizeValidator`]: 'size',
+      });
    }
 
 IntegerFieldValidators
    = items:(__ v:(IntegerDomainValidator / CollectionSizeValidator) { return v; })* {
-      const result = {};
-      for (const v of items) {
-        if (v.$class === `${metamodelNamespace}.IntegerDomainValidator`) { result.range = v; }
-        else if (v.$class === `${metamodelNamespace}.CollectionSizeValidator`) { result.size = v; }
-      }
-      return result;
+      return bucketValidators(items, {
+        [`${metamodelNamespace}.IntegerDomainValidator`]: 'range',
+        [`${metamodelNamespace}.CollectionSizeValidator`]: 'size',
+      });
    }
 
 LongFieldValidators
    = items:(__ v:(LongDomainValidator / CollectionSizeValidator) { return v; })* {
-      const result = {};
-      for (const v of items) {
-        if (v.$class === `${metamodelNamespace}.LongDomainValidator`) { result.range = v; }
-        else if (v.$class === `${metamodelNamespace}.CollectionSizeValidator`) { result.size = v; }
-      }
-      return result;
+      return bucketValidators(items, {
+        [`${metamodelNamespace}.LongDomainValidator`]: 'range',
+        [`${metamodelNamespace}.CollectionSizeValidator`]: 'size',
+      });
    }
 
 RealFieldDeclaration

--- a/packages/concerto-cto/test/parserMain.js
+++ b/packages/concerto-cto/test/parserMain.js
@@ -248,6 +248,48 @@ describe('parser', () => {
             const ast2 = Parser.parse('namespace t@1.0.0\nconcept A { o String[] x size=[1,5] length=[1,10] regex=/abc/ }', undefined, { skipLocationNodes: true });
             ast1.should.deep.equal(ast2);
         });
+
+        it('Should not parse a duplicate regex validator on a String field', () => {
+            (() => {
+                Parser.parse('namespace t@1.0.0\nconcept A { o String x regex=/a/ regex=/b/ }');
+            }).should.throw(/Duplicate regex validator/);
+        });
+
+        it('Should not parse a duplicate length validator on a String field', () => {
+            (() => {
+                Parser.parse('namespace t@1.0.0\nconcept A { o String x length=[1,2] length=[30,40] }');
+            }).should.throw(/Duplicate length validator/);
+        });
+
+        it('Should not parse a duplicate range validator on an Integer field', () => {
+            (() => {
+                Parser.parse('namespace t@1.0.0\nconcept A { o Integer x range=[0,10] range=[500,600] }');
+            }).should.throw(/Duplicate range validator/);
+        });
+
+        it('Should not parse a duplicate range validator on a Double field', () => {
+            (() => {
+                Parser.parse('namespace t@1.0.0\nconcept A { o Double x range=[0.5,1.5] range=[2.5,3.5] }');
+            }).should.throw(/Duplicate range validator/);
+        });
+
+        it('Should not parse a duplicate range validator on a Long field', () => {
+            (() => {
+                Parser.parse('namespace t@1.0.0\nconcept A { o Long x range=[0,10] range=[500,600] }');
+            }).should.throw(/Duplicate range validator/);
+        });
+
+        it('Should not parse a duplicate size validator on a String array field', () => {
+            (() => {
+                Parser.parse('namespace t@1.0.0\nconcept A { o String[] x size=[1,2] size=[9,10] }');
+            }).should.throw(/Duplicate size validator/);
+        });
+
+        it('Should not parse a duplicate regex validator on a String scalar', () => {
+            (() => {
+                Parser.parse('namespace t@1.0.0\nscalar S extends String regex=/a/ regex=/b/');
+            }).should.throw(/Duplicate regex validator/);
+        });
     });
 
     describe('identifiers', () => {


### PR DESCRIPTION
### Changes

- #1305 made validators order-independent by collecting `(validator)*` and bucketing by `$class` with plain assignment. A repeated validator of the same kind now parses and silently keeps only the last one: `regex=/a/ regex=/b/` drops `/a/`, `range=[0,10] range=[500,600]` keeps only `[500,600]`, and the same holds for `length` and `size`, on both fields and scalars. Before #1305 the grammar rejected all of these, and the metamodel has exactly one slot per validator kind, so last-wins silently discards a modeler's constraint and weakens validation. #1305's stated intent was ordering flexibility only.
- The grammar initializer gains a `bucketValidators(items, kindByClass)` helper that raises a located peggy `error('Duplicate <kind> validator')`, surfacing as a normal `ParseException`; the five reducer rules use it. `src/parser.js` is regenerated via `npm run parser`, matching the convention of committing the generated parser.

Executed comparison, old parser (HEAD~1 grammar) vs current main:

```
dup regex (field)   | old: rejected | main: ACCEPTED, kept pattern "b"
dup length (field)  | old: rejected | main: ACCEPTED, kept [30,40]
dup range (field)   | old: rejected | main: ACCEPTED, kept [500,600]
dup size (field)    | old: rejected | main: ACCEPTED, kept [9,10]
dup regex (scalar)  | old: rejected | main: ACCEPTED, kept pattern "b"
```

### Tests

Seven cases added under the `validator ordering` describe in `test/parserMain.js`: duplicate regex and length on a String field, duplicate range on Integer, Double and Long, duplicate size on an array, and duplicate regex on a scalar. With the grammar and generated parser reverted and the tests kept, all seven fail with `expected [Function] to throw an error`; restored, the concerto-cto suite passes 177/177 and every any-order valid case from #1305 still parses. eslint clean.