### PR TITLE
fix(concerto-util): download a shared external model URI only once

### DIFF
--- a/packages/concerto-util/src/filedownloader.ts
+++ b/packages/concerto-util/src/filedownloader.ts
@@ -90,13 +90,21 @@ class FileDownloader<TFile = unknown, TSeed = TFile> {
 
         const downloadedUris = new Set<string>();
 
-        const jobs: Array<DownloadJob<TFile>> = flatten(files.map(file => {
-            const externalImports = this.getExternalImports(file);
-            return Object.keys(externalImports).map(importDeclaration => ({
-                downloadedUris: downloadedUris,
-                url: externalImports[importDeclaration],
-                options: options
-            }));
+        // several import declarations, in one file or across files, can share a
+        // URI, so the URIs are deduplicated before jobs are created for them
+        const importedUris = Array.from(
+            new Set(
+                flatten(files.map(file => {
+                    const externalImports = this.getExternalImports(file);
+                    return Object.keys(externalImports).map(importDeclaration => externalImports[importDeclaration]);
+                }))
+            )
+        );
+
+        const jobs: Array<DownloadJob<TFile>> = importedUris.map(url => ({
+            downloadedUris: downloadedUris,
+            url: url,
+            options: options
         }));
 
         return PromisePool

--- a/packages/concerto-util/test/filedownloader.js
+++ b/packages/concerto-util/test/filedownloader.js
@@ -106,6 +106,50 @@ describe('FileDownloader', () => {
                 });
         });
 
+        it('should download a shared external dependency only once', function() {
+
+            const rootFile = `namespace org.root
+import org.external.Foo from github://external.cto
+import org.external.Bar from github://external.cto
+concept Foo {}`;
+            const otherRootFile = `namespace org.other
+import org.external.Foo from github://external.cto
+concept Foo {}`;
+            const leafFile = `namespace org.external
+concept Foo {}
+concept Bar {}`;
+
+            // create a fake model file loader
+            const ml = sinon.createStubInstance(GitHubFileLoader);
+
+            // it accepts all URLs
+            ml.accepts.returns(true);
+
+            ml.load.withArgs('github://external.cto').returns(Promise.resolve(leafFile));
+
+            // two import declarations in one file, plus a second file, all sharing a URI
+            const getExternalImports = (file) => {
+                if (file === rootFile) {
+                    return {
+                        'org.external.Foo': 'github://external.cto',
+                        'org.external.Bar': 'github://external.cto'
+                    };
+                } else if (file === otherRootFile) {
+                    return {
+                        'org.external.Foo': 'github://external.cto'
+                    };
+                } else {
+                    return {};
+                }
+            };
+            const mfd = new FileDownloader(ml, getExternalImports);
+            return mfd.downloadExternalDependencies([rootFile, otherRootFile])
+                .then((result) => {
+                    result.should.deep.equal([leafFile]);
+                    ml.load.withArgs('github://external.cto').callCount.should.equal(1);
+                });
+        });
+
         it('should handle loader errors', function() {
 
             // create a fake model file loader


### PR DESCRIPTION
### Changes

`FileDownloader.downloadExternalDependencies` builds its root-level jobs by flattening `Object.keys(externalImports)` across all files, with no deduplication, and without consulting the `downloadedUris` cache:

```ts
const jobs = flatten(files.map(file => {
    const externalImports = this.getExternalImports(file);
    return Object.keys(externalImports).map(importDeclaration => ({
        downloadedUris, url: externalImports[importDeclaration], options
    }));
}));
```

Several import declarations commonly share one URI, for example `import x.A from <uri>` and `import x.B from <uri>` in the same model file. Each declaration then produced its own download and its own entry in the returned array.

The intent is clear elsewhere in the same class: `runJob` deduplicates its recursive imports with `Array.from(new Set(...))` and keeps a `downloadedUris` cache commented "cache the URI, so we don't download it again". Only the root level skipped both.

Executed, before the change, with two import declarations on one URI plus a second file importing the same URI:

```
  loader.load -> https://models.example.com/ext.cto (call #1)
  loader.load -> https://models.example.com/ext.cto (call #2)
result       = ["EXT","EXT"]
result.length= 2 (expected 1)
load calls   = 2 (expected 1)
```

After: one call, `result = ["EXT"]`.

### Change

The URIs are deduplicated before jobs are created, mirroring the `Array.from(new Set(...))` idiom already used in `runJob`.

### Tests

`should download a shared external dependency only once` in `test/filedownloader.js`, following the existing `sinon.createStubInstance(GitHubFileLoader)` style. It asserts both the returned array and `load.withArgs(...).callCount === 1`.

Reverting only `filedownloader.ts` and keeping the test fails it with three entries where one is expected. Restored, the package passes 152/152 and eslint is clean.