### PR TITLE
feat(concerto-analysis): export Comparer, ComparerFactory, and CompareContext from root

### DIFF
--- a/packages/concerto-analysis/src/compare-context.ts
+++ b/packages/concerto-analysis/src/compare-context.ts
@@ -12,8 +12,8 @@
  * limitations under the License.
  */
 
-import { CompareMessage } from './compare-message';
+import { CompareFinding } from './compare-results';
 
 export type CompareContext = {
-    report: (finding: CompareMessage) => void;
+    report: (finding: CompareFinding) => void;
 }

--- a/packages/concerto-analysis/src/compare-context.ts
+++ b/packages/concerto-analysis/src/compare-context.ts
@@ -12,8 +12,8 @@
  * limitations under the License.
  */
 
-import { CompareFinding } from './compare-message';
+import { CompareMessage } from './compare-message';
 
 export type CompareContext = {
-    report: (finding: CompareFinding) => void;
+    report: (finding: CompareMessage) => void;
 }

--- a/packages/concerto-analysis/src/compare-message.ts
+++ b/packages/concerto-analysis/src/compare-message.ts
@@ -14,9 +14,11 @@
 
 import { CompareResult } from './compare-config';
 
-export type CompareFinding = {
+export type CompareMessage = {
     key: string;
     message: string;
     element: unknown;
     result?: CompareResult;
 }
+
+export type CompareFinding = CompareMessage;

--- a/packages/concerto-analysis/src/compare-message.ts
+++ b/packages/concerto-analysis/src/compare-message.ts
@@ -12,13 +12,4 @@
  * limitations under the License.
  */
 
-import { CompareResult } from './compare-config';
-
-export type CompareMessage = {
-    key: string;
-    message: string;
-    element: unknown;
-    result?: CompareResult;
-}
-
-export type CompareFinding = CompareMessage;
+export type { CompareFinding } from './compare-results';

--- a/packages/concerto-analysis/src/compare-results.ts
+++ b/packages/concerto-analysis/src/compare-results.ts
@@ -18,6 +18,7 @@ export type CompareFinding = {
     key: string;
     message: string;
     result: CompareResult;
+    element?: unknown;
 }
 
 export type CompareResults = {

--- a/packages/concerto-analysis/src/compare-results.ts
+++ b/packages/concerto-analysis/src/compare-results.ts
@@ -17,8 +17,8 @@ import { CompareResult } from './compare-config';
 export type CompareFinding = {
     key: string;
     message: string;
-    result: CompareResult;
     element?: unknown;
+    result?: CompareResult;
 }
 
 export type CompareResults = {

--- a/packages/concerto-analysis/src/compare.ts
+++ b/packages/concerto-analysis/src/compare.ts
@@ -14,7 +14,7 @@
 
 import { ClassDeclaration, Declaration, MapDeclaration, ModelFile, Property, ScalarDeclaration } from '@accordproject/concerto-core';
 import { CompareConfig, CompareResult, defaultCompareConfig } from './compare-config';
-import { CompareFinding } from './compare-message';
+import { CompareMessage } from './compare-message';
 import { CompareResults } from './compare-results';
 import { Comparer } from './comparer';
 
@@ -27,7 +27,7 @@ export class Compare {
 
     public compare(a: ModelFile, b: ModelFile): CompareResults {
         const comparerFactories = this.config.comparerFactories;
-        const findings: CompareFinding[] = [];
+        const findings: CompareMessage[] = [];
         const comparers = comparerFactories.map(comparerFactory => comparerFactory({
             report: finding => findings.push(finding),
         }));
@@ -143,7 +143,7 @@ export class Compare {
         this.compareScalarDeclarations(comparers, a.getScalarDeclarations(), b.getScalarDeclarations());
     }
 
-    private buildResults(findings: CompareFinding[]) {
+    private buildResults(findings: CompareMessage[]) {
         const results: CompareResults = {
             findings: [],
             result: CompareResult.NONE,

--- a/packages/concerto-analysis/src/compare.ts
+++ b/packages/concerto-analysis/src/compare.ts
@@ -14,8 +14,7 @@
 
 import { ClassDeclaration, Declaration, MapDeclaration, ModelFile, Property, ScalarDeclaration } from '@accordproject/concerto-core';
 import { CompareConfig, CompareResult, defaultCompareConfig } from './compare-config';
-import { CompareMessage } from './compare-message';
-import { CompareResults } from './compare-results';
+import { CompareFinding, CompareResults } from './compare-results';
 import { Comparer } from './comparer';
 
 export class Compare {
@@ -27,7 +26,7 @@ export class Compare {
 
     public compare(a: ModelFile, b: ModelFile): CompareResults {
         const comparerFactories = this.config.comparerFactories;
-        const findings: CompareMessage[] = [];
+        const findings: CompareFinding[] = [];
         const comparers = comparerFactories.map(comparerFactory => comparerFactory({
             report: finding => findings.push(finding),
         }));
@@ -143,7 +142,7 @@ export class Compare {
         this.compareScalarDeclarations(comparers, a.getScalarDeclarations(), b.getScalarDeclarations());
     }
 
-    private buildResults(findings: CompareMessage[]) {
+    private buildResults(findings: CompareFinding[]) {
         const results: CompareResults = {
             findings: [],
             result: CompareResult.NONE,

--- a/packages/concerto-analysis/src/index.ts
+++ b/packages/concerto-analysis/src/index.ts
@@ -13,8 +13,10 @@
  */
 
 export { Compare } from './compare';
-export { CompareConfig, CompareResult, CompareConfigBuilder, compareResultToString } from './compare-config';
-export { CompareFinding, CompareResults } from './compare-results';
+export { CompareResult, CompareConfigBuilder, compareResultToString } from './compare-config';
+export type { CompareConfig } from './compare-config';
+export type { CompareFinding, CompareResults } from './compare-results';
+export type { CompareMessage } from './compare-message';
 export type { Comparer, ComparerFactory } from './comparer';
 export type { CompareContext } from './compare-context';
 

--- a/packages/concerto-analysis/src/index.ts
+++ b/packages/concerto-analysis/src/index.ts
@@ -15,4 +15,6 @@
 export { Compare } from './compare';
 export { CompareConfig, CompareResult, CompareConfigBuilder, compareResultToString } from './compare-config';
 export { CompareFinding, CompareResults } from './compare-results';
+export type { Comparer, ComparerFactory } from './comparer';
+export type { CompareContext } from './compare-context';
 

--- a/packages/concerto-analysis/src/index.ts
+++ b/packages/concerto-analysis/src/index.ts
@@ -16,7 +16,5 @@ export { Compare } from './compare';
 export { CompareResult, CompareConfigBuilder, compareResultToString } from './compare-config';
 export type { CompareConfig } from './compare-config';
 export type { CompareFinding, CompareResults } from './compare-results';
-export type { CompareMessage } from './compare-message';
 export type { Comparer, ComparerFactory } from './comparer';
 export type { CompareContext } from './compare-context';
-

--- a/packages/concerto-analysis/test/unit/index.test.ts
+++ b/packages/concerto-analysis/test/unit/index.test.ts
@@ -14,15 +14,16 @@
 
 import {
     Compare,
-    CompareConfig,
     CompareResult,
     CompareConfigBuilder,
     compareResultToString,
-    type Comparer,
-    type ComparerFactory,
+    type CompareConfig,
     type CompareContext,
     type CompareFinding,
+    type CompareMessage,
     type CompareResults,
+    type Comparer,
+    type ComparerFactory,
 } from '../../src/index';
 
 describe('index exports', () => {
@@ -36,11 +37,12 @@ describe('index exports', () => {
     it('should support typing custom comparers using exported types', () => {
         const customComparerFactory: ComparerFactory = (context: CompareContext): Comparer => ({
             compareModelFiles: () => {
-                context.report({
+                const message: CompareMessage = {
                     key: 'custom-rule',
                     message: 'Custom comparison message',
                     element: null,
-                });
+                };
+                context.report(message);
             },
         });
 
@@ -52,6 +54,7 @@ describe('index exports', () => {
             key: 'custom-rule',
             message: 'Custom comparison message',
             result: CompareResult.PATCH,
+            element: null,
         };
         const results: CompareResults = {
             findings: [finding],

--- a/packages/concerto-analysis/test/unit/index.test.ts
+++ b/packages/concerto-analysis/test/unit/index.test.ts
@@ -20,7 +20,6 @@ import {
     type CompareConfig,
     type CompareContext,
     type CompareFinding,
-    type CompareMessage,
     type CompareResults,
     type Comparer,
     type ComparerFactory,
@@ -37,12 +36,12 @@ describe('index exports', () => {
     it('should support typing custom comparers using exported types', () => {
         const customComparerFactory: ComparerFactory = (context: CompareContext): Comparer => ({
             compareModelFiles: () => {
-                const message: CompareMessage = {
+                const finding: CompareFinding = {
                     key: 'custom-rule',
                     message: 'Custom comparison message',
                     element: null,
                 };
-                context.report(message);
+                context.report(finding);
             },
         });
 

--- a/packages/concerto-analysis/test/unit/index.test.ts
+++ b/packages/concerto-analysis/test/unit/index.test.ts
@@ -1,0 +1,63 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+    Compare,
+    CompareConfig,
+    CompareResult,
+    CompareConfigBuilder,
+    compareResultToString,
+    type Comparer,
+    type ComparerFactory,
+    type CompareContext,
+    type CompareFinding,
+    type CompareResults,
+} from '../../src/index';
+
+describe('index exports', () => {
+    it('should export all public classes and functions', () => {
+        expect(Compare).toBeDefined();
+        expect(CompareResult).toBeDefined();
+        expect(CompareConfigBuilder).toBeDefined();
+        expect(compareResultToString).toBeDefined();
+    });
+
+    it('should support typing custom comparers using exported types', () => {
+        const customComparerFactory: ComparerFactory = (context: CompareContext): Comparer => ({
+            compareModelFiles: () => {
+                context.report({
+                    key: 'custom-rule',
+                    message: 'Custom comparison message',
+                    element: null,
+                });
+            },
+        });
+
+        const builder = new CompareConfigBuilder();
+        const config: CompareConfig = builder.addComparerFactory(customComparerFactory).build();
+        expect(config.comparerFactories).toContain(customComparerFactory);
+
+        const finding: CompareFinding = {
+            key: 'custom-rule',
+            message: 'Custom comparison message',
+            result: CompareResult.PATCH,
+        };
+        const results: CompareResults = {
+            findings: [finding],
+            result: CompareResult.PATCH,
+        };
+        expect(results.findings).toHaveLength(1);
+        expect(results.result).toEqual(CompareResult.PATCH);
+    });
+});


### PR DESCRIPTION
## Description

Export `Comparer`, `ComparerFactory`, `CompareContext`, and `CompareFinding` types from the root entrypoint of `@accordproject/concerto-analysis`.

`CompareConfigBuilder.prototype.addComparerFactory(f: ComparerFactory)` is part of the public root API, but the parameter type `ComparerFactory` and the `CompareContext` it receives were previously only accessible via deep internal imports (e.g. `@accordproject/concerto-analysis/dist/comparer.js`). Re-exporting them from root completes the public API contract for writing custom comparers.

In addition, `CompareFinding` is now unified across the package so that custom comparers can type report findings with the same `CompareFinding` type returned in `CompareResults.findings`.

### Changes
- Export `Comparer` and `ComparerFactory` types from `packages/concerto-analysis/src/index.ts`
- Export `CompareContext` type from `packages/concerto-analysis/src/index.ts`
- Unify `CompareFinding` in `packages/concerto-analysis/src/compare-results.ts` with optional `element?: unknown` and `result?: CompareResult` properties, reusing it for `CompareContext.report`
- Re-export `CompareFinding` from `packages/concerto-analysis/src/compare-message.ts` for backward compatibility
- Use `export type` / `import type` for type-only exports/imports
- Add unit test in `packages/concerto-analysis/test/unit/index.test.ts` verifying root exports and custom comparer typing

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [x] Merging to `main` from `fork:branchname`

Signed-off-by: Matt Roberts <code@rbrts.uk>