### PR TITLE
fix(concerto-core): keep type reference arguments when extracting decorators

### DIFF
--- a/packages/concerto-core/src/decoratorextractor.ts
+++ b/packages/concerto-core/src/decoratorextractor.ts
@@ -257,6 +257,14 @@ class DecoratorExtractor {
         };
         if (dcs.arguments){
             const args = dcs.arguments.map((arg)=>{
+                // type reference arguments carry a type identifier rather than a value
+                if (arg.$class === `${MetaModelNamespace}.DecoratorTypeReference`){
+                    return {
+                        '$class':arg.$class,
+                        'type':arg.type,
+                        'isArray':arg.isArray
+                    };
+                }
                 return {
                     '$class':arg.$class,
                     'value':arg.value

--- a/packages/concerto-core/test/data/decoratorcommands/extract-test-type-reference.cto
+++ b/packages/concerto-core/test/data/decoratorcommands/extract-test-type-reference.cto
@@ -1,0 +1,11 @@
+namespace test@1.0.0
+
+concept Address {
+  o String street
+}
+
+@Form(Address)
+concept Person {
+  @Form(Address[], "text")
+  o String firstName
+}

--- a/packages/concerto-core/test/decoratormanager.js
+++ b/packages/concerto-core/test/decoratormanager.js
@@ -841,6 +841,50 @@ describe('DecoratorManager', () => {
             });
             sourceCTO.should.be.deep.equal(updatedCTO);
         });
+        it('should preserve type reference arguments when extracting decorators', async function() {
+            const testModelManager = new ModelManager();
+            const modelText = fs.readFileSync(path.join(__dirname,'/data/decoratorcommands/extract-test-type-reference.cto'), 'utf-8');
+            testModelManager.addCTOModel(modelText, 'test.cto');
+            const options = {
+                removeDecoratorsFromModel:true,
+                locale:'en'
+            };
+            const resp = DecoratorManager.extractDecorators( testModelManager, options);
+            const commandSet = resp.decoratorCommandSet.find(dcs => dcs.name === 'test');
+            const args = commandSet.commands.map(command => command.decorator.arguments);
+            args.should.be.deep.equal([
+                [
+                    {
+                        $class: 'concerto.metamodel@1.0.0.DecoratorTypeReference',
+                        type: {
+                            $class: 'concerto.metamodel@1.0.0.TypeIdentifier',
+                            name: 'Address',
+                            namespace: 'test@1.0.0'
+                        },
+                        isArray: false
+                    }
+                ],
+                [
+                    {
+                        $class: 'concerto.metamodel@1.0.0.DecoratorTypeReference',
+                        type: {
+                            $class: 'concerto.metamodel@1.0.0.TypeIdentifier',
+                            name: 'Address',
+                            namespace: 'test@1.0.0'
+                        },
+                        isArray: true
+                    },
+                    {
+                        $class: 'concerto.metamodel@1.0.0.DecoratorString',
+                        value: 'text'
+                    }
+                ]
+            ]);
+            (() => DecoratorManager.validate(commandSet)).should.not.throw();
+            const decorated = DecoratorManager.decorateModels(resp.modelManager, commandSet);
+            const decorator = decorated.getType('test@1.0.0.Person').getDecorator('Form');
+            decorator.getArguments()[0].name.should.equal('Address');
+        });
         it('should give proper response in there is no vocabulary on any model', async function() {
             const testModelManager = new ModelManager();
             const modelText = fs.readFileSync(path.join(__dirname,'/data/decoratorcommands/model-without-vocab.cto'), 'utf-8');


### PR DESCRIPTION
### Changes

`DecoratorExtractor.parseNonVocabularyDecorators` maps every decorator argument to `{ $class, value }`:

```js
const args = dcs.arguments.map((arg)=>{
    return { '$class':arg.$class, 'value':arg.value };
});
```

`DecoratorTypeReference` has no `value` field. It carries a required `type` (a `TypeIdentifier`) and `isArray`, so an argument like `@Form(Address)` is reduced to a bare `$class`.

Executed, before the change:

```
"arguments": [ { "$class": "...DecoratorTypeReference" },
               { "$class": "...DecoratorString", "value": "x" },
               { "$class": "...DecoratorNumber", "value": 1 } ]

validate  THREW: The instance "concerto.metamodel@1.0.0.DecoratorTypeReference" is missing the required field "type".
re-apply  THREW: Cannot read properties of undefined (reading 'name')
```

So the extracted command set fails `DecoratorManager.validate`, which is the structural check the output is meant to satisfy, and crashes when re-applied. `decoratormanager.ts` filters decorator arguments on `a.type`, so the consumer already expects the field that extraction was discarding: the two halves of the documented extract and re-decorate round trip disagree.

With `removeDecoratorsFromModel: true` the loss is unrecoverable, because the decorator is stripped from the model and the command intended to carry it is malformed.

After the change, the same script reports `validate: PASSED` and `re-apply: PASSED`, with `type: { name: "HR", namespace: "org.acme.cat@1.0.0" }` and `isArray: false` preserved.

### Tests

New fixture `test/data/decoratorcommands/extract-test-type-reference.cto` and a test asserting the extracted arguments, that `validate` does not throw, and that re-applying restores `@Form(Address)` on the declaration. Covers both `Address` and `Address[]` so `isArray` is exercised in both states.

Reverting only `decoratorextractor.ts` and keeping the test fails it, showing `value: [undefined]` where `type` and `isArray` are expected. Restored, `decoratormanager.js` passes 75/75.

Note on the local suite: this checkout has 17 pre-existing failures in the size-validator tests caused by a stale `node_modules/@accordproject/concerto-cto`; they fail identically on pristine `main` and are unrelated to this change.

Related but distinct: #1243 discusses type references on the vocabulary `@Term` path, which is an open design question. This is the non-vocabulary path, where type reference arguments are unambiguously legal. Open PR #1256 touches `decoratormanager.ts` only, so there is no overlap with `decoratorextractor.ts`.