### PR TITLE
fix(deps): override concerto-codegen peer deps to unblock v5 publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,12 @@
     "e2e"
   ],
   "overrides": {
-    "ajv@^8.0.0": "8.17.1"
+    "ajv@^8.0.0": "8.17.1",
+    "@accordproject/concerto-codegen": {
+      "@accordproject/concerto-core": "*",
+      "@accordproject/concerto-util": "*",
+      "@accordproject/concerto-vocabulary": "*"
+    }
   },
   "name": "concerto",
   "description": "Monorepo for concerto packages",


### PR DESCRIPTION
## Summary
Fixes the failing [Publish to npm workflow](https://github.com/accordproject/concerto/actions/runs/33876163647/job/101033530082) (run for `v5.0.0-beta.1`).

## Root cause
`npm publish --workspaces` fails with `ERESOLVE` once workspace packages are bumped to `5.0.0-beta.1`:

- `@accordproject/concerto-codegen` (a `concertino` devDependency, used only by its `generate-types` build script) declares `peerDependencies: { "@accordproject/concerto-core": "^4.0.3", "@accordproject/concerto-util": "^4.0.3", "@accordproject/concerto-vocabulary": "^4.0.3" }`.
- Once the workspace bumps `concerto-core`/`concerto-util`/`concerto-vocabulary` to `5.0.0-beta.1`, that peer range is no longer satisfied, and `npm publish` fails during dependency resolution before anything is published.
- No published version of `concerto-codegen` (up to the latest, `6.2.0`) supports concerto-core v5 yet.

## Fix
Added an `overrides` entry so npm accepts the local workspace version for these three packages instead of enforcing `concerto-codegen`'s stale `^4.x` peer range:

```json
"overrides": {
  "@accordproject/concerto-codegen": {
    "@accordproject/concerto-core": "*",
    "@accordproject/concerto-util": "*",
    "@accordproject/concerto-vocabulary": "*"
  }
}
```

## Verification
Reproduced the failure and validated the fix in an isolated worktree using the exact workflow steps:
```
npm ci
node ./scripts/bump_version.js v5.0.0-beta.1
npm version --workspaces --include-workspace-root --no-git-tag-version --yes --exact v5.0.0-beta.1
npm publish --workspaces --access public --tag=unstable --dry-run
```
- Before the fix: fails with `ERESOLVE could not resolve` (matches the failed run).
- After the fix: dry-run publish completes successfully for all workspaces (only skipping the intentionally-private `concerto-e2e` workspace).

`package-lock.json` is unchanged — the override only affects resolution once `concerto-core` is bumped past `4.x`, which doesn't happen in the checked-in repo state, so `npm ci` stays in sync.

## Flags
No functional runtime change; this only affects dependency resolution during `npm publish --workspaces` in CI.

## Author Checklist
- [x] DCO sign-off provided on the commit
- [x] Commit message follows `type(scope): description` format
- [x] Verified fix via reproducible dry-run in an isolated worktree