### PR TITLE
fix(concerto-cto): preserve an empty string default

### DIFF
--- a/packages/concerto-cto/src/parser.js
+++ b/packages/concerto-cto/src/parser.js
@@ -793,7 +793,7 @@ function peg$parse(input, options) {
       const result = {
         $class: "concerto.metamodel@1.0.0.StringScalar",
       };
-      if (d) {
+      if (d !== null) {
         result.defaultValue = d;
       }
       if (validators.regex) {
@@ -808,7 +808,7 @@ function peg$parse(input, options) {
      const result = {
         $class: "concerto.metamodel@1.0.0.DateTimeScalar",
       };
-      if (d) {
+      if (d !== null) {
         result.defaultValue = d;
       }
       return result;
@@ -857,7 +857,7 @@ function peg$parse(input, options) {
     		isOptional: buildBoolean(optional),
             ...buildRange(location())
     	};
-      if (d) {
+      if (d !== null) {
         result.defaultValue = d;
       }
       if (decorators.length > 0) {
@@ -895,7 +895,7 @@ function peg$parse(input, options) {
     		isOptional: buildBoolean(optional),
             ...buildRange(location())
     	};
-      if (d) {
+      if (d !== null) {
         result.defaultValue = d;
       }
       if (decorators.length > 0) {
@@ -914,7 +914,7 @@ function peg$parse(input, options) {
     		isOptional: buildBoolean(optional),
             ...buildRange(location())
     	};
-      if (d) {
+      if (d !== null) {
         result.defaultValue = d;
       }
       if (decorators.length > 0) {

--- a/packages/concerto-cto/src/parser.pegjs
+++ b/packages/concerto-cto/src/parser.pegjs
@@ -1187,7 +1187,7 @@ StringScalar
       const result = {
         $class: "concerto.metamodel@1.0.0.StringScalar",
       };
-      if (d) {
+      if (d !== null) {
         result.defaultValue = d;
       }
       if (validators.regex) {
@@ -1204,7 +1204,7 @@ DateTimeScalar
      const result = {
         $class: "concerto.metamodel@1.0.0.DateTimeScalar",
       };
-      if (d) {
+      if (d !== null) {
         result.defaultValue = d;
       }
       return result;
@@ -1288,7 +1288,7 @@ ObjectFieldDeclaration
     		isOptional: buildBoolean(optional),
             ...buildRange(location())
     	};
-      if (d) {
+      if (d !== null) {
         result.defaultValue = d;
       }
       if (decorators.length > 0) {
@@ -1330,7 +1330,7 @@ DateTimeFieldDeclaration
     		isOptional: buildBoolean(optional),
             ...buildRange(location())
     	};
-      if (d) {
+      if (d !== null) {
         result.defaultValue = d;
       }
       if (decorators.length > 0) {
@@ -1351,7 +1351,7 @@ StringFieldDeclaration
     		isOptional: buildBoolean(optional),
             ...buildRange(location())
     	};
-      if (d) {
+      if (d !== null) {
         result.defaultValue = d;
       }
       if (decorators.length > 0) {

--- a/packages/concerto-cto/src/printer.ts
+++ b/packages/concerto-cto/src/printer.ts
@@ -190,7 +190,7 @@ function modifiersFromMetaModel(mm: any): string {
             break;
         case `${MetaModelNamespace}.DateTimeProperty`:
         case `${MetaModelNamespace}.DateTimeScalar`:
-            if (mm.defaultValue) {
+            if (mm.defaultValue !== undefined) {
                 defaultString += ` default="${mm.defaultValue}"`;
             }
             break;
@@ -230,7 +230,7 @@ function modifiersFromMetaModel(mm: any): string {
             break;
         case `${MetaModelNamespace}.StringProperty`:
         case `${MetaModelNamespace}.StringScalar`:
-            if (mm.defaultValue) {
+            if (mm.defaultValue !== undefined) {
                 defaultString += ` default="${mm.defaultValue}"`;
             }
             if (mm.validator) {
@@ -243,7 +243,7 @@ function modifiersFromMetaModel(mm: any): string {
             }
             break;
         case `${MetaModelNamespace}.ObjectProperty`:
-            if (mm.defaultValue) {
+            if (mm.defaultValue !== undefined) {
                 defaultString += ` default="${mm.defaultValue}"`;
             }
             break;

--- a/packages/concerto-cto/test/cto/emptydefault.cto
+++ b/packages/concerto-cto/test/cto/emptydefault.cto
@@ -1,0 +1,12 @@
+namespace org.acme@1.0.0
+
+scalar EmptyStringScalar extends String default=""
+
+scalar NonEmptyStringScalar extends String default="something"
+
+concept EmptyDefaults {
+  o String emptyString default=""
+  o String nonEmptyString default="something"
+  o String emptyStringWithLength default="" length=[0,10]
+  o EmptyStringScalar emptyStringScalar
+}

--- a/packages/concerto-cto/test/cto/emptydefault.json
+++ b/packages/concerto-cto/test/cto/emptydefault.json
@@ -1,0 +1,61 @@
+{
+    "$class": "concerto.metamodel@1.0.0.Model",
+    "decorators": [],
+    "namespace": "org.acme@1.0.0",
+    "imports": [],
+    "declarations": [
+        {
+            "$class": "concerto.metamodel@1.0.0.StringScalar",
+            "defaultValue": "",
+            "name": "EmptyStringScalar"
+        },
+        {
+            "$class": "concerto.metamodel@1.0.0.StringScalar",
+            "defaultValue": "something",
+            "name": "NonEmptyStringScalar"
+        },
+        {
+            "$class": "concerto.metamodel@1.0.0.ConceptDeclaration",
+            "name": "EmptyDefaults",
+            "isAbstract": false,
+            "properties": [
+                {
+                    "$class": "concerto.metamodel@1.0.0.StringProperty",
+                    "name": "emptyString",
+                    "isArray": false,
+                    "isOptional": false,
+                    "defaultValue": ""
+                },
+                {
+                    "$class": "concerto.metamodel@1.0.0.StringProperty",
+                    "name": "nonEmptyString",
+                    "isArray": false,
+                    "isOptional": false,
+                    "defaultValue": "something"
+                },
+                {
+                    "$class": "concerto.metamodel@1.0.0.StringProperty",
+                    "name": "emptyStringWithLength",
+                    "isArray": false,
+                    "isOptional": false,
+                    "defaultValue": "",
+                    "lengthValidator": {
+                        "$class": "concerto.metamodel@1.0.0.StringLengthValidator",
+                        "minLength": 0,
+                        "maxLength": 10
+                    }
+                },
+                {
+                    "$class": "concerto.metamodel@1.0.0.ObjectProperty",
+                    "name": "emptyStringScalar",
+                    "type": {
+                        "$class": "concerto.metamodel@1.0.0.TypeIdentifier",
+                        "name": "EmptyStringScalar"
+                    },
+                    "isArray": false,
+                    "isOptional": false
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
### Changes

- The default-value rules in the grammar guard with a plain truthiness check. The numeric and boolean rules return the raw matched text (`$SignedInteger`, `$BooleanLiteral`, `$SignedRealLiteral`), so a `0` or `false` default survives as a non-empty string. `StringDefault` returns the decoded value, so `default=""` is falsy and the default is discarded at parse time.
- The printer mirrors the mistake: `Double`, `Integer` and `Long` use `!== undefined` and `Boolean` uses an explicit `=== true || === false`, while `String`, `DateTime` and `Object` use plain truthiness, so an AST carrying `defaultValue: ''` prints without it.

Executed, before the change:

```
o String s default=""     ->  defaultValue = undefined
o String t default="x"    ->  defaultValue = "x"
```

`concerto-core` already supports falsy defaults. `field.ts` and `scalardeclaration.ts` both guard with `!Util.isNull(this.ast.defaultValue)`, and feeding the same AST directly, bypassing the CTO parser, yields `getDefaultValue() -> ""` and serializes as `{"s": ""}`. So only the front end loses it.

The practical effect is worse than a missing default: the field ends up with no default at all, so creating an instance and validating it reports the field as missing entirely.

This is the same class of bug as #865 ("Serialization exception when declaring a default false boolean field"), which was fixed in core; the CTO layer still had it for the empty string.

### Tests

New fixture pair `test/cto/emptydefault.{cto,json}`, picked up automatically by both the parser and printer suites. It covers a String property, a String scalar, `default=""` combined with `length=[0,10]`, and a non-empty control so an over-correction would also fail.

Reverting only the three source files and keeping the fixture fails 3 tests, on both the parse and print paths. Restoring passes 172/172, and eslint is clean.

`src/parser.js` was regenerated with the repo's own `npx peggy -o src/parser.js src/parser.pegjs`; the generated diff is exactly the five changed guards with no version drift.

Note: this touches three lines in `printer.ts` that my open #1293 also rewrites. Whichever lands second needs a small rebase, and I will handle it.